### PR TITLE
Audit all damage type values in BLU spells.

### DIFF
--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -230,7 +230,7 @@ function BlueFinalAdjustments(caster, target, spell, dmg, params)
     -- handling stoneskin
     dmg = utils.stoneskin(target, dmg)
 
-    local damageType = params.dmgType or tpz.damageType.NONE
+    local damageType = params.damageType or tpz.damageType.NONE
     target:takeSpellDamage(caster, spell, dmg, tpz.attackType.PHYSICAL, damageType)
     target:updateEnmityFromDamage(caster,dmg)
     target:handleAfflatusMiseryDamage(dmg)

--- a/scripts/globals/spells/bluemagic/1000_needles.lua
+++ b/scripts/globals/spells/bluemagic/1000_needles.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_CRITICAL
-        params.dmgtype = tpz.damageType.PIERCING
+        params.damageType = tpz.damageType.LIGHT
         params.scattr = SC_COMPRESSION
         params.numhits = 1
         params.multiplier = 1.5

--- a/scripts/globals/spells/bluemagic/asuran_claws.lua
+++ b/scripts/globals/spells/bluemagic/asuran_claws.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_ACC
-        params.dmgtype = tpz.damageType.HTH
+        params.damageType = tpz.damageType.BLUNT
         params.scattr = SC_IMPACTION
         params.numhits = 6
         params.multiplier = 1.0

--- a/scripts/globals/spells/bluemagic/bad_breath.lua
+++ b/scripts/globals/spells/bluemagic/bad_breath.lua
@@ -28,6 +28,7 @@ function onSpellCast(caster,target,spell)
     if (caster:hasStatusEffect(tpz.effect.AZURE_LORE)) then
         multi = multi + 0.50
     end
+        params.damageType = tpz.damageType.EARTH
         params.multiplier = multi
         params.tMultiplier = 1.5
         params.duppercap = 69

--- a/scripts/globals/spells/bluemagic/battle_dance.lua
+++ b/scripts/globals/spells/bluemagic/battle_dance.lua
@@ -26,7 +26,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_DURATION
-        params.dmgtype = tpz.damageType.SLASHING
+        params.damageType = tpz.damageType.SLASHING
         params.scattr = SC_IMPACTION
         params.numhits = 1
         params.multiplier = 2.0

--- a/scripts/globals/spells/bluemagic/blastbomb.lua
+++ b/scripts/globals/spells/bluemagic/blastbomb.lua
@@ -23,6 +23,7 @@ end
 
 function onSpellCast(caster,target,spell)
     local params = {}
+    params.damageType = tpz.damageType.FIRE
     params.multiplier = 1.375
     params.tMultiplier = 1.0
     params.duppercap = 30

--- a/scripts/globals/spells/bluemagic/blitzstrahl.lua
+++ b/scripts/globals/spells/bluemagic/blitzstrahl.lua
@@ -24,6 +24,7 @@ end
 function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
+    params.damageType = tpz.damageType.LIGHTNING
     params.multiplier = 1.5625
     params.tMultiplier = 1.0
     params.duppercap = 61

--- a/scripts/globals/spells/bluemagic/blood_drain.lua
+++ b/scripts/globals/spells/bluemagic/blood_drain.lua
@@ -51,6 +51,7 @@ function onSpellCast(caster,target,spell)
         dmg = target:getHP()
     end
 
+    params.damageType = tpz.damageType.DARK
     dmg = BlueFinalAdjustments(caster,target,spell,dmg,params)
     caster:addHP(dmg)
 

--- a/scripts/globals/spells/bluemagic/blood_saber.lua
+++ b/scripts/globals/spells/bluemagic/blood_saber.lua
@@ -51,6 +51,7 @@ function onSpellCast(caster,target,spell)
         dmg = target:getHP()
     end
 
+    params.damageType = tpz.damageType.DARK
     dmg = BlueFinalAdjustments(caster,target,spell,dmg,params)
     caster:addHP(dmg)
 

