### PR TITLE
add mob's target as an optional parameter ("attacker") to OnCriticalHit and its related hook.

### DIFF
--- a/scripts/zones/Wajaom_Woodlands/mobs/Iriz_Ima.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Iriz_Ima.lua
@@ -15,7 +15,7 @@ function onMobSpawn(mob)
     mob:setLocalVar("BreakChance", 5)
 end
 
-function onCriticalHit(mob, player)
+function onCriticalHit(mob, attacker)
     if math.random(100) <= mob:getLocalVar("BreakChance") then
         local animationSub = mob:AnimationSub()
         if animationSub == 4 then

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1522,7 +1522,11 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
 
                     if (PTarget->objtype == TYPE_MOB)
                     {
-                        luautils::OnCriticalHit(PTarget);
+                        // Listener (hook)
+                        PTarget->PAI->EventHandler.triggerListener("CRITICAL_TAKE", PTarget, this);
+
+                        // Binding
+                        luautils::OnCriticalHit(PTarget, this);
                     }
                 }
                 // Not critical hit.

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -2752,9 +2752,11 @@ namespace luautils
     {
         TPZ_DEBUG_BREAK_IF(PMob == nullptr || PMob->objtype != TYPE_MOB)
 
-            CLuaBaseEntity LuaMobEntity(PMob);
+        CLuaBaseEntity LuaMobEntity(PMob);
+        CBattleEntity* PAttacker = static_cast<CBattleEntity*>(PMob->GetBattleTarget());
+        CLuaBaseEntity LuaKillerEntity(PAttacker);
 
-        PMob->PAI->EventHandler.triggerListener("CRITICAL_TAKE", PMob);
+        PMob->PAI->EventHandler.triggerListener("CRITICAL_TAKE", PMob, PAttacker);
         lua_prepscript("scripts/zones/%s/mobs/%s.lua", PMob->loc.zone->GetName(), PMob->GetName());
 
         if (prepFile(File, "onCriticalHit"))
@@ -2763,8 +2765,12 @@ namespace luautils
         }
 
         Lunar<CLuaBaseEntity>::push(LuaHandle, &LuaMobEntity);
+        if (PAttacker)
+            Lunar<CLuaBaseEntity>::push(LuaHandle, &LuaKillerEntity);
+        else
+            lua_pushnil(LuaHandle);
 
-        if (lua_pcall(LuaHandle, 1, 0, 0))
+        if (lua_pcall(LuaHandle, 2, 0, 0))
         {
             ShowError("luautils::onCriticalHit: %s\n", lua_tostring(LuaHandle, -1));
             lua_pop(LuaHandle, 1);

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -2748,15 +2748,13 @@ namespace luautils
         return 0;
     }
 
-    int32 OnCriticalHit(CBattleEntity* PMob)
+    int32 OnCriticalHit(CBattleEntity* PMob, CBattleEntity* PAttacker)
     {
         TPZ_DEBUG_BREAK_IF(PMob == nullptr || PMob->objtype != TYPE_MOB)
 
         CLuaBaseEntity LuaMobEntity(PMob);
-        CBattleEntity* PAttacker = static_cast<CBattleEntity*>(PMob->GetBattleTarget());
         CLuaBaseEntity LuaKillerEntity(PAttacker);
 
-        PMob->PAI->EventHandler.triggerListener("CRITICAL_TAKE", PMob, PAttacker);
         lua_prepscript("scripts/zones/%s/mobs/%s.lua", PMob->loc.zone->GetName(), PMob->GetName());
 
         if (prepFile(File, "onCriticalHit"))
@@ -3190,9 +3188,9 @@ namespace luautils
 
         if (criticalHit == true)
         {
-            CBattleEntity* PTarget = (CBattleEntity*)PMob;
-            luautils::OnCriticalHit(PTarget);
+            luautils::OnCriticalHit((CBattleEntity*)PMob, (CBattleEntity*)PChar);
         }
+
         lua_pop(LuaHandle, 4);
         return std::make_tuple(dmg, tpHitsLanded, extraHitsLanded);
     }

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -227,7 +227,7 @@ namespace luautils
     int32 OnMobDisengage(CBaseEntity* PMob);                                      // triggers on mob disengaging (no more targets)
     int32 OnMobDrawIn(CBaseEntity* PMob, CBaseEntity* PTarget);
     int32 OnMobFight(CBaseEntity* PMob, CBaseEntity* PTarget);                    // Сalled every 3 sec when a player fight monster
-    int32 OnCriticalHit(CBattleEntity* PTarget);
+    int32 OnCriticalHit(CBattleEntity* PMob, CBattleEntity* PAttacker);
     int32 OnMobDeath(CBaseEntity* PMob, CBaseEntity* PKiller);                    // triggers on mob death
     int32 OnMobDespawn(CBaseEntity* PMob);                                        // triggers on mob despawn (death not assured)
 


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](https://github.com/project-topaz/topaz/blob/master/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

nothing currently really _needs_ this yet, but something I was working on could have been made simpler instead of my using `mobb:getTarget()` to grab a table of everything on its hatelist yesterday when I really just need the current target...and I would wager a retail use case for it will show up eventually.

Oddly the hook (listener) is _inside the binding_ instead of in the spot in battleutils that the binding is triggered from. When the listeners were made they were intended to phase out the bindings, though I personally like the bindings better. ¯\\\_(ツ)\_/¯ 

So..I did this all at the binding itself. It now occurs to me I'm getting the target of a target..The alternative is I go in battleutils where its in the context of the players own attack making the mob itself "PTarget" and adding a param for that entity there like..`luautils::OnCriticalHit(PTarget, this);` and then updating all the calls to match while passing it along as `mob, attacker`. I decided to stop and get some input first, but I am leaning toward doing that instead.