### PR TITLE
allow NMs to also be bound when using charm

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -3825,13 +3825,9 @@ namespace battleutils
         // player charming mob
         if (PVictim->objtype == TYPE_MOB && PCharmer->objtype == TYPE_PC)
         {
-            // cannot charm NM
-            if (((CMobEntity*)PVictim)->m_Type & MOBTYPE_NOTORIOUS) {
-                return;
-            }
-
-            //Bind uncharmable mobs for 5 seconds
-            if ( ((CMobEntity*)PVictim)->getMobMod(MOBMOD_CHARMABLE) == 0 ||  PVictim->PMaster != nullptr) {
+            //Bind uncharmable mobs and NMs for 1 to 5 seconds
+            if ( ((CMobEntity*)PVictim)->getMobMod(MOBMOD_CHARMABLE) == 0 || ((CMobEntity*)PVictim)->m_Type & MOBTYPE_NOTORIOUS ||  PVictim->PMaster != nullptr)
+            {
                 PVictim->StatusEffectContainer->AddStatusEffect(
                     new CStatusEffect(EFFECT_BIND, EFFECT_BIND, 1, 0, tpzrand::GetRandomNumber(1, 5)));
                 return;


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](https://github.com/project-topaz/topaz/blob/master/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

currently a charm on a NM is just a failed attempt and a return, but it should follow the same rules as a mob thats not charmable and set a bind effect for a brief time