--- a/scripts/globals/spells/bluemagic/bludgeon.lua
+++ b/scripts/globals/spells/bluemagic/bludgeon.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_ACC
-        params.dmgtype = tpz.damageType.HTH
+        params.damageType = tpz.damageType.BLUNT
         params.scattr = SC_LIQUEFACTION
         params.numhits = 3
         params.multiplier = 1.0

--- a/scripts/globals/spells/bluemagic/body_slam.lua
+++ b/scripts/globals/spells/bluemagic/body_slam.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_ATTACK
-        params.dmgtype = tpz.damageType.BLUNT
+        params.damageType = tpz.damageType.BLUNT
         params.scattr = SC_IMPACTION
         params.numhits = 1
         params.multiplier = 1.5

--- a/scripts/globals/spells/bluemagic/bomb_toss.lua
+++ b/scripts/globals/spells/bluemagic/bomb_toss.lua
@@ -24,6 +24,7 @@ end
 function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
+        params.damageType = tpz.damageType.FIRE
         params.multiplier = 1.625
         params.tMultiplier = 1.0
         params.duppercap = 40

--- a/scripts/globals/spells/bluemagic/cannonball.lua
+++ b/scripts/globals/spells/bluemagic/cannonball.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_DAMAGE
-        params.dmgtype = tpz.damageType.HTH
+        params.damageType = tpz.damageType.BLUNT
         params.scattr = SC_FUSION
         params.numhits = 1
         params.multiplier = 1.75

--- a/scripts/globals/spells/bluemagic/claw_cyclone.lua
+++ b/scripts/globals/spells/bluemagic/claw_cyclone.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_ATTACK
-        params.dmgtype = tpz.damageType.SLASHING
+        params.damageType = tpz.damageType.SLASHING
         params.scattr = SC_SCISSION
         params.numhits = 2
         params.multiplier = 1.4375

--- a/scripts/globals/spells/bluemagic/corrosive_ooze.lua
+++ b/scripts/globals/spells/bluemagic/corrosive_ooze.lua
@@ -28,6 +28,7 @@ function onSpellCast(caster,target,spell)
     if (caster:hasStatusEffect(tpz.effect.AZURE_LORE)) then
         multi = multi + 0.50
     end
+        params.damageType = tpz.damageType.WATER
         params.multiplier = multi
         params.tMultiplier = 2.0
         params.duppercap = 69

--- a/scripts/globals/spells/bluemagic/cursed_sphere.lua
+++ b/scripts/globals/spells/bluemagic/cursed_sphere.lua
@@ -24,6 +24,7 @@ end
 function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
+        params.damageType = tpz.damageType.WATER
         params.multiplier = 1.50
         params.tMultiplier = 1.0
         params.duppercap = 30

--- a/scripts/globals/spells/bluemagic/death_ray.lua
+++ b/scripts/globals/spells/bluemagic/death_ray.lua
@@ -28,6 +28,7 @@ function onSpellCast(caster,target,spell)
     if (caster:hasStatusEffect(tpz.effect.AZURE_LORE)) then
         multi = multi + 2.0
     end
+        params.damageType = tpz.damageType.DARK
         params.multiplier = multi
         params.tMultiplier = 1.0
         params.duppercap = 51

--- a/scripts/globals/spells/bluemagic/death_scissors.lua
+++ b/scripts/globals/spells/bluemagic/death_scissors.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_DAMAGE
-        params.dmgtype = tpz.damageType.SLASHING
+        params.damageType = tpz.damageType.SLASHING
         params.scattr = SC_COMPRESSION
         params.numhits = 1
         params.multiplier = 1.5

--- a/scripts/globals/spells/bluemagic/digest.lua
+++ b/scripts/globals/spells/bluemagic/digest.lua
@@ -52,6 +52,7 @@ function onSpellCast(caster,target,spell)
         dmg = target:getHP()
     end
 
+    params.damageType = tpz.damageType.DARK
     dmg = BlueFinalAdjustments(caster,target,spell,dmg,params)
     caster:addHP(dmg)
 

