### PR TITLE
Fix starburst and sunburst element param always being the same due to being overwritten

### DIFF
--- a/scripts/globals/weaponskills/starburst.lua
+++ b/scripts/globals/weaponskills/starburst.lua
@@ -17,19 +17,24 @@ require("scripts/globals/weaponskills")
 -----------------------------------
 
 function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
-
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2 params.ftp300 = 2.5
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
-    params.ele = tpz.magic.ele.DARK params.ele = tpz.magic.ele.LIGHT
+    params.str_wsc = 0.0 params.dex_wsc = 0.0
+    params.vit_wsc = 0.0 params.agi_wsc = 0.0
+    params.int_wsc = 0.0 params.mnd_wsc = 0.0
+    params.chr_wsc = 0.0
     params.skill = tpz.skill.STAFF
     params.includemab = true
+    -- 50/50 shot of being light or dark
+    params.ele = tpz.magic.ele.LIGHT
+    if math.random() < 0.5 then
+        params.ele = tpz.magic.ele.DARK
+    end
 
-    if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
+    if USE_ADOULIN_WEAPON_SKILL_CHANGES == true then
         params.str_wsc = 0.4 params.mnd_wsc = 0.4
     end
 
     local damage, criticalHit, tpHits, extraHits = doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
     return tpHits, extraHits, criticalHit, damage
-
 end

--- a/scripts/globals/weaponskills/sunburst.lua
+++ b/scripts/globals/weaponskills/sunburst.lua
@@ -17,19 +17,24 @@ require("scripts/globals/weaponskills")
 -----------------------------------
 
 function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
-
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2.5 params.ftp300 = 4
-    params.str_wsc = 0.4 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.4 params.chr_wsc = 0.0
-    params.ele = tpz.magic.ele.DARK params.ele = tpz.magic.ele.LIGHT
+    params.str_wsc = 0.4 params.dex_wsc = 0.0
+    params.vit_wsc = 0.0 params.agi_wsc = 0.0
+    params.int_wsc = 0.0 params.mnd_wsc = 0.4
+    params.chr_wsc = 0.0
     params.skill = tpz.skill.STAFF
     params.includemab = true
+    -- 50/50 shot of being light or dark
+    params.ele = tpz.magic.ele.LIGHT
+    if math.random() < 0.5 then
+        params.ele = tpz.magic.ele.DARK
+    end
 
-    if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
+    if USE_ADOULIN_WEAPON_SKILL_CHANGES == true then
         params.str_wsc = 0.4 params.mnd_wsc = 0.4
     end
 
     local damage, criticalHit, tpHits, extraHits = doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
     return tpHits, extraHits, criticalHit, damage
-
 end


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](https://github.com/project-topaz/topaz/blob/master/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

[Spotted some derp in sunburst.lua](https://github.com/project-topaz/topaz/blob/2943fab983cc1457ce75f15dd9dca9d3bfa21b05/scripts/globals/weaponskills/sunburst.lua#L24)
`params.ele = tpz.magic.ele.DARK params.ele = tpz.magic.ele.LIGHT`
its just always going to be light because its being replaced immediately.
Also reformatted a bit because I dislike wide lines.