--- a/scripts/globals/spells/bluemagic/dimensional_death.lua
+++ b/scripts/globals/spells/bluemagic/dimensional_death.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_ATTACK
-        params.dmgtype = tpz.damageType.HTH
+        params.damageType = tpz.damageType.BLUNT
         params.scattr = SC_IMPACTION
         params.numhits = 1
         params.multiplier = 2.25

--- a/scripts/globals/spells/bluemagic/disseverment.lua
+++ b/scripts/globals/spells/bluemagic/disseverment.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_ACC
-        params.dmgtype = tpz.damageType.PIERCING
+        params.damageType = tpz.damageType.PIERCING
         params.scattr = SC_DISTORTION
         params.numhits = 5
         params.multiplier = 1.5

--- a/scripts/globals/spells/bluemagic/eyes_on_me.lua
+++ b/scripts/globals/spells/bluemagic/eyes_on_me.lua
@@ -28,6 +28,7 @@ function onSpellCast(caster,target,spell)
     if (caster:hasStatusEffect(tpz.effect.AZURE_LORE)) then
         multi = multi + 2.0
     end
+        params.damageType = tpz.damageType.DARK
         params.multiplier = multi
         params.tMultiplier = 1.5
         params.duppercap = 69

--- a/scripts/globals/spells/bluemagic/feather_storm.lua
+++ b/scripts/globals/spells/bluemagic/feather_storm.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_CRITICAL
-        params.dmgtype = tpz.damageType.PIERCING
+        params.damageType = tpz.damageType.PIERCING
         params.scattr = SC_LIGHT
         params.numhits = 1
         params.multiplier = 1.25

--- a/scripts/globals/spells/bluemagic/firespit.lua
+++ b/scripts/globals/spells/bluemagic/firespit.lua
@@ -24,6 +24,7 @@ end
 function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
+        params.damageType = tpz.damageType.FIRE
         params.multiplier = 3.0
         params.tMultiplier = 1.5
         params.duppercap = 69

--- a/scripts/globals/spells/bluemagic/flying_hip_press.lua
+++ b/scripts/globals/spells/bluemagic/flying_hip_press.lua
@@ -23,6 +23,7 @@ end
 
 function onSpellCast(caster,target,spell)
     local params = {}
+        params.damageType = tpz.damageType.WIND
         params.multiplier = 2.775
         params.tMultiplier = 2.912
         params.duppercap = 58

--- a/scripts/globals/spells/bluemagic/foot_kick.lua
+++ b/scripts/globals/spells/bluemagic/foot_kick.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_CRITICAL
-        params.dmgtype = tpz.damageType.SLASHING
+        params.damageType = tpz.damageType.SLASHING
         params.scattr = SC_DETONATION
         params.numhits = 1
         params.multiplier = 1.0

--- a/scripts/globals/spells/bluemagic/frenetic_rip.lua
+++ b/scripts/globals/spells/bluemagic/frenetic_rip.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_DAMAGE
-        params.dmgtype = tpz.damageType.HTH
+        params.damageType = tpz.damageType.BLUNT
         params.scattr = SC_INDURATION
         params.numhits = 3
         params.multiplier = 1.36

--- a/scripts/globals/spells/bluemagic/frost_breath.lua
+++ b/scripts/globals/spells/bluemagic/frost_breath.lua
@@ -31,6 +31,7 @@ function onSpellCast(caster,target,spell)
     local resist = applyResistance(caster, target, spell, params)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
+        params.damageType = tpz.damageType.ICE
         params.multiplier = multi
         params.tMultiplier = 1.5
         params.duppercap = 69

--- a/scripts/globals/spells/bluemagic/frypan.lua
+++ b/scripts/globals/spells/bluemagic/frypan.lua
@@ -33,7 +33,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_ACC
-        params.dmgtype = tpz.damageType.BLUNT
+        params.damageType = tpz.damageType.BLUNT
         params.scattr = SC_IMPACTION
         params.numhits = 1
         params.multiplier = 1.78

--- a/scripts/globals/spells/bluemagic/grand_slam.lua
+++ b/scripts/globals/spells/bluemagic/grand_slam.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_ATTACK
-        params.dmgtype = tpz.damageType.BLUNT
+        params.damageType = tpz.damageType.BLUNT
         params.scattr = SC_INDURATION
         params.numhits = 1
         params.multiplier = 1.0

--- a/scripts/globals/spells/bluemagic/head_butt.lua
+++ b/scripts/globals/spells/bluemagic/head_butt.lua
@@ -33,7 +33,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_DAMAGE
-        params.dmgtype = tpz.damageType.BLUNT
+        params.damageType = tpz.damageType.BLUNT
         params.scattr = SC_IMPACTION
         params.numhits = 1
         params.multiplier = 1.75

--- a/scripts/globals/spells/bluemagic/heat_breath.lua
+++ b/scripts/globals/spells/bluemagic/heat_breath.lua
@@ -31,6 +31,7 @@ function onSpellCast(caster,target,spell)
     local resist = applyResistance(caster, target, spell, params)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
+        params.damageType = tpz.damageType.FIRE
         params.multiplier = multi
         params.tMultiplier = 1.5
         params.duppercap = 69

--- a/scripts/globals/spells/bluemagic/hecatomb_wave.lua
+++ b/scripts/globals/spells/bluemagic/hecatomb_wave.lua
@@ -36,6 +36,7 @@ function onSpellCast(caster,target,spell)
     local resist = applyResistance(caster, target, spell, params)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
+        params.damageType = tpz.damageType.WIND
         params.multiplier = 1.375
         params.tMultiplier = 1.0
         params.duppercap = 54

--- a/scripts/globals/spells/bluemagic/helldive.lua
+++ b/scripts/globals/spells/bluemagic/helldive.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_DAMAGE
-        params.dmgtype = tpz.damageType.BLUNT
+        params.damageType = tpz.damageType.BLUNT
         params.scattr = SC_TRANSFIXION
         params.numhits = 1
         params.multiplier = 1.25

--- a/scripts/globals/spells/bluemagic/hydro_shot.lua
+++ b/scripts/globals/spells/bluemagic/hydro_shot.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_CHANCE
-        params.dmgtype = tpz.damageType.HTH
+        params.damageType = tpz.damageType.BLUNT
         params.scattr = SC_REVERBERATION
         params.numhits = 1
         params.multiplier = 1.25

--- a/scripts/globals/spells/bluemagic/hysteric_barrage.lua
+++ b/scripts/globals/spells/bluemagic/hysteric_barrage.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_DAMAGE
-        params.dmgtype = tpz.damageType.HTH
+        params.damageType = tpz.damageType.HTH
         params.scattr = SC_DETONATION
         params.numhits = 5
         params.multiplier = 1.25

--- a/scripts/globals/spells/bluemagic/ice_break.lua
+++ b/scripts/globals/spells/bluemagic/ice_break.lua
@@ -36,6 +36,7 @@ function onSpellCast(caster,target,spell)
     local resist = applyResistance(caster, target, spell, params)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
+        params.damageType = tpz.damageType.ICE
         params.multiplier = 2.25
         params.tMultiplier = 1.0
         params.duppercap = 69

--- a/scripts/globals/spells/bluemagic/jet_stream.lua
+++ b/scripts/globals/spells/bluemagic/jet_stream.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_ACC
-        params.dmgtype = tpz.damageType.BLUNT
+        params.damageType = tpz.damageType.BLUNT
         params.scattr = SC_IMPACTION
         params.numhits = 3
         params.multiplier = 1.125

--- a/scripts/globals/spells/bluemagic/maelstrom.lua
+++ b/scripts/globals/spells/bluemagic/maelstrom.lua
@@ -24,6 +24,7 @@ end
 function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
+        params.damageType = tpz.damageType.WATER
         params.multiplier = 2.375
         params.tMultiplier = 1.5
         params.duppercap = 69

--- a/scripts/globals/spells/bluemagic/magic_hammer.lua
+++ b/scripts/globals/spells/bluemagic/magic_hammer.lua
@@ -39,6 +39,7 @@ function onSpellCast(caster,target,spell)
 
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
+    params.damageType = tpz.damageType.LIGHT
     params.multiplier = multi
     params.tMultiplier = 1.0
     params.duppercap = 35

--- a/scripts/globals/spells/bluemagic/magnetite_cloud.lua
+++ b/scripts/globals/spells/bluemagic/magnetite_cloud.lua
@@ -23,6 +23,7 @@ end
 
 function onSpellCast(caster,target,spell)
     local params = {}
+        params.damageType = tpz.damageType.EARTH
         params.diff = caster:getStat(tpz.mod.INT) - target:getStat(tpz.mod.INT)
         params.attribute = tpz.mod.INT
         params.skillType = tpz.skill.BLUE_MAGIC

--- a/scripts/globals/spells/bluemagic/mandibular_bite.lua
+++ b/scripts/globals/spells/bluemagic/mandibular_bite.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_ATTACK
-        params.dmgtype = tpz.damageType.SLASHING
+        params.damageType = tpz.damageType.SLASHING
         params.scattr = SC_INDURATION
         params.numhits = 1
         params.multiplier = 2.0

--- a/scripts/globals/spells/bluemagic/mind_blast.lua
+++ b/scripts/globals/spells/bluemagic/mind_blast.lua
@@ -23,6 +23,7 @@ end
 
 function onSpellCast(caster,target,spell)
     local params = {}
+    params.damageType = tpz.damageType.LIGHTNING
     params.diff = caster:getStat(tpz.mod.INT) - target:getStat(tpz.mod.INT)
     params.attribute = tpz.mod.INT
     params.skillType = tpz.skill.BLUE_MAGIC

--- a/scripts/globals/spells/bluemagic/mysterious_light.lua
+++ b/scripts/globals/spells/bluemagic/mysterious_light.lua
@@ -23,6 +23,7 @@ end
 
 function onSpellCast(caster,target,spell)
     local params = {}
+        params.damageType = tpz.damageType.WIND
         params.diff = caster:getStat(tpz.mod.INT) - target:getStat(tpz.mod.INT)
         params.attribute = tpz.mod.INT
         params.skillType = tpz.skill.BLUE_MAGIC

--- a/scripts/globals/spells/bluemagic/poison_breath.lua
+++ b/scripts/globals/spells/bluemagic/poison_breath.lua
@@ -26,6 +26,7 @@ end
 
 function onSpellCast(caster,target,spell)
     local params = {}
+        params.damageType = tpz.damageType.WATER
         params.diff = caster:getStat(tpz.mod.INT) - target:getStat(tpz.mod.INT)
         params.attribute = tpz.mod.INT
         params.skillType = tpz.skill.BLUE_MAGIC

--- a/scripts/globals/spells/bluemagic/power_attack.lua
+++ b/scripts/globals/spells/bluemagic/power_attack.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_CRITICAL
-        params.dmgtype = tpz.damageType.BLUNT
+        params.damageType = tpz.damageType.BLUNT
         params.scattr = SC_REVERBERATION
         params.numhits = 1
         params.multiplier = 1.125

--- a/scripts/globals/spells/bluemagic/queasyshroom.lua
+++ b/scripts/globals/spells/bluemagic/queasyshroom.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_CRITICAL
-        params.dmgtype = tpz.damageType.PIERCING
+        params.damageType = tpz.damageType.PIERCING
         params.scattr = SC_DARK
         params.numhits = 1
         params.multiplier = 1.25

--- a/scripts/globals/spells/bluemagic/radiant_breath.lua
+++ b/scripts/globals/spells/bluemagic/radiant_breath.lua
@@ -29,6 +29,7 @@ function onSpellCast(caster,target,spell)
 
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
+        params.damageType = tpz.damageType.LIGHT
         params.multiplier = multi
         params.tMultiplier = 1.5
         params.duppercap = 69

--- a/scripts/globals/spells/bluemagic/ram_charge.lua
+++ b/scripts/globals/spells/bluemagic/ram_charge.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
     params.tpmod = TPMOD_DAMAGE
-    params.dmgtype = tpz.damageType.BLUNT
+    params.damageType = tpz.damageType.BLUNT
     params.scattr = SC_FRAGMENTATION
     params.numhits = 1
     params.multiplier = 1.0

--- a/scripts/globals/spells/bluemagic/regurgitation.lua
+++ b/scripts/globals/spells/bluemagic/regurgitation.lua
@@ -23,6 +23,7 @@ end
 
 function onSpellCast(caster,target,spell)
     local params = {}
+        params.damageType = tpz.damageType.WATER
         params.multiplier = 1.83
         params.tMultiplier = 2.0
         params.duppercap = 69

--- a/scripts/globals/spells/bluemagic/rending_deluge.lua
+++ b/scripts/globals/spells/bluemagic/rending_deluge.lua
@@ -13,6 +13,7 @@
 -----------------------------------------
 require("scripts/globals/bluemagic")
 require("scripts/globals/magic")
+require("scripts/globals/status")
 -----------------------------------------
 
 function onMagicCastingCheck(caster,target,spell)
@@ -25,6 +26,7 @@ function onSpellCast(caster,target,spell)
         multi = multi + 1.50
     end
     local params = {}
+    params.damageType = tpz.damageType.WATER
     params.attribute = tpz.mod.INT
     params.skillType = tpz.skill.BLUE_MAGIC
     params.effect = tpz.effect.NONE

--- a/scripts/globals/spells/bluemagic/sandspin.lua
+++ b/scripts/globals/spells/bluemagic/sandspin.lua
@@ -24,6 +24,7 @@ end
 function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
+        params.damageType = tpz.damageType.EARTH
         params.multiplier = 1.0
         params.tMultiplier = 1.0
         params.duppercap = 13

--- a/scripts/globals/spells/bluemagic/screwdriver.lua
+++ b/scripts/globals/spells/bluemagic/screwdriver.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_CRITICAL
-        params.dmgtype = tpz.damageType.PIERCING
+        params.damageType = tpz.damageType.PIERCING
         params.scattr = SC_TRANSFIXION
         params.scattr2 = SC_SCISSION
         params.numhits = 1

--- a/scripts/globals/spells/bluemagic/seedspray.lua
+++ b/scripts/globals/spells/bluemagic/seedspray.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_CRITICAL
-        params.dmgtype = tpz.damageType.SLASHING
+        params.damageType = tpz.damageType.SLASHING
         params.scattr = SC_GRAVITATION
         params.numhits = 3
         params.multiplier = 1.925

--- a/scripts/globals/spells/bluemagic/sickle_slash.lua
+++ b/scripts/globals/spells/bluemagic/sickle_slash.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_CRITICAL
-        params.dmgtype = tpz.damageType.HTH
+        params.damageType = tpz.damageType.HTH
         params.scattr = SC_COMPRESSION
         params.numhits = 1
         params.multiplier = 1.5

--- a/scripts/globals/spells/bluemagic/smite_of_rage.lua
+++ b/scripts/globals/spells/bluemagic/smite_of_rage.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_DAMAGE
-        params.dmgtype = tpz.damageType.SLASHING
+        params.damageType = tpz.damageType.SLASHING
         params.scattr = SC_DETONATION
         params.numhits = 1
         params.multiplier = 1.5

--- a/scripts/globals/spells/bluemagic/spinal_cleave.lua
+++ b/scripts/globals/spells/bluemagic/spinal_cleave.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_ACC
-        params.dmgtype = tpz.damageType.SLASHING
+        params.damageType = tpz.damageType.SLASHING
         params.scattr = SC_SCISSION
         params.scattr2 = SC_DETONATION
         params.numhits = 1

--- a/scripts/globals/spells/bluemagic/spiral_spin.lua
+++ b/scripts/globals/spells/bluemagic/spiral_spin.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_CRITICAL
-        params.dmgtype = tpz.damageType.SLASHING
+        params.damageType = tpz.damageType.SLASHING
         params.scattr = SC_TRANSFIXION
         params.numhits = 1
     params.multiplier = 1.925

--- a/scripts/globals/spells/bluemagic/sprout_smack.lua
+++ b/scripts/globals/spells/bluemagic/sprout_smack.lua
@@ -27,7 +27,7 @@ function onSpellCast(caster, target, spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
     params.tpmod = TPMOD_DURATION
-    params.dmgtype = tpz.damageType.BLUNT
+    params.damageType = tpz.damageType.BLUNT
     params.scattr = SC_REVERBERATION
     params.numhits = 1
     params.multiplier = 1.5

--- a/scripts/globals/spells/bluemagic/sub-zero_smash.lua
+++ b/scripts/globals/spells/bluemagic/sub-zero_smash.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_CRITICAL
-        params.dmgtype = tpz.damageType.BLUNT
+        params.damageType = tpz.damageType.BLUNT
         params.scattr = SC_FRAGMENTATION
         params.numhits = 1
         params.multiplier = 1.95

--- a/scripts/globals/spells/bluemagic/sudden_lunge.lua
+++ b/scripts/globals/spells/bluemagic/sudden_lunge.lua
@@ -33,7 +33,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- Todo: determine if these param values are retail
         params.tpmod = TPMOD_DAMAGE
-        params.dmgtype = tpz.damageType.SLASHING
+        params.damageType = tpz.damageType.SLASHING
         params.scattr = SC_DETONATION
         params.numhits = 1
         params.multiplier = 1.875

--- a/scripts/globals/spells/bluemagic/tail_slap.lua
+++ b/scripts/globals/spells/bluemagic/tail_slap.lua
@@ -33,7 +33,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_ATTACK
-        params.dmgtype = tpz.damageType.HTH
+        params.damageType = tpz.damageType.HTH
         params.scattr = SC_REVERBERATION
         params.numhits = 1
         params.multiplier = 1.625

--- a/scripts/globals/spells/bluemagic/terror_touch.lua
+++ b/scripts/globals/spells/bluemagic/terror_touch.lua
@@ -27,7 +27,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_ACC
-        params.dmgtype = tpz.damageType.HTH
+        params.damageType = tpz.damageType.HTH
         params.scattr = SC_COMPRESSION
         params.numhits = 1
         params.multiplier = 1.5

--- a/scripts/globals/spells/bluemagic/uppercut.lua
+++ b/scripts/globals/spells/bluemagic/uppercut.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_ATTACK
-        params.dmgtype = tpz.damageType.HTH
+        params.damageType = tpz.damageType.HTH
         params.scattr = SC_LIQUEFACTION
         params.scattr2 = SC_IMPACTION
         params.numhits = 1

--- a/scripts/globals/spells/bluemagic/vertical_cleave.lua
+++ b/scripts/globals/spells/bluemagic/vertical_cleave.lua
@@ -25,7 +25,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_ATTACK
-        params.dmgtype = tpz.damageType.SLASHING
+        params.damageType = tpz.damageType.SLASHING
         params.scattr = SC_GRAVITATION
         params.numhits = 1
         params.multiplier = 3.0

--- a/scripts/globals/spells/bluemagic/wild_oats.lua
+++ b/scripts/globals/spells/bluemagic/wild_oats.lua
@@ -26,7 +26,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_DURATION
-        params.dmgtype = tpz.damageType.PIERCING
+        params.damageType = tpz.damageType.PIERCING
         params.scattr = SC_TRANSFIXION
         params.numhits = 1
         params.multiplier = 1.84


### PR DESCRIPTION
Corrects /adds any inaccurate or missing damage types.

Also updated the param value in the Lua table to use `damageType`
instead of `dmgtype`. This better matches the enum value naming
convention for `tpz.damageType`.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](https://github.com/project-topaz/topaz/blob/master/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

