### PR TITLE
Bulk remove semicolons from Lua scripts/commands.

### DIFF
--- a/scripts/commands/addallattachments.lua
+++ b/scripts/commands/addallattachments.lua
@@ -7,7 +7,7 @@ cmdprops =
 {
     permission = 1,
     parameters = "s"
-};
+}
 
 local ValidAttachments = {
   8193, 8194, 8195, 8196, 8197, 8198, 8224, 8225, 8226, 8227,
@@ -19,23 +19,23 @@ local ValidAttachments = {
   8586, 8609, 8610, 8611, 8612, 8613, 8614, 8615, 8616, 8617,
   8618, 8641, 8642, 8643, 8644, 8645, 8646, 8648, 8649, 8650,
   8673, 8674, 8675, 8676, 8677, 8678, 8680, 8681
-};
+}
 
 local function AddAllAttachments(player)
     for i = 1, #ValidAttachments do
-        player:unlockAttachment(ValidAttachments[i]);
+        player:unlockAttachment(ValidAttachments[i])
     end
-end;
+end
 
 function onTrigger(player, target)
     if (target == nil) then
-        AddAllAttachments(player);
+        AddAllAttachments(player)
     else
-        local targ = GetPlayerByName(target);
+        local targ = GetPlayerByName(target)
         if (targ == nil) then
-            player:PrintToPlayer(string.format( "Player named '%s' not found!", target ));
+            player:PrintToPlayer(string.format( "Player named '%s' not found!", target ))
         else
-            AddAllAttachments(targ);
+            AddAllAttachments(targ)
         end
     end
 end

--- a/scripts/commands/addallmaps.lua
+++ b/scripts/commands/addallmaps.lua
@@ -7,12 +7,12 @@ cmdprops =
 {
     permission = 1,
     parameters = "s"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!addallmaps {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!addallmaps {player}")
+end
 
 function onTrigger(player, target)
     local keyIds =
@@ -25,23 +25,23 @@ function onTrigger(player, target)
         1882, 1883, 1884, 1885, 1886, 1887, 1888, 1889, 1890, 1891, 1892, 1893, 1894, 1895, 1896, 1897,
         1898, 1899, 1900, 1901, 1902, 1903, 1904, 1905, 1906, 1907, 1908, 1909, 1910, 1911, 1912, 1913,
         1914, 1915, 1916, 1917, 1918, 2302, 2303, 2304, 2305, 2307, 2308, 2309
-    };
+    }
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format("Player named '%s' not found!", target));
-            return;
+            error(player, string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
     -- add maps
     for _, v in ipairs( keyIds ) do
-        targ:addKeyItem( v );
+        targ:addKeyItem( v )
     end
-    player:PrintToPlayer(string.format("%s now has all maps.",targ:getName()));
+    player:PrintToPlayer(string.format("%s now has all maps.",targ:getName()))
 end

--- a/scripts/commands/addcurrency.lua
+++ b/scripts/commands/addcurrency.lua
@@ -7,41 +7,41 @@ cmdprops =
 {
     permission = 1,
     parameters = "sis"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!addcurrency <currency type> <amount> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!addcurrency <currency type> <amount> {player}")
+end
 
 function onTrigger(player,currency,amount,target)
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format("Player named '%s' not found!", target));
-            return;
+            error(player, string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
     -- validate currency
     -- note: getCurrency does not ever return nil at the moment.  will work on this in future update.
     if (currency == nil or targ:getCurrency(currency) == nil) then
-        error(player, "Invalid currency type.");
-        return;
+        error(player, "Invalid currency type.")
+        return
     end
 
     -- validate amount
     if (amount == nil or amount < 1) then
-        error(player, "Invalid amount.");
-        return;
+        error(player, "Invalid amount.")
+        return
     end
     
     -- add currency
-    targ:addCurrency(currency,amount);
-    local newAmount = targ:getCurrency(currency);
-    player:PrintToPlayer(string.format("%s was given %i %s, for a total of %i.",targ:getName(),amount,currency,newAmount));
-end;
+    targ:addCurrency(currency,amount)
+    local newAmount = targ:getCurrency(currency)
+    player:PrintToPlayer(string.format("%s was given %i %s, for a total of %i.",targ:getName(),amount,currency,newAmount))
+end

--- a/scripts/commands/addeffect.lua
+++ b/scripts/commands/addeffect.lua
@@ -3,93 +3,93 @@
 -- desc: Adds the given effect to the given player.
 ---------------------------------------------------------------------------------------------------
 
-require("scripts/globals/status");
-require("scripts/globals/teleports");
+require("scripts/globals/status")
+require("scripts/globals/teleports")
 
 
 cmdprops =
 {
     permission = 1,
     parameters = "ssssss"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!addeffect {player} <effect> {power} {duration} {subid} {subPower}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!addeffect {player} <effect> {power} {duration} {subid} {subPower}")
+end
 
 function onTrigger(player, arg1, arg2, arg3, arg4, arg5, arg6)
 
-    local targ;
-    local id;
-    local power;
-    local duration;
-    local subId;
-    local subPower;
+    local targ
+    local id
+    local power
+    local duration
+    local subId
+    local subPower
 
     if (arg1 == nil) then
-        error(player, "Invalid effect.");
-        return;
+        error(player, "Invalid effect.")
+        return
     else
-        targ = GetPlayerByName(arg1);
+        targ = GetPlayerByName(arg1)
         if (targ == nil) then
             -- no valid target given. shift arguments by one.
-            targ = player;
-            id = arg1;
-            power = tonumber(arg2) or 1;
-            duration = tonumber(arg3) or 60;
-            subId = tonumber(arg4) or 0;
-            subPower = tonumber(arg5) or 0;
+            targ = player
+            id = arg1
+            power = tonumber(arg2) or 1
+            duration = tonumber(arg3) or 60
+            subId = tonumber(arg4) or 0
+            subPower = tonumber(arg5) or 0
         else
             -- valid target found. assign arguments as usual
-            id = arg2;
-            power = tonumber(arg3) or 1;
-            duration = tonumber(arg4) or 60;
-            subId = tonumber(arg5) or 0;
-            subPower = tonumber(arg6) or 0;
+            id = arg2
+            power = tonumber(arg3) or 1
+            duration = tonumber(arg4) or 60
+            subId = tonumber(arg5) or 0
+            subPower = tonumber(arg6) or 0
         end
     end
 
     -- validate effect
     if (id == nil) then
-        error(player, "Invalid effect.");
-        return;
+        error(player, "Invalid effect.")
+        return
     else
-        id = tonumber(id) or tpz.effect[string.upper(id)];
+        id = tonumber(id) or tpz.effect[string.upper(id)]
         if (id == nil) then
-            error(player, "Invalid player or effect.");
-            return;
+            error(player, "Invalid player or effect.")
+            return
         end
     end
 
     -- validate power
     if (power < 0) then
-        error(player, "Invalid power.");
-        return;
+        error(player, "Invalid power.")
+        return
     end
 
     -- validate duration
     if (duration < 0) then
-        error(player, "Invalid duration.");
-        return;
+        error(player, "Invalid duration.")
+        return
     end
 
     -- validate subId
     if (subId < 0) then
-        error(player, "Invalid subId.");
-        return;
+        error(player, "Invalid subId.")
+        return
     end
 
     -- validate subPower
     if (subPower < 0) then
-        error(player, "Invalid subPower.");
-        return;
+        error(player, "Invalid subPower.")
+        return
     end
 
     -- add effect
     if (targ:addStatusEffect(id, power, 3, duration, subid, subPower)) then
-        targ:messagePublic(280, targ, id, id);
+        targ:messagePublic(280, targ, id, id)
     else
-        targ:messagePublic(283, targ, id);
+        targ:messagePublic(283, targ, id)
     end
 end

--- a/scripts/commands/additem.lua
+++ b/scripts/commands/additem.lua
@@ -7,12 +7,12 @@ cmdprops =
 {
     permission = 1,
     parameters = "iiiiiiiiiii"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!additem <itemId> {quantity} {aug1} {v1} {aug2} {v2} {aug3} {v3} {aug4} {v4} {trial}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!additem <itemId> {quantity} {aug1} {v1} {aug2} {v2} {aug3} {v3} {aug4} {v4} {trial}")
+end
 
 function onTrigger(player, itemId, quantity, aug0, aug0val, aug1, aug1val, aug2, aug2val, aug3, aug3val, trialId)
     -- Load needed text ids for players current zone..
@@ -20,17 +20,17 @@ function onTrigger(player, itemId, quantity, aug0, aug0val, aug1, aug1val, aug2,
 
     -- validate itemId
     if (itemId == nil or tonumber(itemId) == nil or tonumber(itemId) == 0) then
-        error(player, "Invalid itemId.");
-        return;
+        error(player, "Invalid itemId.")
+        return
     end
     
     -- Ensure the GM has room to obtain the item...
     if (player:getFreeSlotsCount() == 0) then
-        player:messageSpecial( ID.text.ITEM_CANNOT_BE_OBTAINED, itemId );
-        return;
+        player:messageSpecial( ID.text.ITEM_CANNOT_BE_OBTAINED, itemId )
+        return
     end
     
     -- Give the GM the item...
-    player:addItem( itemId, quantity, aug0, aug0val, aug1, aug1val, aug2, aug2val, aug3, aug3val, trialId );
-    player:messageSpecial( ID.text.ITEM_OBTAINED, itemId );
+    player:addItem( itemId, quantity, aug0, aug0val, aug1, aug1val, aug2, aug2val, aug3, aug3val, trialId )
+    player:messageSpecial( ID.text.ITEM_OBTAINED, itemId )
 end

--- a/scripts/commands/addkeyitem.lua
+++ b/scripts/commands/addkeyitem.lua
@@ -9,45 +9,45 @@ cmdprops =
 {
     permission = 1,
     parameters = "ss"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!addkeyitem <key item ID> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!addkeyitem <key item ID> {player}")
+end
 
 function onTrigger(player, keyId, target)
 
     -- validate key item id
     if (keyId == nil) then
-        error(player, "You must supply a Key Item ID.");
-        return;
+        error(player, "You must supply a Key Item ID.")
+        return
     end
-    keyId = tonumber(keyId) or tpz.ki[string.upper(keyId)];
+    keyId = tonumber(keyId) or tpz.ki[string.upper(keyId)]
     if (keyId == nil or keyId == 0) then
-        error(player, "Invalid Key Item ID.");
-        return;
+        error(player, "Invalid Key Item ID.")
+        return
     end
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format("Player named '%s' not found!", target));
-            return;
+            error(player, string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
     -- add key item to target
     if (targ:hasKeyItem(keyId)) then
-        player:PrintToPlayer(string.format("%s already has key item %i.", targ:getName(), keyId));
+        player:PrintToPlayer(string.format("%s already has key item %i.", targ:getName(), keyId))
     else
         local ID = zones[targ:getZoneID()]
-        targ:addKeyItem( keyId );
-        targ:messageSpecial( ID.text.KEYITEM_OBTAINED, keyId );
-        player:PrintToPlayer(string.format("Key item %i was given to %s.", keyId, targ:getName()));
+        targ:addKeyItem( keyId )
+        targ:messageSpecial( ID.text.KEYITEM_OBTAINED, keyId )
+        player:PrintToPlayer(string.format("Key item %i was given to %s.", keyId, targ:getName()))
     end
-end;
+end

--- a/scripts/commands/addmission.lua
+++ b/scripts/commands/addmission.lua
@@ -3,54 +3,54 @@
 -- desc: Adds a mission to the GM or target players log.
 ---------------------------------------------------------------------------------------------------
 
-require("scripts/globals/missions");
+require("scripts/globals/missions")
 
 cmdprops =
 {
     permission = 1,
     parameters = "sss"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!addmission <logID> <missionID> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!addmission <logID> <missionID> {player}")
+end
 
 function onTrigger(player, logId, missionId, target)
 
     -- validate logId
-    local logName;
-    local logInfo = GetMissionLogInfo(logId);
+    local logName
+    local logInfo = GetMissionLogInfo(logId)
     if (logInfo == nil) then
-        error(player, "Invalid logID.");
-        return;
+        error(player, "Invalid logID.")
+        return
     end
-    logName = logInfo.full_name;
-    logId = logInfo.mission_log;
+    logName = logInfo.full_name
+    logId = logInfo.mission_log
     
     -- validate missionId
     local areaMissionIds = tpz.mission.id[tpz.mission.area[logId]]
     if (missionId ~= nil) then
-        missionId = tonumber(missionId) or areaMissionIds[string.upper(missionId)] or _G[string.upper(missionId)];
+        missionId = tonumber(missionId) or areaMissionIds[string.upper(missionId)] or _G[string.upper(missionId)]
     end
     if (missionId == nil or missionId < 0) then
-        error(player, "Invalid missionID.");
-        return;
+        error(player, "Invalid missionID.")
+        return
     end
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format("Player named '%s' not found!", target));
-            return;
+            error(player, string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
     -- add mission
-    targ:addMission(logId, missionId);
-    player:PrintToPlayer(string.format("Added %s mission %i to %s.", logName, missionId, targ:getName()));
-end;
+    targ:addMission(logId, missionId)
+    player:PrintToPlayer(string.format("Added %s mission %i to %s.", logName, missionId, targ:getName()))
+end

--- a/scripts/commands/addquest.lua
+++ b/scripts/commands/addquest.lua
@@ -3,53 +3,53 @@
 -- desc: Adds a quest to the given targets log.
 ---------------------------------------------------------------------------------------------------
 
-require("scripts/globals/quests");
+require("scripts/globals/quests")
 
 cmdprops =
 {
     permission = 1,
     parameters = "sss"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!addquest <logID> <questID> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!addquest <logID> <questID> {player}")
+end
 
 function onTrigger(player, logId, questId, target)
 
     -- validate logId
-    local questLog = GetQuestLogInfo(logId);
+    local questLog = GetQuestLogInfo(logId)
     if (questLog == nil) then
-        error(player, "Invalid logID.");
-        return;
+        error(player, "Invalid logID.")
+        return
     end
-    local logName = questLog.full_name;
-    logId = questLog.quest_log;
+    local logName = questLog.full_name
+    logId = questLog.quest_log
 
     -- validate questId
-    local areaQuestIds = tpz.quest.id[tpz.quest.area[logId]];
+    local areaQuestIds = tpz.quest.id[tpz.quest.area[logId]]
     if (questId ~= nil) then
-        questId = tonumber(questId) or areaQuestIds[string.upper(questId)];
+        questId = tonumber(questId) or areaQuestIds[string.upper(questId)]
     end
     if (questId == nil or questId < 0) then
-        error(player, "Invalid questID.");
-        return;
+        error(player, "Invalid questID.")
+        return
     end
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format("Player named '%s' not found!", target));
-            return;
+            error(player, string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
     -- add quest
-    targ:addQuest(logId, questId);
-    player:PrintToPlayer(string.format("Added %s quest %i to %s.", logName, questId, targ:getName()));
-end;
+    targ:addQuest(logId, questId)
+    player:PrintToPlayer(string.format("Added %s quest %i to %s.", logName, questId, targ:getName()))
+end

--- a/scripts/commands/addspell.lua
+++ b/scripts/commands/addspell.lua
@@ -7,35 +7,35 @@ cmdprops =
 {
     permission = 1,
     parameters = "is"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!addspell <spellID> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!addspell <spellID> {player}")
+end
 
 function onTrigger(player, spellId, target)
     -- validate spellId
     if (spellId == nil) then
-        error(player, "Invalid spellID.");
-        return;
+        error(player, "Invalid spellID.")
+        return
     end
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format("Player named '%s' not found!", target));
-            return;
+            error(player, string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
     -- add spell
-    local save = true;
-    local silent = false;
-    targ:addSpell(spellId, silent, save);
-    player:PrintToPlayer(string.format("Added spell %i to %s.",spellId,targ:getName()));
-end;
+    local save = true
+    local silent = false
+    targ:addSpell(spellId, silent, save)
+    player:PrintToPlayer(string.format("Added spell %i to %s.",spellId,targ:getName()))
+end

--- a/scripts/commands/addtempitem.lua
+++ b/scripts/commands/addtempitem.lua
@@ -7,30 +7,30 @@ cmdprops =
 {
     permission = 1,
     parameters = "ii"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!addtempitem <itemID> <quantity>");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!addtempitem <itemID> <quantity>")
+end
 
 function onTrigger(player, itemId, quantity)
     -- validate itemId
     if (itemId ~= nil) then
-        itemId = tonumber(itemId);
+        itemId = tonumber(itemId)
     end
     if (itemId == nil or itemId == 0) then
-        error(player, "Invalid itemID.");
-        return;
+        error(player, "Invalid itemID.")
+        return
     end
 
     -- validate quantity
-    quantity = tonumber(quantity) or 1;
+    quantity = tonumber(quantity) or 1
     if (quantity == nil or quantity < 1) then
-        error(player, "Invalid quantity.");
-        return;
+        error(player, "Invalid quantity.")
+        return
     end
 
     -- add temp item
-    player:addTempItem(itemId, quantity, 0, 0, 0, 0, 0, 0, 0, 0);
+    player:addTempItem(itemId, quantity, 0, 0, 0, 0, 0, 0, 0, 0)
 end

--- a/scripts/commands/addtitle.lua
+++ b/scripts/commands/addtitle.lua
@@ -3,45 +3,45 @@
 -- desc: Add and set player title.
 ---------------------------------------------------------------------------------------------------
 
-require("scripts/globals/titles");
+require("scripts/globals/titles")
 
 cmdprops =
 {
     permission = 1,
     parameters = "ss"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!addtitle <title ID> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!addtitle <title ID> {player}")
+end
 
 function onTrigger(player, titleId, target)
 
     -- validate titleId
     if (titleId == nil) then
-        error(player, "You must supply a title ID.");
-        return;
+        error(player, "You must supply a title ID.")
+        return
     end
-    titleId = tonumber(titleId) or tpz.title[string.upper(titleId)];
+    titleId = tonumber(titleId) or tpz.title[string.upper(titleId)]
     if (titleId == nil or titleId < 1) then
-        error(player, "Invalid title ID.");
-        return;
+        error(player, "Invalid title ID.")
+        return
     end
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format("Player named '%s' not found!", target));
-            return;
+            error(player, string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
     -- add title
-    targ:addTitle( titleId );
-    player:PrintToPlayer( string.format("%s was given title %s.", targ:getName(), titleId) );
+    targ:addTitle( titleId )
+    player:PrintToPlayer( string.format("%s was given title %s.", targ:getName(), titleId) )
 end

--- a/scripts/commands/addtreasure.lua
+++ b/scripts/commands/addtreasure.lua
@@ -7,45 +7,45 @@ cmdprops =
 {
     permission = 1,
     parameters = "isi"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!addtreasure <itemID> {player} {npcID}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!addtreasure <itemID> {player} {npcID}")
+end
 
 function onTrigger(player, itemId, target, dropper)
     -- validate itemId
     if (itemId ~= nil) then
-        itemId = tonumber(itemId);
+        itemId = tonumber(itemId)
     end
     if (itemId == nil or itemId == 0) then
-        error(player, "Invalid itemID.");
-        return;
+        error(player, "Invalid itemID.")
+        return
     end
     
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format("Player named '%s' not found!", target));
-            return;
+            error(player, string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
     -- validate dropper
     if (dropper ~= nil) then
-        dropper = GetNPCByID(dropper);
+        dropper = GetNPCByID(dropper)
         if (dropper == nil) then
-            error(player, "Invalid npcID.");
-            return;
+            error(player, "Invalid npcID.")
+            return
         end
     end
 
     -- add treasure to pool
-    targ:addTreasure(itemId, dropper);
-    player:PrintToPlayer(string.format("Item of ID %d was added to the treasure pool of %s or their party/alliance.", itemId, targ:getName()));
+    targ:addTreasure(itemId, dropper)
+    player:PrintToPlayer(string.format("Item of ID %d was added to the treasure pool of %s or their party/alliance.", itemId, targ:getName()))
 end

--- a/scripts/commands/ah.lua
+++ b/scripts/commands/ah.lua
@@ -7,8 +7,8 @@ cmdprops =
 {
     permission = 1,
     parameters = ""
-};
+}
 
 function onTrigger(player)
-    player:sendMenu(3);
-end;
+    player:sendMenu(3)
+end

--- a/scripts/commands/animatenpc.lua
+++ b/scripts/commands/animatenpc.lua
@@ -3,53 +3,53 @@
 -- desc: Changes the animation of the given npc. (For testing purposes.)
 ---------------------------------------------------------------------------------------------------
 
-require("scripts/globals/status");
+require("scripts/globals/status")
 
 cmdprops =
 {
     permission = 1,
     parameters = "ss"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!animatenpc {npcID} <animationID>");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!animatenpc {npcID} <animationID>")
+end
 
 function onTrigger(player, arg1, arg2)
-    local targ;
-    local animationId;
+    local targ
+    local animationId
 
     if (arg2 == nil) then
         -- player did not provide npcId.  Shift arguments by one.
-        targ = player:getCursorTarget();
-        animationId = arg1;
+        targ = player:getCursorTarget()
+        animationId = arg1
     else
         -- player provided npcId and animationId.
-        targ = GetNPCByID(tonumber(arg1));
-        animationId = arg2;
+        targ = GetNPCByID(tonumber(arg1))
+        animationId = arg2
     end
 
     -- validate target
     if (targ == nil) then
-        error(player,"You must either enter a valid npcID or target an NPC.");
-        return;
+        error(player,"You must either enter a valid npcID or target an NPC.")
+        return
     end
     if (not targ:isNPC()) then
-        error(player,"Targeted entity is not an NPC.");
-        return;
+        error(player,"Targeted entity is not an NPC.")
+        return
     end
 
     -- validate animationID
     if (animationId ~= nil) then
-        animationId = tonumber(animationId) or tpz.anim[string.upper(animationId)];
+        animationId = tonumber(animationId) or tpz.anim[string.upper(animationId)]
     end
     if (animationId == nil) then
-        error(player,"Invalid animationID.");
-        return;
+        error(player,"Invalid animationID.")
+        return
     end
     
-    local oldAnimation = targ:getAnimation();
-    targ:setAnimation( animationId );
-    player:PrintToPlayer(string.format("NPC ID: %i - %s | Old animation: %i | New animation: %i\n", targ:getID(), targ:getName(), oldAnimation, animationId));
+    local oldAnimation = targ:getAnimation()
+    targ:setAnimation( animationId )
+    player:PrintToPlayer(string.format("NPC ID: %i - %s | Old animation: %i | New animation: %i\n", targ:getID(), targ:getName(), oldAnimation, animationId))
 end

--- a/scripts/commands/animatesubnpc.lua
+++ b/scripts/commands/animatesubnpc.lua
@@ -3,53 +3,53 @@
 -- desc: Changes the animationSub of the given npc. (For testing purposes.)
 ---------------------------------------------------------------------------------------------------
 
-require("scripts/globals/status");
+require("scripts/globals/status")
 
 cmdprops =
 {
     permission = 1,
     parameters = "ss"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!animatesubnpc {npcID} <animationID>");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!animatesubnpc {npcID} <animationID>")
+end
 
 function onTrigger(player, arg1, arg2)
-    local targ;
-    local animationId;
+    local targ
+    local animationId
 
     if (arg2 == nil) then
         -- player did not provide npcId.  Shift arguments by one.
-        targ = player:getCursorTarget();
-        animationId = arg1;
+        targ = player:getCursorTarget()
+        animationId = arg1
     else
         -- player provided npcId and animationId.
-        targ = GetNPCByID(tonumber(arg1));
-        animationId = arg2;
+        targ = GetNPCByID(tonumber(arg1))
+        animationId = arg2
     end
 
     -- validate target
     if (targ == nil) then
-        error(player,"You must either enter a valid npcID or target an NPC.");
-        return;
+        error(player,"You must either enter a valid npcID or target an NPC.")
+        return
     end
     if (not targ:isNPC()) then
-        error(player,"Targeted entity is not an NPC.");
-        return;
+        error(player,"Targeted entity is not an NPC.")
+        return
     end
 
     -- validate animationID
     if (animationId ~= nil) then
-        animationId = tonumber(animationId) or tpz.anim[string.upper(animationId)];
+        animationId = tonumber(animationId) or tpz.anim[string.upper(animationId)]
     end
     if (animationId == nil) then
-        error(player,"Invalid animationID.");
-        return;
+        error(player,"Invalid animationID.")
+        return
     end
     
-    local oldAnimation = targ:AnimationSub();
-    targ:AnimationSub( animationId );
-    player:PrintToPlayer(string.format("NPC ID: %i - %s | Old animationSub: %i | New animationSub: %i\n", targ:getID(), targ:getName(), oldAnimation, animationId));
+    local oldAnimation = targ:AnimationSub()
+    targ:AnimationSub( animationId )
+    player:PrintToPlayer(string.format("NPC ID: %i - %s | Old animationSub: %i | New animationSub: %i\n", targ:getID(), targ:getName(), oldAnimation, animationId))
 end

--- a/scripts/commands/animation.lua
+++ b/scripts/commands/animation.lua
@@ -3,35 +3,35 @@
 -- desc: Sets the players current animation.
 ---------------------------------------------------------------------------------------------------
 
-require("scripts/globals/status");
+require("scripts/globals/status")
 
 cmdprops =
 {
     permission = 1,
     parameters = "s"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!animation {animationID}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!animation {animationID}")
+end
 
 function onTrigger(player, animationId)
-    local oldAnimation = player:getAnimation();
+    local oldAnimation = player:getAnimation()
     
     if (animationId == nil) then
-        player:PrintToPlayer(string.format("Current player animation: %d", oldAnimation));
-        return;
+        player:PrintToPlayer(string.format("Current player animation: %d", oldAnimation))
+        return
     end
 
     -- validate animationId
-    animationId = tonumber(animationId) or tpz.anim[string.upper(animationId)];
+    animationId = tonumber(animationId) or tpz.anim[string.upper(animationId)]
     if (animationId == nil or animationId < 0) then
-        error(player, "Invalid animationId.");
-        return;
+        error(player, "Invalid animationId.")
+        return
     end
 
     -- set player animation
-    player:setAnimation(animationId);
-    player:PrintToPlayer(string.format("%s | Old animation: %i | New animation: %i\n", player:getName(), oldAnimation, animationId));
+    player:setAnimation(animationId)
+    player:PrintToPlayer(string.format("%s | Old animation: %i | New animation: %i\n", player:getName(), oldAnimation, animationId))
 end

--- a/scripts/commands/bring.lua
+++ b/scripts/commands/bring.lua
@@ -7,41 +7,41 @@ cmdprops =
 {
     permission = 1,
     parameters = "si"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!bring <player> {forceZone}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!bring <player> {forceZone}")
+end
 
 function onTrigger(player, target, forceZone)
     -- validate target
     if (target == nil) then
-        error(player, "You must enter a target player name.");
-        return;
+        error(player, "You must enter a target player name.")
+        return
     end
-    local targ = GetPlayerByName( target );
+    local targ = GetPlayerByName( target )
     if (targ == nil) then
         if not player:bringPlayer( target ) then
-            error(player, string.format( "Player named '%s' not found!", target ) );
-        end;
-        return;
+            error(player, string.format( "Player named '%s' not found!", target ) )
+        end
+        return
     end
 
     -- validate forceZone
     if (forceZone ~= nil) then
         if (forceZone ~= 0 and forceZone ~= 1) then
-            error(player, "If provided, forceZone must be 1 (true) or 0 (false).");
-            return;
+            error(player, "If provided, forceZone must be 1 (true) or 0 (false).")
+            return
         end
     else
-        forceZone = 1;
+        forceZone = 1
     end
 
     -- bring target
     if (targ:getZoneID() ~= player:getZoneID() or forceZone == 1) then
-        targ:setPos( player:getXPos(), player:getYPos(), player:getZPos(), player:getRotPos(), player:getZoneID() );
+        targ:setPos( player:getXPos(), player:getYPos(), player:getZPos(), player:getRotPos(), player:getZoneID() )
     else
-        targ:setPos( player:getXPos(), player:getYPos(), player:getZPos(), player:getRotPos() );
+        targ:setPos( player:getXPos(), player:getYPos(), player:getZPos(), player:getRotPos() )
     end
 end

--- a/scripts/commands/capallskills.lua
+++ b/scripts/commands/capallskills.lua
@@ -7,9 +7,9 @@ cmdprops =
 {
     permission = 1,
     parameters = ""
-};
+}
 
 function onTrigger(player)
-    player:capAllSkills();
-    player:PrintToPlayer( 'All skills capped!' );
+    player:capAllSkills()
+    player:PrintToPlayer( 'All skills capped!' )
 end

--- a/scripts/commands/capskill.lua
+++ b/scripts/commands/capskill.lua
@@ -3,32 +3,32 @@
 -- desc: Caps a specific skill.
 ---------------------------------------------------------------------------------------------------
 
-require("scripts/globals/status");
+require("scripts/globals/status")
 
 cmdprops =
 {
     permission = 1,
     parameters = "s"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!capskill <skillID>");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!capskill <skillID>")
+end
 
 function onTrigger(player, skillId)
     -- validate skillId
     if (skillId == nil) then
-        error(player, "You must provide a skillID.");
-        return;
+        error(player, "You must provide a skillID.")
+        return
     end
-    skillId = tonumber(skillId) or tpz.skill[string.upper(skillId)];
+    skillId = tonumber(skillId) or tpz.skill[string.upper(skillId)]
     if (skillId == nil or skillId == 0) then
-        error(player, "Invalid skillID.");
-        return;
+        error(player, "Invalid skillID.")
+        return
     end
 
     -- cap skill
-    player:capSkill( skillId );
-    player:PrintToPlayer( string.format( "Capped skillID %i.", skillId ) );
+    player:capSkill( skillId )
+    player:PrintToPlayer( string.format( "Capped skillID %i.", skillId ) )
 end

--- a/scripts/commands/changejob.lua
+++ b/scripts/commands/changejob.lua
@@ -3,51 +3,51 @@
 -- desc: Changes the players current job.
 ---------------------------------------------------------------------------------------------------
 
-require("scripts/globals/status");
+require("scripts/globals/status")
 
 cmdprops =
 {
     permission = 1,
     parameters = "si"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!changejob <jobID> {level}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!changejob <jobID> {level}")
+end
 
 function onTrigger(player, jobId, level)
     -- validate jobId
     if (jobId == nil) then
-        error(player, "You must enter a job short-name, e.g. WAR, or its equivalent numeric ID.");
-        return;
+        error(player, "You must enter a job short-name, e.g. WAR, or its equivalent numeric ID.")
+        return
     end
-    jobId = tonumber(jobId) or tpz.job[string.upper(jobId)];
+    jobId = tonumber(jobId) or tpz.job[string.upper(jobId)]
     if (jobId == nil or jobId <= 0 or jobId >= tpz.MAX_JOB_TYPE) then
-        error(player, "Invalid jobID.  Use job short name, e.g. WAR, or its equivalent numeric ID.");
-        return;
+        error(player, "Invalid jobID.  Use job short name, e.g. WAR, or its equivalent numeric ID.")
+        return
     end
 
     -- validate level
     if (level ~= nil) then
         if (level < 1 or level > 99) then
-            error(player, "Invalid level. Level must be between 1 and 99!");
-            return;
+            error(player, "Invalid level. Level must be between 1 and 99!")
+            return
         end
     end
 
     -- change job and (optionally) level
-    player:changeJob(jobId);
+    player:changeJob(jobId)
     if (level ~= nil) then
-        player:setLevel(level);
+        player:setLevel(level)
     end
 
     -- invert tpz.job table
-    local jobNameByNum={};
+    local jobNameByNum={}
     for k,v in pairs(tpz.job) do
-        jobNameByNum[v]=k;
+        jobNameByNum[v]=k
     end
 
     -- output new job to player
-    player:PrintToPlayer(string.format("You are now a %s%i/%s%i.", jobNameByNum[player:getMainJob()], player:getMainLvl(), jobNameByNum[player:getSubJob()], player:getSubLvl()));
+    player:PrintToPlayer(string.format("You are now a %s%i/%s%i.", jobNameByNum[player:getMainJob()], player:getMainLvl(), jobNameByNum[player:getSubJob()], player:getSubLvl()))
 end

--- a/scripts/commands/changesjob.lua
+++ b/scripts/commands/changesjob.lua
@@ -3,51 +3,51 @@
 -- desc: Changes the players current subjob.
 ---------------------------------------------------------------------------------------------------
 
-require("scripts/globals/status");
+require("scripts/globals/status")
 
 cmdprops =
 {
     permission = 1,
     parameters = "si"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!changesjob <jobID> {level}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!changesjob <jobID> {level}")
+end
 
 function onTrigger(player, jobId, level)
     -- validate jobId
     if (jobId == nil) then
-        error(player, "You must enter a job short-name, e.g. WAR, or its equivalent numeric ID.");
-        return;
+        error(player, "You must enter a job short-name, e.g. WAR, or its equivalent numeric ID.")
+        return
     end
-    jobId = tonumber(jobId) or tpz.job[string.upper(jobId)];
+    jobId = tonumber(jobId) or tpz.job[string.upper(jobId)]
     if (jobId == nil or jobId <= 0 or jobId >= tpz.MAX_JOB_TYPE) then
-        error(player, "Invalid jobID.  Use job short name, e.g. WAR, or its equivalent numeric ID.");
-        return;
+        error(player, "Invalid jobID.  Use job short name, e.g. WAR, or its equivalent numeric ID.")
+        return
     end
 
     -- validate level
     if (level ~= nil) then
         if (level < 1 or level > 99) then
-            error(player, "Invalid level. Level must be between 1 and 99!");
-            return;
+            error(player, "Invalid level. Level must be between 1 and 99!")
+            return
         end
     end
 
     -- change job and (optionally) level
-    player:changesJob(jobId);
+    player:changesJob(jobId)
     if (level ~= nil) then
-        player:setsLevel(level);
+        player:setsLevel(level)
     end
 
     -- invert tpz.job table
-    local jobNameByNum={};
+    local jobNameByNum={}
     for k,v in pairs(tpz.job) do
-        jobNameByNum[v]=k;
+        jobNameByNum[v]=k
     end
 
     -- output new job to player
-    player:PrintToPlayer(string.format("You are now a %s%i/%s%i.", jobNameByNum[player:getMainJob()], player:getMainLvl(), jobNameByNum[player:getSubJob()], player:getSubLvl()));
+    player:PrintToPlayer(string.format("You are now a %s%i/%s%i.", jobNameByNum[player:getMainJob()], player:getMainLvl(), jobNameByNum[player:getSubJob()], player:getSubLvl()))
 end

--- a/scripts/commands/checkmission.lua
+++ b/scripts/commands/checkmission.lua
@@ -3,52 +3,52 @@
 -- desc: Prints current MissionID for the given LogID and target Player to the in game chatlog
 ---------------------------------------------------------------------------------------------------
 
-require("scripts/globals/missions");
+require("scripts/globals/missions")
 
 cmdprops =
 {
     permission = 1,
     parameters = "ss"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!checkmission <logID> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!checkmission <logID> {player}")
+end
 
 function onTrigger(player,logId,target)
 
     -- validate logId
-    local logName;
-    local logInfo = GetMissionLogInfo(logId);
+    local logName
+    local logInfo = GetMissionLogInfo(logId)
     if (logInfo == nil) then
-        error(player, "Invalid logID.");
-        return;
+        error(player, "Invalid logID.")
+        return
     end
-    logName = logInfo.full_name;
-    logId = logInfo.mission_log;
+    logName = logInfo.full_name
+    logId = logInfo.mission_log
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player:getCursorTarget();
+        targ = player:getCursorTarget()
         if (targ == nil or not targ:isPC()) then
-            targ = player;
+            targ = player
         end
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format("Player named '%s' not found!", target));
-            return;
+            error(player, string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
     -- report mission
-    local currentMission = targ:getCurrentMission(logId);
+    local currentMission = targ:getCurrentMission(logId)
 
     if ((logId <= 3) and (currentMission == 255)) then
-        player:PrintToPlayer( string.format( "No current %s mission for %s.", logName, targ:getName() ) );
+        player:PrintToPlayer( string.format( "No current %s mission for %s.", logName, targ:getName() ) )
     else
-        player:PrintToPlayer( string.format( "Current %s Mission ID is %s for %s.", logName, currentMission, targ:getName() ) );
+        player:PrintToPlayer( string.format( "Current %s Mission ID is %s for %s.", logName, currentMission, targ:getName() ) )
     end
 end

--- a/scripts/commands/checkquest.lua
+++ b/scripts/commands/checkquest.lua
@@ -3,65 +3,65 @@
 -- desc: Prints status of the quest to the in game chatlog
 ---------------------------------------------------------------------------------------------------
 
-require("scripts/globals/quests");
+require("scripts/globals/quests")
 
 cmdprops =
 {
     permission = 1,
     parameters = "sss"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!checkquest <logID> <questID> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!checkquest <logID> <questID> {player}")
+end
 
 function onTrigger(player,logId,questId,target)
 
     -- validate logId
-    local questLog = GetQuestLogInfo(logId);
+    local questLog = GetQuestLogInfo(logId)
     if (questLog == nil) then
-        error(player, "Invalid logID.");
-        return;
+        error(player, "Invalid logID.")
+        return
     end
-    local logName = questLog.full_name;
-    logId = questLog.quest_log;
+    local logName = questLog.full_name
+    logId = questLog.quest_log
 
     -- validate questId
-    local areaQuestIds = tpz.quest.id[tpz.quest.area[logId]];
+    local areaQuestIds = tpz.quest.id[tpz.quest.area[logId]]
     if (questId ~= nil) then
-        questId = tonumber(questId) or areaQuestIds[string.upper(questId)];
+        questId = tonumber(questId) or areaQuestIds[string.upper(questId)]
     end
     if (questId == nil or questId < 0) then
-        error(player, "Invalid questID.");
-        return;
+        error(player, "Invalid questID.")
+        return
     end
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player:getCursorTarget();
+        targ = player:getCursorTarget()
         if (targ == nil or not targ:isPC()) then
-            targ = player;
+            targ = player
         end
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format("Player named '%s' not found!", target));
-            return;
+            error(player, string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
     -- get quest status
-    local status = targ:getQuestStatus(logId,questId);
+    local status = targ:getQuestStatus(logId,questId)
     switch (status): caseof
     {
-        [0] = function (x) status = "AVAILABLE"; end,
-        [1] = function (x) status = "ACCEPTED"; end,
-        [2] = function (x) status = "COMPLETED"; end,
+        [0] = function (x) status = "AVAILABLE" end,
+        [1] = function (x) status = "ACCEPTED" end,
+        [2] = function (x) status = "COMPLETED" end,
     }
 
     -- show quest status
-    player:PrintToPlayer( string.format( "%s's status for %s quest ID %i is: %s", targ:getName(), logName, questId, status ) );
+    player:PrintToPlayer( string.format( "%s's status for %s quest ID %i is: %s", targ:getName(), logName, questId, status ) )
 
-end;
+end

--- a/scripts/commands/checkvar.lua
+++ b/scripts/commands/checkvar.lua
@@ -7,55 +7,55 @@ cmdprops =
 {
     permission = 1,
     parameters = "ss"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!checkvar {'server', or player} <variable name>");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!checkvar {'server', or player} <variable name>")
+end
 
 function onTrigger(player, arg1, arg2)
-    local targ;
-    local varName;
+    local targ
+    local varName
     
     if (arg2 == nil) then
         -- no player provided. shift arguments by one.
-        targ = nil;
-        varName = arg1;
+        targ = nil
+        varName = arg1
     else
-        targ = arg1;
-        varName = arg2;
+        targ = arg1
+        varName = arg2
     end
     
     -- validate target
     if (targ == nil) then
-        targ = player:getCursorTarget();
+        targ = player:getCursorTarget()
         if (targ == nil or not targ:isPC()) then
-            targ = player;
+            targ = player
         end
     else
         if (string.upper(targ) == 'SERVER') then
-            targ = 'server';
+            targ = 'server'
         else
-            local target = targ;
-            targ = GetPlayerByName(targ);
+            local target = targ
+            targ = GetPlayerByName(targ)
             if (targ == nil) then
-                error(player, string.format("Player named '%s' not found!", target));
-                return;
+                error(player, string.format("Player named '%s' not found!", target))
+                return
             end
         end
     end
     
     -- validate varName
     if (varName == nil) then
-        error(player, "You must provide a variable name.");
-        return;
+        error(player, "You must provide a variable name.")
+        return
     end
 
     -- show variable
     if (targ == "server") then
-        player:PrintToPlayer(string.format("Server variable '%s' : %u ", varName, GetServerVariable(varName)));
+        player:PrintToPlayer(string.format("Server variable '%s' : %u ", varName, GetServerVariable(varName)))
     else
-        player:PrintToPlayer(string.format("%s's variable '%s' : %u", targ:getName(), varName, targ:getCharVar(varName)));
+        player:PrintToPlayer(string.format("%s's variable '%s' : %u", targ:getName(), varName, targ:getCharVar(varName)))
     end
 end

--- a/scripts/commands/cnation.lua
+++ b/scripts/commands/cnation.lua
@@ -7,12 +7,12 @@ cmdprops =
 {
     permission = 1,
     parameters = "ss"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!cnation <player> <campaign allegiance>");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!cnation <player> <campaign allegiance>")
+end
 
 function onTrigger(player, target, nation)
     -- nation xref tables
@@ -22,33 +22,33 @@ function onTrigger(player, target, nation)
         ["BASTOK"]   =  2,
         ["WINDURST"] =  3
     }
-    local nationNumToName ={};
+    local nationNumToName ={}
     for k,v in pairs(nationNameToNum) do
-        nationNumToName[v]=k;
+        nationNumToName[v]=k
     end
     
     -- validate target
     if (target == nil) then
-        error(player, "You must specify an online player by name.");
-        return;
+        error(player, "You must specify an online player by name.")
+        return
     end
-    local targ = GetPlayerByName( target );
+    local targ = GetPlayerByName( target )
     if (targ == nil) then
-        error(player, string.format( "Player named '%s' not found!", target ) );
-        return;
-    end;
+        error(player, string.format( "Player named '%s' not found!", target ) )
+        return
+    end
     
     -- show or set allegiance
     if (nation == nil) then
-        player:PrintToPlayer(string.format("%s's current campaign allegiance: %s", targ:getName(), nationNumToName[targ:getCampaignAllegiance()]));
+        player:PrintToPlayer(string.format("%s's current campaign allegiance: %s", targ:getName(), nationNumToName[targ:getCampaignAllegiance()]))
     else
-        nation = tonumber(nation) or nationNameToNum[string.upper(nation)];
+        nation = tonumber(nation) or nationNameToNum[string.upper(nation)]
         if (nation == nil or nation < 0 or nation > 3) then
-            error(player, "Invalid campaign allegiange. Valid choices are SANDORIA (1), BASTOK (2), or WINDURST (3).");
-            return;
+            error(player, "Invalid campaign allegiange. Valid choices are SANDORIA (1), BASTOK (2), or WINDURST (3).")
+            return
         end
-        player:PrintToPlayer(string.format("%s's old campaign allegiance: %s", targ:getName(), nationNumToName[targ:getCampaignAllegiance()]));
-        targ:setCampaignAllegiance(nation);
-        player:PrintToPlayer(string.format("%s's new campaign allegiance: %s", targ:getName(), nationNumToName[targ:getCampaignAllegiance()]));
+        player:PrintToPlayer(string.format("%s's old campaign allegiance: %s", targ:getName(), nationNumToName[targ:getCampaignAllegiance()]))
+        targ:setCampaignAllegiance(nation)
+        player:PrintToPlayer(string.format("%s's new campaign allegiance: %s", targ:getName(), nationNumToName[targ:getCampaignAllegiance()]))
     end
-end;
+end

--- a/scripts/commands/completemission.lua
+++ b/scripts/commands/completemission.lua
@@ -3,54 +3,54 @@
 -- desc: Completes the given mission for the target player, if that mission is currently active.
 ---------------------------------------------------------------------------------------------------
 
-require("scripts/globals/missions");
+require("scripts/globals/missions")
 
 cmdprops =
 {
     permission = 1,
     parameters = "sss"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!completemission <logID> <missionID> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!completemission <logID> <missionID> {player}")
+end
 
 function onTrigger(player, logId, missionId, target)
 
     -- validate logId
-    local logName;
-    local logInfo = GetMissionLogInfo(logId);
+    local logName
+    local logInfo = GetMissionLogInfo(logId)
     if (logInfo == nil) then
-        error(player, "Invalid logID.");
-        return;
+        error(player, "Invalid logID.")
+        return
     end
-    logName = logInfo.full_name;
-    logId = logInfo.mission_log;
+    logName = logInfo.full_name
+    logId = logInfo.mission_log
 
     -- validate missionId
     local areaMissionIds = tpz.mission.id[tpz.mission.area[logId]]
     if (missionId ~= nil) then
-        missionId = tonumber(missionId) or areaMissionIds[string.upper(missionId)] or _G[string.upper(missionId)];
+        missionId = tonumber(missionId) or areaMissionIds[string.upper(missionId)] or _G[string.upper(missionId)]
     end
     if (missionId == nil or missionId < 0) then
-        error(player, "Invalid missionID.");
-        return;
+        error(player, "Invalid missionID.")
+        return
     end
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format("Player named '%s' not found!", target));
-            return;
+            error(player, string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
     -- complete mission
-    targ:completeMission( logId, missionId );
-    player:PrintToPlayer( string.format( "Completed %s Mission with ID %u for %s", logName, missionId, targ:getName() ) );
-end;
+    targ:completeMission( logId, missionId )
+    player:PrintToPlayer( string.format( "Completed %s Mission with ID %u for %s", logName, missionId, targ:getName() ) )
+end

--- a/scripts/commands/completequest.lua
+++ b/scripts/commands/completequest.lua
@@ -9,47 +9,47 @@ cmdprops =
 {
     permission = 1,
     parameters = "sss"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!completequest <logID> <questID> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!completequest <logID> <questID> {player}")
+end
 
 function onTrigger(player, logId, questId, target)
 
     -- validate logId
-    local questLog = GetQuestLogInfo(logId);
+    local questLog = GetQuestLogInfo(logId)
     if (questLog == nil) then
-        error(player, "Invalid logID.");
-        return;
+        error(player, "Invalid logID.")
+        return
     end
-    local logName = questLog.full_name;
-    logId = questLog.quest_log;
+    local logName = questLog.full_name
+    logId = questLog.quest_log
 
     -- validate questId
-    local areaQuestIds = tpz.quest.id[tpz.quest.area[logId]];
+    local areaQuestIds = tpz.quest.id[tpz.quest.area[logId]]
     if (questId ~= nil) then
-        questId = tonumber(questId) or areaQuestIds[string.upper(questId)];
+        questId = tonumber(questId) or areaQuestIds[string.upper(questId)]
     end
     if (questId == nil or questId < 0) then
-        error(player, "Invalid questID.");
-        return;
+        error(player, "Invalid questID.")
+        return
     end
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format("Player named '%s' not found!", target));
-            return;
+            error(player, string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
     -- complete quest
-    targ:completeQuest( logId, questId );
-    player:PrintToPlayer( string.format( "Completed %s Quest with ID %u for %s", logName, questId, targ:getName() ) );
-end;
+    targ:completeQuest( logId, questId )
+    player:PrintToPlayer( string.format( "Completed %s Quest with ID %u for %s", logName, questId, targ:getName() ) )
+end

--- a/scripts/commands/costume.lua
+++ b/scripts/commands/costume.lua
@@ -7,20 +7,20 @@ cmdprops =
 {
     permission = 1,
     parameters = "i"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!costume <costumeID>");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!costume <costumeID>")
+end
 
 function onTrigger(player, costumeId)
     -- validate costumeId
     if (costumeId == nil or costumeId < 0) then
-        error(player, "Invalid costumeID.");
-        return;
+        error(player, "Invalid costumeID.")
+        return
     end
     
     -- put on costume
-    player:costume( costumeId );
+    player:costume( costumeId )
 end

--- a/scripts/commands/cp.lua
+++ b/scripts/commands/cp.lua
@@ -7,21 +7,21 @@ cmdprops =
 {
     permission = 1,
     parameters = "i"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!cp <amount>");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!cp <amount>")
+end
 
 function onTrigger(player, cp)
     -- validate amount
     if (cp == nil or cp == 0) then
-        error(player, "Invalid amount.");
-        return;
+        error(player, "Invalid amount.")
+        return
     end
     
     -- add cp
-    player:addCP( cp );
-    player:PrintToPlayer(string.format("Added %i cp to %s.", cp, player:getName()));
+    player:addCP( cp )
+    player:PrintToPlayer(string.format("Added %i cp to %s.", cp, player:getName()))
 end

--- a/scripts/commands/cs.lua
+++ b/scripts/commands/cs.lua
@@ -7,24 +7,24 @@ cmdprops =
 {
     permission = 1,
     parameters = "ssssssssss"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!cs <csID> {op1} {op2} {op3} {op4} {op5} {op6} {op7} {op8} {texttable}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!cs <csID> {op1} {op2} {op3} {op4} {op5} {op6} {op7} {op8} {texttable}")
+end
 
 function onTrigger(player, csid, op1, op2, op3, op4, op5, op6, op7, op8, texttable)
     -- validate csid
     if (csid == nil) then
-        error(player, "You must enter a cutscene id.");
-        return;
+        error(player, "You must enter a cutscene id.")
+        return
     end
     
     -- play cutscene
     if (op1 == nil) then
-        player:startEvent(csid);
+        player:startEvent(csid)
     else
-        player:startEvent(csid, op1, op2, op3, op4, op5, op6, op7, op8, texttable);
+        player:startEvent(csid, op1, op2, op3, op4, op5, op6, op7, op8, texttable)
     end
 end

--- a/scripts/commands/cs2.lua
+++ b/scripts/commands/cs2.lua
@@ -7,20 +7,20 @@ cmdprops =
 {
     permission = 1,
     parameters = "sssssiiiiiiii"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!cs2 <csID> {string1} {string2} {string3} {string4} {op1} {op2} {op3} {op4} {op5} {op6} {op7} {op8}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!cs2 <csID> {string1} {string2} {string3} {string4} {op1} {op2} {op3} {op4} {op5} {op6} {op7} {op8}")
+end
 
 function onTrigger(player, csid, string1, string2, string3, string4, op1, op2, op3, op4, op5, op6, op7, op8)
     -- validate csid
     if (csid == nil) then
-        error(player, "You must enter a cutscene id.");
-        return;
+        error(player, "You must enter a cutscene id.")
+        return
     end
     
     -- play cs
-    player:startEventString(csid, string1, string2, string3, string4, op1, op2, op3, op4, op5, op6, op7, op8);
+    player:startEventString(csid, string1, string2, string3, string4, op1, op2, op3, op4, op5, op6, op7, op8)
 end

--- a/scripts/commands/delcurrency.lua
+++ b/scripts/commands/delcurrency.lua
@@ -7,45 +7,45 @@ cmdprops =
 {
     permission = 1,
     parameters = "sis"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!delcurrency <currency type> <amount> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!delcurrency <currency type> <amount> {player}")
+end
 
 function onTrigger(player,currency,amount,target)
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format("Player named '%s' not found!", target));
-            return;
+            error(player, string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
     -- validate currency
     -- note: getCurrency does not ever return nil at the moment.  will work on this in future update.
     if (currency == nil or targ:getCurrency(currency) == nil) then
-        error(player, "Invalid currency type.");
-        return;
+        error(player, "Invalid currency type.")
+        return
     end
 
     -- validate amount
-    local currentAmount = targ:getCurrency(currency);
+    local currentAmount = targ:getCurrency(currency)
     if (amount == nil or amount < 1) then
-        error(player, "Invalid amount.");
-        return;
+        error(player, "Invalid amount.")
+        return
     end
     if (amount > currentAmount) then
-        amount = currentAmount;
+        amount = currentAmount
     end
     
     -- delete currency
-    targ:delCurrency(currency,amount);
-    local newAmount = targ:getCurrency(currency);
-    player:PrintToPlayer(string.format("%i %s was taken from %s, for a total of %i.",amount,currency,targ:getName(),newAmount));
-end;
+    targ:delCurrency(currency,amount)
+    local newAmount = targ:getCurrency(currency)
+    player:PrintToPlayer(string.format("%i %s was taken from %s, for a total of %i.",amount,currency,targ:getName(),newAmount))
+end

--- a/scripts/commands/deleffect.lua
+++ b/scripts/commands/deleffect.lua
@@ -3,52 +3,52 @@
 -- desc: Removes the given effect from the given player.
 ---------------------------------------------------------------------------------------------------
 
-require("scripts/globals/status");
+require("scripts/globals/status")
 
 cmdprops =
 {
     permission = 1,
     parameters = "si"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!deleffect {player} <effect>");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!deleffect {player} <effect>")
+end
 
 function onTrigger(player, arg1, arg2)
-    local targ;
-    local id;
+    local targ
+    local id
 
     if (arg1 == nil) then
-        error(player, "You must provide an effect ID.");
-        return;
+        error(player, "You must provide an effect ID.")
+        return
     elseif (arg2 == nil) then
-        targ = player;
-        id = arg1;
+        targ = player
+        id = arg1
     else
-        targ = GetPlayerByName(arg1);
-        id = arg2;
+        targ = GetPlayerByName(arg1)
+        id = arg2
     end
 
     -- validate target
     if (targ == nil) then
-        error(player, string.format("Player named '%s' not found!", arg1));
-        return;
+        error(player, string.format("Player named '%s' not found!", arg1))
+        return
     end
 
     -- validate effect
-    id = tonumber(id) or tpz.effect[string.upper(id)];
+    id = tonumber(id) or tpz.effect[string.upper(id)]
     if (id == nil) then
-        error(player, "Invalid effect.");
-        return;
+        error(player, "Invalid effect.")
+        return
     elseif (id == 0) then
-        id = 1;
+        id = 1
     end
 
     -- delete status effect
-    targ:delStatusEffect(id);
+    targ:delStatusEffect(id)
     if (targ:getID() ~= player:getID()) then
-        player:PrintToPlayer(string.format("Removed effect %i from %s.",id,targ:getName()));
+        player:PrintToPlayer(string.format("Removed effect %i from %s.",id,targ:getName()))
     end
 end

--- a/scripts/commands/delitem.lua
+++ b/scripts/commands/delitem.lua
@@ -3,49 +3,49 @@
 -- desc: Deletes a single item held by a player, if they have it.
 ---------------------------------------------------------------------------------------------------
 
-require("scripts/globals/status");
+require("scripts/globals/status")
 
 cmdprops =
 {
     permission = 1,
     parameters = "is"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!delitem <itemID> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!delitem <itemID> {player}")
+end
 
 function onTrigger(player, itemId, target)
 
     -- validate itemId
     if (itemId == nil or itemId < 1) then
-        error(player,"Invalid itemID.");
-        return;
+        error(player,"Invalid itemID.")
+        return
     end
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player,string.format("Player named '%s' not found!", target));
-            return;
+            error(player,string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
     -- search target inventory for item, and delete if found
     for i = tpz.inv.INVENTORY, tpz.inv.WARDROBE4 do -- inventory locations enums
         if (targ:hasItem(itemId, i)) then
-            targ:delItem(itemId, 1, i);
-            player:PrintToPlayer(string.format("Item %i was deleted from %s.", itemId, targ:getName()));
-            break;
+            targ:delItem(itemId, 1, i)
+            player:PrintToPlayer(string.format("Item %i was deleted from %s.", itemId, targ:getName()))
+            break
         end
         if (i == tpz.inv.WARDROBE4) then -- Wardrobe 4 is the last inventory location, if it reaches this point then the player does not have the item anywhere.
-            player:PrintToPlayer(string.format("%s does not have item %i.", targ:getName(), itemId));
+            player:PrintToPlayer(string.format("%s does not have item %i.", targ:getName(), itemId))
         end
     end
 
-end;
+end

--- a/scripts/commands/delkeyitem.lua
+++ b/scripts/commands/delkeyitem.lua
@@ -3,51 +3,51 @@
 -- desc: Deletes the given key item from the player.
 ---------------------------------------------------------------------------------------------------
 
-require("scripts/globals/keyitems");
+require("scripts/globals/keyitems")
 
 cmdprops =
 {
     permission = 1,
     parameters = "ss"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!delkeyitem <key item ID> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!delkeyitem <key item ID> {player}")
+end
 
 function onTrigger(player, keyId, target)
 
     -- validate key item id
     if (keyId == nil) then
-        error(player, "You must supply a key item ID.");
-        return;
+        error(player, "You must supply a key item ID.")
+        return
     end
-    keyId = tonumber(keyId) or tpz.ki[string.upper(keyId)];
+    keyId = tonumber(keyId) or tpz.ki[string.upper(keyId)]
     if (keyId == nil or keyId < 1) then
-        error(player, "Invalid Key Item ID.");
-        return;
+        error(player, "Invalid Key Item ID.")
+        return
     end
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format("Player named '%s' not found!", target));
-            return;
+            error(player, string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
     -- delete key item from target
     if (targ:hasKeyItem(keyId)) then
         local ID = zones[targ:getZoneID()]
-        targ:delKeyItem( keyId );
-        targ:messageSpecial(ID.text.KEYITEM_OBTAINED + 1, keyId);
-        player:PrintToPlayer(string.format("Key item %i deleted from %s.", keyId, targ:getName()));
+        targ:delKeyItem( keyId )
+        targ:messageSpecial(ID.text.KEYITEM_OBTAINED + 1, keyId)
+        player:PrintToPlayer(string.format("Key item %i deleted from %s.", keyId, targ:getName()))
     else
-        player:PrintToPlayer(string.format("%s does not have key item %i.", targ:getName(), keyId));
+        player:PrintToPlayer(string.format("%s does not have key item %i.", targ:getName(), keyId))
     end
-end;
+end

--- a/scripts/commands/delmission.lua
+++ b/scripts/commands/delmission.lua
@@ -3,53 +3,53 @@
 -- desc: Deletes the given mission from the GM or target player.
 ---------------------------------------------------------------------------------------------------
 
-require("scripts/globals/missions");
+require("scripts/globals/missions")
 
 cmdprops =
 {
     permission = 1,
     parameters = "sss"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!delmission <logID> <missionID> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!delmission <logID> <missionID> {player}")
+end
 
 function onTrigger(player, logId, missionId, target)
     -- validate logId
-    local logName;
-    local logInfo = GetMissionLogInfo(logId);
+    local logName
+    local logInfo = GetMissionLogInfo(logId)
     if (logInfo == nil) then
-        error(player, "Invalid logID.");
-        return;
+        error(player, "Invalid logID.")
+        return
     end
-    logName = logInfo.full_name;
-    logId = logInfo.mission_log;
+    logName = logInfo.full_name
+    logId = logInfo.mission_log
     
     -- validate missionId
     local areaMissionIds = tpz.mission.id[tpz.mission.area[logId]]
     if (missionId ~= nil) then
-        missionId = tonumber(missionId) or areaMissionIds[string.upper(missionId)] or _G[string.upper(missionId)];
+        missionId = tonumber(missionId) or areaMissionIds[string.upper(missionId)] or _G[string.upper(missionId)]
     end
     if (missionId == nil or missionId < 0) then
-        error(player, "Invalid missionID.");
-        return;
+        error(player, "Invalid missionID.")
+        return
     end
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format("Player named '%s' not found!", target));
-            return;
+            error(player, string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
     -- delete mission
-    targ:delMission(logId, missionId);
-    player:PrintToPlayer(string.format("Deleted %s mission %i from %s.", logName, missionId, targ:getName()));
-end;
+    targ:delMission(logId, missionId)
+    player:PrintToPlayer(string.format("Deleted %s mission %i from %s.", logName, missionId, targ:getName()))
+end

--- a/scripts/commands/delquest.lua
+++ b/scripts/commands/delquest.lua
@@ -3,54 +3,54 @@
 -- desc: Deletes the given quest from the GM or target player.
 ---------------------------------------------------------------------------------------------------
 
-require("scripts/globals/quests");
+require("scripts/globals/quests")
 
 cmdprops =
 {
     permission = 1,
     parameters = "sss"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!delquest <logID> <questID> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!delquest <logID> <questID> {player}")
+end
 
 function onTrigger(player, logId, questId, target)
 
     -- validate logId
-    local questLog = GetQuestLogInfo(logId);
+    local questLog = GetQuestLogInfo(logId)
     if (questLog == nil) then
-        error(player, "Invalid logID.");
-        return;
+        error(player, "Invalid logID.")
+        return
     end
-    local logName = questLog.full_name;
-    logId = questLog.quest_log;
+    local logName = questLog.full_name
+    logId = questLog.quest_log
 
     -- validate questId
-    local areaQuestIds = tpz.quest.id[tpz.quest.area[logId]];
+    local areaQuestIds = tpz.quest.id[tpz.quest.area[logId]]
     if (questId ~= nil) then
-        questId = tonumber(questId) or areaQuestIds[string.upper(questId)];
+        questId = tonumber(questId) or areaQuestIds[string.upper(questId)]
     end
     if (questId == nil or questId < 0) then
-        error(player, "Invalid questID.");
-        return;
+        error(player, "Invalid questID.")
+        return
     end
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format("Player named '%s' not found!", target));
-            return;
+            error(player, string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
     -- add quest
-    targ:delQuest(logId, questId);
-    player:PrintToPlayer(string.format("Deleted %s quest %i from %s.", logName, questId, targ:getName()));
+    targ:delQuest(logId, questId)
+    player:PrintToPlayer(string.format("Deleted %s quest %i from %s.", logName, questId, targ:getName()))
 
-end;
+end

--- a/scripts/commands/delspell.lua
+++ b/scripts/commands/delspell.lua
@@ -7,35 +7,35 @@ cmdprops =
 {
     permission = 1,
     parameters = "is"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!delspell <spellID> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!delspell <spellID> {player}")
+end
 
 function onTrigger(player, spellId, target)
 
     -- validate spellId
     if (spellId == nil) then
-        error(player, "Invalid spellID.");
-        return;
+        error(player, "Invalid spellID.")
+        return
     end
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format("Player named '%s' not found!", target));
-            return;
+            error(player, string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
     -- add spell
-    targ:delSpell(spellId);
-    player:PrintToPlayer(string.format("Deleted spell %i from %s.",spellId,targ:getName()));
+    targ:delSpell(spellId)
+    player:PrintToPlayer(string.format("Deleted spell %i from %s.",spellId,targ:getName()))
 
-end;
+end

--- a/scripts/commands/despawnmob.lua
+++ b/scripts/commands/despawnmob.lua
@@ -7,33 +7,33 @@ cmdprops =
 {
     permission = 1,
     parameters = "i"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!despawnmob {mobID}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!despawnmob {mobID}")
+end
 
 function onTrigger(player, mobId)
 
     -- validate mobId
-    local targ;
+    local targ
     if (mobId == nil) then
-        targ = player:getCursorTarget();
+        targ = player:getCursorTarget()
         if (targ == nil or not targ:isMob()) then
-            error(player,"You must either provide a mobID or target a mob.");
-            return;
+            error(player,"You must either provide a mobID or target a mob.")
+            return
         end
     else
-        targ = GetMobByID(mobId);
+        targ = GetMobByID(mobId)
         if (targ == nil) then
-            error(player,"Invalid mobID.");
-            return;
+            error(player,"Invalid mobID.")
+            return
         end
     end
     
     -- despawn mob
-    DespawnMob(targ:getID());
-    player:PrintToPlayer(string.format("Despawned %s %i.",targ:getName(),targ:getID()));
+    DespawnMob(targ:getID())
+    player:PrintToPlayer(string.format("Despawned %s %i.",targ:getName(),targ:getID()))
 
 end

--- a/scripts/commands/entityvisual.lua
+++ b/scripts/commands/entityvisual.lua
@@ -7,20 +7,20 @@ cmdprops =
 {
     permission = 1,
     parameters = "s"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!entityvisual <animation string>");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!entityvisual <animation string>")
+end
 
 function onTrigger(player, visualstring)
     -- validate visualstring
     if (visualstring == nil) then
-        error(player, "You must enter a valid animation string.");
-        return;
+        error(player, "You must enter a valid animation string.")
+        return
     end
 
     -- push visual packet to player
-    player:entityVisualPacket(visualstring);
+    player:entityVisualPacket(visualstring)
 end

--- a/scripts/commands/exec.lua
+++ b/scripts/commands/exec.lua
@@ -7,39 +7,39 @@ cmdprops =
 {
     permission = 4,
     parameters = "s"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!exec <Lua string>");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!exec <Lua string>")
+end
 
 function onTrigger(player, str)
     -- Ensure a command was given..
     if (str == nil or string.len(str) == 0) then
-        error(player, "You must enter a string to execute.");
-        return;
+        error(player, "You must enter a string to execute.")
+        return
     end
     
     -- For safety measures we will nuke the os table..
-    local old_os = os;
-    os = nil;
+    local old_os = os
+    os = nil
     
     -- Ensure the command compiles / is valid..
-    local scriptObj, err = loadstring(str);
+    local scriptObj, err = loadstring(str)
     if (scriptObj == nil) then
-        player:PrintToPlayer("Failed to load the given string.");
-        player:PrintToPlayer(err);
-        os = old_os;
-        return;
+        player:PrintToPlayer("Failed to load the given string.")
+        player:PrintToPlayer(err)
+        os = old_os
+        return
     end
     
     -- Execute the string..
-    local status, err = pcall(scriptObj);
+    local status, err = pcall(scriptObj)
     if (status == false) then
-        player:PrintToPlayer(err);
+        player:PrintToPlayer(err)
     end
     
     -- Restore the os table..
-    os = old_os;
+    os = old_os
 end

--- a/scripts/commands/getid.lua
+++ b/scripts/commands/getid.lua
@@ -7,13 +7,13 @@ cmdprops =
 {
     permission = 1,
     parameters = ""
-};
+}
 
 function onTrigger(player)
-    local targ = player:getCursorTarget();
+    local targ = player:getCursorTarget()
     if (targ ~= nil) then
-        player:PrintToPlayer(string.format("%s's ID is: %u ", targ:getName(),targ:getID()));
+        player:PrintToPlayer(string.format("%s's ID is: %u ", targ:getName(),targ:getID()))
     else
-        player:PrintToPlayer("Must select a target using in game cursor first.");
+        player:PrintToPlayer("Must select a target using in game cursor first.")
     end
-end;
+end

--- a/scripts/commands/getmobaction.lua
+++ b/scripts/commands/getmobaction.lua
@@ -7,32 +7,32 @@ cmdprops =
 {
     permission = 1,
     parameters = "i"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!getmobaction {mobID}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!getmobaction {mobID}")
+end
 
 function onTrigger(player, mobId)
 
     -- validate mobid
-    local targ;
+    local targ
     if (mobId == nil) then
-        targ = player:getCursorTarget();
+        targ = player:getCursorTarget()
         if (not targ:isMob()) then
-            error(player, "You must either provide a mobID or target a mob with your cursor.");
-            return;
+            error(player, "You must either provide a mobID or target a mob with your cursor.")
+            return
         end
     else
-        targ = GetMobByID(mobId);
+        targ = GetMobByID(mobId)
         if (targ == nil) then
-            error(player, "Invalid mobID.");
-            return;
+            error(player, "Invalid mobID.")
+            return
         end
     end
 
     -- report mob action
-    player:PrintToPlayer(string.format("%s %i current action ID is %i.", targ:getName(), targ:getID(), targ:getCurrentAction()));
+    player:PrintToPlayer(string.format("%s %i current action ID is %i.", targ:getName(), targ:getID(), targ:getCurrentAction()))
 
-end;
+end

--- a/scripts/commands/givegil.lua
+++ b/scripts/commands/givegil.lua
@@ -7,35 +7,35 @@ cmdprops =
 {
     permission = 1,
     parameters = "is"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!givegil <amount> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!givegil <amount> {player}")
+end
 
 function onTrigger(player, amount, target)
 
     -- validate amount
     if (amount == nil or amount < 1) then
-        error(player, "Invalid amount of gil.");
-        return;
+        error(player, "Invalid amount of gil.")
+        return
     end
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format("Player named '%s' not found!", target));
-            return;
+            error(player, string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
     -- give gil to target
-    targ:addGil(amount);
-    player:PrintToPlayer(string.format("Gave %i gil to %s.  They now have %i gil.", amount, targ:getName(), targ:getGil()));
+    targ:addGil(amount)
+    player:PrintToPlayer(string.format("Gave %i gil to %s.  They now have %i gil.", amount, targ:getName(), targ:getGil()))
     
-end;
+end

--- a/scripts/commands/giveitem.lua
+++ b/scripts/commands/giveitem.lua
@@ -7,18 +7,18 @@ cmdprops =
 {
     permission = 1,
     parameters = "siiiiiiiiii"
-};
+}
 
 function onTrigger(player, target, itemId, amount, aug0, aug0val, aug1, aug1val, aug2, aug2val, aug3, aug3val)
     if (target == nil or itemId == nil) then
-        player:PrintToPlayer("You must enter a valid player name and item ID.");
-        return;
+        player:PrintToPlayer("You must enter a valid player name and item ID.")
+        return
     end
 
-    local targ = GetPlayerByName( target );
+    local targ = GetPlayerByName( target )
     if (targ == nil) then
-        player:PrintToPlayer( string.format( "Player named '%s' not found!", target ) );
-        return;
+        player:PrintToPlayer( string.format( "Player named '%s' not found!", target ) )
+        return
     end
 
     -- Load needed text ids for target's current zone..
@@ -26,11 +26,11 @@ function onTrigger(player, target, itemId, amount, aug0, aug0val, aug1, aug1val,
 
     -- Attempt to give the target the item..
     if (targ:getFreeSlotsCount() == 0) then
-        targ:messageSpecial( ID.text.ITEM_CANNOT_BE_OBTAINED, itemId );
-        player:PrintToPlayer( string.format( "Player '%s' does not have free space for that item!", target ) );
+        targ:messageSpecial( ID.text.ITEM_CANNOT_BE_OBTAINED, itemId )
+        player:PrintToPlayer( string.format( "Player '%s' does not have free space for that item!", target ) )
     else
-        targ:addItem( itemId, amount, aug0, aug0val, aug1, aug1val, aug2, aug2val, aug3, aug3val );
-        targ:messageSpecial( ID.text.ITEM_OBTAINED, itemId );
-        player:PrintToPlayer( string.format( "Gave player '%s' Item with ID of '%u' ", target, itemId ) );
+        targ:addItem( itemId, amount, aug0, aug0val, aug1, aug1val, aug2, aug2val, aug3, aug3val )
+        targ:messageSpecial( ID.text.ITEM_OBTAINED, itemId )
+        player:PrintToPlayer( string.format( "Gave player '%s' Item with ID of '%u' ", target, itemId ) )
     end
-end;
+end

--- a/scripts/commands/givexp.lua
+++ b/scripts/commands/givexp.lua
@@ -7,34 +7,34 @@ cmdprops =
 {
     permission = 1,
     parameters = "is"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!givexp <amount> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!givexp <amount> {player}")
+end
 
 function onTrigger(player, amount, target)
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format("Player named '%s' not found!", target));
-            return;
+            error(player, string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
     -- validate amount
     if (amount == nil or amount < 1) then
-        error(player, "Invalid amount.");
-        return;
+        error(player, "Invalid amount.")
+        return
     end
 
     -- give XP to target
-    targ:addExp(amount);
-    player:PrintToPlayer( string.format( "Gave %i exp to %s. They are now level %i.", amount, targ:getName(), targ:getMainLvl() ));
-end;
+    targ:addExp(amount)
+    player:PrintToPlayer( string.format( "Gave %i exp to %s. They are now level %i.", amount, targ:getName(), targ:getMainLvl() ))
+end

--- a/scripts/commands/godmode.lua
+++ b/scripts/commands/godmode.lua
@@ -7,68 +7,68 @@ cmdprops =
 {
     permission = 1,
     parameters = ""
-};
+}
 
 function onTrigger(player)
     if (player:getCharVar("GodMode") == 0) then
         -- Toggle GodMode on..
-        player:setCharVar("GodMode", 1);
+        player:setCharVar("GodMode", 1)
 
         -- Add bonus effects to the player..
-        player:addStatusEffect(tpz.effect.MAX_HP_BOOST,1000,0,0);
-        player:addStatusEffect(tpz.effect.MAX_MP_BOOST,1000,0,0);
-        player:addStatusEffect(tpz.effect.MIGHTY_STRIKES,1,0,0);
-        player:addStatusEffect(tpz.effect.HUNDRED_FISTS,1,0,0);
-        player:addStatusEffect(tpz.effect.CHAINSPELL,1,0,0);
-        player:addStatusEffect(tpz.effect.PERFECT_DODGE,1,0,0);
-        player:addStatusEffect(tpz.effect.INVINCIBLE,1,0,0);
-        player:addStatusEffect(tpz.effect.ELEMENTAL_SFORZO,1,0,0);
-        player:addStatusEffect(tpz.effect.MANAFONT,1,0,0);
-        player:addStatusEffect(tpz.effect.REGAIN,300,0,0);
-        player:addStatusEffect(tpz.effect.REFRESH,99,0,0);
-        player:addStatusEffect(tpz.effect.REGEN,99,0,0);
+        player:addStatusEffect(tpz.effect.MAX_HP_BOOST,1000,0,0)
+        player:addStatusEffect(tpz.effect.MAX_MP_BOOST,1000,0,0)
+        player:addStatusEffect(tpz.effect.MIGHTY_STRIKES,1,0,0)
+        player:addStatusEffect(tpz.effect.HUNDRED_FISTS,1,0,0)
+        player:addStatusEffect(tpz.effect.CHAINSPELL,1,0,0)
+        player:addStatusEffect(tpz.effect.PERFECT_DODGE,1,0,0)
+        player:addStatusEffect(tpz.effect.INVINCIBLE,1,0,0)
+        player:addStatusEffect(tpz.effect.ELEMENTAL_SFORZO,1,0,0)
+        player:addStatusEffect(tpz.effect.MANAFONT,1,0,0)
+        player:addStatusEffect(tpz.effect.REGAIN,300,0,0)
+        player:addStatusEffect(tpz.effect.REFRESH,99,0,0)
+        player:addStatusEffect(tpz.effect.REGEN,99,0,0)
 
         -- Add bonus mods to the player..
-        player:addMod(tpz.mod.RACC,2500);
-        player:addMod(tpz.mod.RATT,2500);
-        player:addMod(tpz.mod.ACC,2500);
-        player:addMod(tpz.mod.ATT,2500);
-        player:addMod(tpz.mod.MATT,2500);
-        player:addMod(tpz.mod.MACC,2500);
-        player:addMod(tpz.mod.RDEF,2500);
-        player:addMod(tpz.mod.DEF,2500);
-        player:addMod(tpz.mod.MDEF,2500);
+        player:addMod(tpz.mod.RACC,2500)
+        player:addMod(tpz.mod.RATT,2500)
+        player:addMod(tpz.mod.ACC,2500)
+        player:addMod(tpz.mod.ATT,2500)
+        player:addMod(tpz.mod.MATT,2500)
+        player:addMod(tpz.mod.MACC,2500)
+        player:addMod(tpz.mod.RDEF,2500)
+        player:addMod(tpz.mod.DEF,2500)
+        player:addMod(tpz.mod.MDEF,2500)
 
         -- Heal the player from the new buffs..
-        player:addHP( 50000 );
-        player:setMP( 50000 );
+        player:addHP( 50000 )
+        player:setMP( 50000 )
     else
         -- Toggle GodMode off..
-        player:setCharVar("GodMode", 0);
+        player:setCharVar("GodMode", 0)
 
         -- Remove bonus effects..
-        player:delStatusEffect(tpz.effect.MAX_HP_BOOST);
-        player:delStatusEffect(tpz.effect.MAX_MP_BOOST);
-        player:delStatusEffect(tpz.effect.MIGHTY_STRIKES);
-        player:delStatusEffect(tpz.effect.HUNDRED_FISTS);
-        player:delStatusEffect(tpz.effect.CHAINSPELL);
-        player:delStatusEffect(tpz.effect.PERFECT_DODGE);
-        player:delStatusEffect(tpz.effect.INVINCIBLE);
-        player:delStatusEffect(tpz.effect.ELEMENTAL_SFORZO);
-        player:delStatusEffect(tpz.effect.MANAFONT);
-        player:delStatusEffect(tpz.effect.REGAIN);
-        player:delStatusEffect(tpz.effect.REFRESH);
-        player:delStatusEffect(tpz.effect.REGEN);
+        player:delStatusEffect(tpz.effect.MAX_HP_BOOST)
+        player:delStatusEffect(tpz.effect.MAX_MP_BOOST)
+        player:delStatusEffect(tpz.effect.MIGHTY_STRIKES)
+        player:delStatusEffect(tpz.effect.HUNDRED_FISTS)
+        player:delStatusEffect(tpz.effect.CHAINSPELL)
+        player:delStatusEffect(tpz.effect.PERFECT_DODGE)
+        player:delStatusEffect(tpz.effect.INVINCIBLE)
+        player:delStatusEffect(tpz.effect.ELEMENTAL_SFORZO)
+        player:delStatusEffect(tpz.effect.MANAFONT)
+        player:delStatusEffect(tpz.effect.REGAIN)
+        player:delStatusEffect(tpz.effect.REFRESH)
+        player:delStatusEffect(tpz.effect.REGEN)
 
         -- Remove bonus mods..
-        player:delMod(tpz.mod.RACC,2500);
-        player:delMod(tpz.mod.RATT,2500);
-        player:delMod(tpz.mod.ACC,2500);
-        player:delMod(tpz.mod.ATT,2500);
-        player:delMod(tpz.mod.MATT,2500);
-        player:delMod(tpz.mod.MACC,2500);
-        player:delMod(tpz.mod.RDEF,2500);
-        player:delMod(tpz.mod.DEF,2500);
-        player:delMod(tpz.mod.MDEF,2500);
+        player:delMod(tpz.mod.RACC,2500)
+        player:delMod(tpz.mod.RATT,2500)
+        player:delMod(tpz.mod.ACC,2500)
+        player:delMod(tpz.mod.ATT,2500)
+        player:delMod(tpz.mod.MATT,2500)
+        player:delMod(tpz.mod.MACC,2500)
+        player:delMod(tpz.mod.RDEF,2500)
+        player:delMod(tpz.mod.DEF,2500)
+        player:delMod(tpz.mod.MDEF,2500)
     end
 end

--- a/scripts/commands/goto.lua
+++ b/scripts/commands/goto.lua
@@ -7,18 +7,18 @@ cmdprops =
 {
     permission = 1,
     parameters = "si"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!goto <player> {forceZone}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!goto <player> {forceZone}")
+end
 
 function onTrigger(player, target, forceZone)
 
     -- validate target
     if not target then
-        error(player, "You must enter a player name.");
+        error(player, "You must enter a player name.")
         return
     end
 

--- a/scripts/commands/hasitem.lua
+++ b/scripts/commands/hasitem.lua
@@ -7,42 +7,42 @@ cmdprops =
 {
     permission = 1,
     parameters = "is"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!hasitem <itemID> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!hasitem <itemID> {player}")
+end
 
 function onTrigger(player, itemId, target)
     -- validate itemId
     if (itemId == nil) then
-        error(player, "You must provide an itemID.");
-        return;
+        error(player, "You must provide an itemID.")
+        return
     elseif (itemId < 1) then
-        error(player, "Invalid itemID.");
-        return;
+        error(player, "Invalid itemID.")
+        return
     end
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player:getCursorTarget();
+        targ = player:getCursorTarget()
         if (targ == nil or not targ:isPC()) then
-            targ = player;
+            targ = player
         end
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format("Player named '%s' not found!", target));
-            return;
+            error(player, string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
     -- report hasItem
     if (targ:hasItem(itemId)) then
-        player:PrintToPlayer(string.format("%s has item %i.", targ:getName(), itemId));
+        player:PrintToPlayer(string.format("%s has item %i.", targ:getName(), itemId))
     else
-        player:PrintToPlayer(string.format("%s does not have item %i.", targ:getName(), itemId));
+        player:PrintToPlayer(string.format("%s does not have item %i.", targ:getName(), itemId))
     end
-end;
+end

--- a/scripts/commands/haskeyitem.lua
+++ b/scripts/commands/haskeyitem.lua
@@ -4,51 +4,51 @@
 --       Can use either of number or the variable string from keyitems.lua
 ---------------------------------------------------------------------------------------------------
 
-require("scripts/globals/keyitems");
+require("scripts/globals/keyitems")
 
 cmdprops =
 {
     permission = 1,
     parameters = "ss"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!haskeyitem <key item ID> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!haskeyitem <key item ID> {player}")
+end
 
 function onTrigger(player, keyId, target)
     -- validate itemId
     if (keyId == nil) then
-        error(player, "You must provide a key item ID.");
-        return;
+        error(player, "You must provide a key item ID.")
+        return
     else
-        keyId = tonumber(keyId) or tpz.ki[string.upper(keyId)];
+        keyId = tonumber(keyId) or tpz.ki[string.upper(keyId)]
         if (keyId == nil or keyId < 1) then
-            error(player, "Invalid key item ID.");
-            return;
+            error(player, "Invalid key item ID.")
+            return
         end
     end
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player:getCursorTarget();
+        targ = player:getCursorTarget()
         if (targ == nil or not targ:isPC()) then
-            targ = player;
+            targ = player
         end
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format("Player named '%s' not found!", target));
-            return;
+            error(player, string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
     -- report hasKeyItem
     if (targ:hasKeyItem(keyId)) then
-        player:PrintToPlayer(string.format("%s has key item %i.", targ:getName(), keyId));
+        player:PrintToPlayer(string.format("%s has key item %i.", targ:getName(), keyId))
     else
-        player:PrintToPlayer(string.format("%s does not have key item %i.", targ:getName(), keyId));
+        player:PrintToPlayer(string.format("%s does not have key item %i.", targ:getName(), keyId))
     end
-end;
+end

--- a/scripts/commands/hastitle.lua
+++ b/scripts/commands/hastitle.lua
@@ -3,47 +3,47 @@
 -- desc: Check if player already has a title.
 ---------------------------------------------------------------------------------------------------
 
-require("scripts/globals/titles");
+require("scripts/globals/titles")
 
 cmdprops =
 {
     permission = 1,
     parameters = "ss"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!hastitle <title ID> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!hastitle <title ID> {player}")
+end
 
 function onTrigger(player, titleId, target)
 
     -- validate titleId
     if (titleId == nil) then
-        error(player, "You must supply a title ID.");
-        return;
+        error(player, "You must supply a title ID.")
+        return
     end
-    titleId = tonumber(titleId) or tpz.title[string.upper(titleId)];
+    titleId = tonumber(titleId) or tpz.title[string.upper(titleId)]
     if (titleId == nil or titleId < 1) then
-        error(player, "Invalid title ID.");
-        return;
+        error(player, "Invalid title ID.")
+        return
     end
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format("Player named '%s' not found!", target));
-            return;
+            error(player, string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
     if (targ:hasTitle(titleId)) then
-        player:PrintToPlayer(string.format("%s has title %s.", targ:getName(), titleId));
+        player:PrintToPlayer(string.format("%s has title %s.", targ:getName(), titleId))
     else
-        player:PrintToPlayer(string.format("%s does not have title %s.", targ:getName(), titleId));
+        player:PrintToPlayer(string.format("%s does not have title %s.", targ:getName(), titleId))
     end
 end

--- a/scripts/commands/hide.lua
+++ b/scripts/commands/hide.lua
@@ -7,33 +7,33 @@ cmdprops =
 {
     permission = 1,
     parameters = "s"
-};
+}
 
 function onTrigger(player, cmd)
     -- Obtain the players hide status..
-    local isHidden = player:getCharVar("GMHidden");
+    local isHidden = player:getCharVar("GMHidden")
     if (cmd ~= nil) then
         if (cmd == "status") then
-            player:PrintToPlayer(string.format('Current hide status: %s', tostring(isHidden)));
-            return;
+            player:PrintToPlayer(string.format('Current hide status: %s', tostring(isHidden)))
+            return
         end
     end
 
     -- Toggle the hide status..
     if (isHidden == 0) then
-        isHidden = 1;
+        isHidden = 1
     else
-        isHidden = 0;
+        isHidden = 0
     end
     
     -- If hidden animate us beginning our hide..
     if (isHidden == 1) then
-        player:setCharVar( "GMHidden", 1 );
-        player:setGMHidden(true);
-        player:PrintToPlayer( "You are now GM hidden from other players." );
+        player:setCharVar( "GMHidden", 1 )
+        player:setGMHidden(true)
+        player:PrintToPlayer( "You are now GM hidden from other players." )
     else
-        player:setCharVar( "GMHidden", 0 );
-        player:setGMHidden(false);
-        player:PrintToPlayer( "You are no longer GM hidden from other players." );
+        player:setCharVar( "GMHidden", 0 )
+        player:setGMHidden(false)
+        player:PrintToPlayer( "You are no longer GM hidden from other players." )
     end
 end

--- a/scripts/commands/homepoint.lua
+++ b/scripts/commands/homepoint.lua
@@ -7,29 +7,29 @@ cmdprops =
 {
     permission = 1,
     parameters = "s"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!homepoint {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!homepoint {player}")
+end
 
 function onTrigger(player, target)
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName( target );
+        targ = GetPlayerByName( target )
         if (targ == nil) then
-            error(player, string.format( "Player named '%s' not found!", target ) );
-            return;
+            error(player, string.format( "Player named '%s' not found!", target ) )
+            return
         end
     end
 
     -- homepoint target
-    targ:warp();
+    targ:warp()
     if (targ:getID() ~= player:getID()) then
-        player:PrintToPlayer(string.format("Sent %s to their homepoint.",targ:getName()));
+        player:PrintToPlayer(string.format("Sent %s to their homepoint.",targ:getName()))
     end
 end

--- a/scripts/commands/hp.lua
+++ b/scripts/commands/hp.lua
@@ -7,42 +7,42 @@ cmdprops =
 {
     permission = 1,
     parameters = "is"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!hp <amount> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!hp <amount> {player}")
+end
 
 function onTrigger(player, hp, target)
     -- validate amount
     if (hp == nil or tonumber(hp) == nil) then
-        error(player, "You must provide an amount.");
-        return;
+        error(player, "You must provide an amount.")
+        return
     elseif (hp < 0) then
-        error(player, "Invalid amount.");
-        return;
+        error(player, "Invalid amount.")
+        return
     end
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format( "Player named '%s' not found!", target ) );
-            return;
+            error(player, string.format( "Player named '%s' not found!", target ) )
+            return
         end
     end
     
     -- set hp
     if (targ:getHP() > 0) then
-        targ:setHP(hp);
+        targ:setHP(hp)
         if(targ:getID() ~= player:getID()) then
-            player:PrintToPlayer(string.format("Set %s's HP to %i.", targ:getName(), targ:getHP()));
+            player:PrintToPlayer(string.format("Set %s's HP to %i.", targ:getName(), targ:getHP()))
         end
     else
-        player:PrintToPlayer(string.format("%s is currently dead.", targ:getName()));
+        player:PrintToPlayer(string.format("%s is currently dead.", targ:getName()))
     end
 end

--- a/scripts/commands/inject.lua
+++ b/scripts/commands/inject.lua
@@ -7,20 +7,20 @@ cmdprops =
 {
     permission = 1,
     parameters = "s"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!inject <packet>");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!inject <packet>")
+end
 
 function onTrigger(player, packet)
     -- validate packet
     if (packet == nil) then
-        error(player, "You must enter a packet file name.");
-        return;
+        error(player, "You must enter a packet file name.")
+        return
     end
 
     -- inject packet
-    player:injectPacket( packet );
+    player:injectPacket( packet )
 end

--- a/scripts/commands/injectaction.lua
+++ b/scripts/commands/injectaction.lua
@@ -7,30 +7,30 @@ cmdprops =
 {
     permission = 1,
     parameters = "iiiii"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!injectaction <action ID> <animation ID> {speceffect} {reaction} {message}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!injectaction <action ID> <animation ID> {speceffect} {reaction} {message}")
+end
 
 function onTrigger(player, actionId, animationId, speceffect, reaction, message)
     -- validate actionId
     if (actionId == nil) then
-        error(player, "You must provide an action ID.");
-        return;
+        error(player, "You must provide an action ID.")
+        return
     end
     
     -- validate animationId
     if (animationId == nil) then
-        error(player, "You must provide an animation ID.");
-        return;
+        error(player, "You must provide an animation ID.")
+        return
     end
     
     if (message == nil) then
-        message = 185; -- Default message
+        message = 185 -- Default message
     end
 
     -- inject action packet
-    player:injectActionPacket(actionId, animationId, speceffect, reaction, message);
+    player:injectActionPacket(actionId, animationId, speceffect, reaction, message)
 end

--- a/scripts/commands/jail.lua
+++ b/scripts/commands/jail.lua
@@ -7,7 +7,7 @@ cmdprops =
 {
     permission = 1,
     parameters = "sis"
-};
+}
 
 function onTrigger(player, target, cellId, reason)
     local jailCells =
@@ -23,31 +23,31 @@ function onTrigger(player, target, cellId, reason)
         {-620, -400,  220, 0},  {-180, -400,  220, 0}, {260, -400,  220, 0}, {700, -400,  220, 0},
         {-620, -400, -220, 0},  {-180, -400, -220, 0}, {260, -400, -220, 0}, {700, -400, -220, 0},
         {-620, -400, -620, 0},  {-180, -400, -620, 0}, {260, -400, -620, 0}, {700, -400, -620, 0},
-    };
+    }
 
     -- Validate the target..
-    local targ = GetPlayerByName( target );
+    local targ = GetPlayerByName( target )
     if (targ == nil) then
-        player:PrintToPlayer( string.format( "Invalid player '%s' given.", target ) );
-        return;
+        player:PrintToPlayer( string.format( "Invalid player '%s' given.", target ) )
+        return
     end
 
     -- Validate the cell id..
     if (cellId == nil or cellId == 0 or cellId > 32) then
-        cellId = 1;
+        cellId = 1
     end
     
     -- Validate the reason..
     if (reason == nil) then
-        reason = "Unspecified.";
+        reason = "Unspecified."
     end
 
     -- Print that we have jailed someone..
-    local message = string.format( '%s jailed %s(%d) into cell %d. Reason: %s', player:getName(), target, targ:getID(), cellId, reason );
-    printf( message );
+    local message = string.format( '%s jailed %s(%d) into cell %d. Reason: %s', player:getName(), target, targ:getID(), cellId, reason )
+    printf( message )
 
     -- Send the target to jail..
-    local dest = jailCells[ cellId ];
-    targ:setCharVar( "inJail", cellId );
-    targ:setPos( dest[1], dest[2], dest[3], dest[4], 131 );
+    local dest = jailCells[ cellId ]
+    targ:setCharVar( "inJail", cellId )
+    targ:setPos( dest[1], dest[2], dest[3], dest[4], 131 )
 end

--- a/scripts/commands/logoff.lua
+++ b/scripts/commands/logoff.lua
@@ -7,29 +7,29 @@ cmdprops =
 {
     permission = 1,
     parameters = "s"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!logoff {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!logoff {player}")
+end
 
 function onTrigger(player, target)
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName( target );
+        targ = GetPlayerByName( target )
         if (targ == nil) then
-            error(player, string.format( "Invalid player '%s' given.", target ) );
-            return;
+            error(player, string.format( "Invalid player '%s' given.", target ) )
+            return
         end
     end
 
     -- logoff target
-    targ:leavegame();
+    targ:leavegame()
     if (targ:getID() ~= player:getID()) then
-        player:PrintToPlayer(string.format("%s has been logged off.",targ:getName()));
+        player:PrintToPlayer(string.format("%s has been logged off.",targ:getName()))
     end
 end

--- a/scripts/commands/messagebasic.lua
+++ b/scripts/commands/messagebasic.lua
@@ -7,25 +7,25 @@ cmdprops =
 {
     permission = 1,
     parameters = "iii"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!messagebasic <message ID> {param1} {param2}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!messagebasic <message ID> {param1} {param2}")
+end
 
 function onTrigger(player, msgId, param1, param2)
     -- validate msgId
     if (msgId == nil) then
-        error(player, "You must provide a message ID.");
-        return;
+        error(player, "You must provide a message ID.")
+        return
     end
 
-    local target = player:getCursorTarget();
+    local target = player:getCursorTarget()
     if target == nil then
-        target = player;
+        target = player
     end
     
     -- inject message packet
-    player:messageBasic(msgId, param1, param2, target);
+    player:messageBasic(msgId, param1, param2, target)
 end

--- a/scripts/commands/messagespecial.lua
+++ b/scripts/commands/messagespecial.lua
@@ -7,32 +7,32 @@ cmdprops =
 {
     permission = 1,
     parameters = "iiiii"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!messagespecial <message ID> {param1} {param2} {param3} {param4} {param5}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!messagespecial <message ID> {param1} {param2} {param3} {param4} {param5}")
+end
 
 function onTrigger(player, msgId, param1, param2, param3, param4, param5)
     -- validate msgId
     if (msgId == nil) then
-        error(player, "You must provide a message ID.");
-        return;
+        error(player, "You must provide a message ID.")
+        return
     end
 
     -- inject message special packet
     if (param5 ~= nil) then
-        player:messageSpecial(msgId, param1, param2, param3, param4, param5);
+        player:messageSpecial(msgId, param1, param2, param3, param4, param5)
     elseif (param4 ~= nil) then
-        player:messageSpecial(msgId, param1, param2, param3, param4);
+        player:messageSpecial(msgId, param1, param2, param3, param4)
     elseif (param3 ~= nil) then
-        player:messageSpecial(msgId, param1, param2, param3);
+        player:messageSpecial(msgId, param1, param2, param3)
     elseif (param2 ~= nil) then
-        player:messageSpecial(msgId, param1, param2);
+        player:messageSpecial(msgId, param1, param2)
     elseif (param1 ~= nil) then
-        player:messageSpecial(msgId, param1);
+        player:messageSpecial(msgId, param1)
     else
-        player:messageSpecial(msgId);
+        player:messageSpecial(msgId)
     end
 end

--- a/scripts/commands/mobhere.lua
+++ b/scripts/commands/mobhere.lua
@@ -8,40 +8,40 @@ cmdprops =
 {
     permission = 1,
     parameters = "is"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!mobhere {mobID} {noDepop}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!mobhere {mobID} {noDepop}")
+end
 
 function onTrigger(player, mobId, noDepop)
     -- validate mobId
-    local targ;
+    local targ
     if (mobId == nil) then
-        targ = player:getCursorTarget();
+        targ = player:getCursorTarget()
         if (targ == nil or not targ:isMob()) then
-            error(player, "You must either provide a mobID or target a mob.");
-            return;
+            error(player, "You must either provide a mobID or target a mob.")
+            return
         end
     else
-        targ = GetMobByID(mobId);
+        targ = GetMobByID(mobId)
         if (targ == nil) then
-            error(player, "Invalid mobID.");
-            return;
+            error(player, "Invalid mobID.")
+            return
         end
     end
-    mobId = targ:getID();
+    mobId = targ:getID()
     
     -- attempt to bring mob here
-    SpawnMob( mobId );
+    SpawnMob( mobId )
     if (player:getZoneID() == targ:getZoneID()) then
-        targ:setPos( player:getXPos(), player:getYPos(), player:getZPos(), player:getRotPos(), player:getZoneID() );
+        targ:setPos( player:getXPos(), player:getYPos(), player:getZPos(), player:getRotPos(), player:getZoneID() )
     else
         if (noDepop == nil or noDepop == 0) then
-            DespawnMob( mobId );
-            player:PrintToPlayer("Despawned the mob because of an error.");
+            DespawnMob( mobId )
+            player:PrintToPlayer("Despawned the mob because of an error.")
         end
-        player:PrintToPlayer("Mob could not be moved to current pos - you are probably in the wrong zone.");
+        player:PrintToPlayer("Mob could not be moved to current pos - you are probably in the wrong zone.")
     end
-end;
+end

--- a/scripts/commands/mobsub.lua
+++ b/scripts/commands/mobsub.lua
@@ -3,56 +3,56 @@
 -- desc: Changes the sub-animation of the given mob. (For testing purposes.)
 ---------------------------------------------------------------------------------------------------
 
-require("scripts/globals/status");
+require("scripts/globals/status")
 
 cmdprops =
 {
     permission = 1,
     parameters = "ss"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!mobsub {mob ID} <animation ID>");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!mobsub {mob ID} <animation ID>")
+end
 
 function onTrigger(player, arg1, arg2)
-    local target;
-    local animationId;
+    local target
+    local animationId
     
     if (arg2 ~= nil) then
-        target = arg1;
-        animationId = arg2;
+        target = arg1
+        animationId = arg2
     elseif (arg1 ~= nil) then
-        animationId = arg1;
+        animationId = arg1
     else
-        error(player, "You must provide an animation ID.");
-        return;
+        error(player, "You must provide an animation ID.")
+        return
     end
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player:getCursorTarget();
+        targ = player:getCursorTarget()
         if (targ == nil or not targ:isMob()) then
-            error(player, "You must either provide a mob ID or target a mob.");
-            return;
+            error(player, "You must either provide a mob ID or target a mob.")
+            return
         end
     else
-        targ = GetMobByID(target);
+        targ = GetMobByID(target)
         if (targ == nil) then
-            error(player, "Invalid mob ID.");
-            return;
+            error(player, "Invalid mob ID.")
+            return
         end
-    end;
+    end
 
     -- validate animationId
-    animationId = tonumber(animationId) or tpz.anim[string.upper(animationId)];
+    animationId = tonumber(animationId) or tpz.anim[string.upper(animationId)]
     if (animationId == nil or animationId < 0) then
-        error(player, "Invalid animation ID.");
-        return;
+        error(player, "Invalid animation ID.")
+        return
     end
 
     -- set animation sub
-    targ:AnimationSub( animationId );
+    targ:AnimationSub( animationId )
 end

--- a/scripts/commands/mp.lua
+++ b/scripts/commands/mp.lua
@@ -7,43 +7,43 @@ cmdprops =
 {
     permission = 1,
     parameters = "is"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!mp <amount> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!mp <amount> {player}")
+end
 
 function onTrigger(player, mp, target)
     -- validate amount
     if (mp == nil or tonumber(mp) == nil) then
-        error(player, "You must provide an amount.");
-        return;
+        error(player, "You must provide an amount.")
+        return
     elseif (mp < 0) then
-        error(player, "Invalid amount.");
-        return;
+        error(player, "Invalid amount.")
+        return
     end
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format( "Player named '%s' not found!", target ) );
-            return;
+            error(player, string.format( "Player named '%s' not found!", target ) )
+            return
         end
     end
     
     -- set mp
     if (targ:getHP() > 0) then
-        targ:setMP(mp);
+        targ:setMP(mp)
         if(targ:getID() ~= player:getID()) then
-            player:PrintToPlayer(string.format("Set %s's MP to %i.", targ:getName(), targ:getMP()));
+            player:PrintToPlayer(string.format("Set %s's MP to %i.", targ:getName(), targ:getMP()))
         end
     else
-        player:PrintToPlayer(string.format("%s is currently dead.", targ:getName()));
+        player:PrintToPlayer(string.format("%s is currently dead.", targ:getName()))
     end
 
-end;
+end

--- a/scripts/commands/npchere.lua
+++ b/scripts/commands/npchere.lua
@@ -8,40 +8,40 @@ cmdprops =
 {
     permission = 1,
     parameters = "is"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!npchere {npcID} {noDepop}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!npchere {npcID} {noDepop}")
+end
 
 function onTrigger(player, npcId, noDepop)
-    require("scripts/globals/status");
+    require("scripts/globals/status")
 
     -- validate npc
-    local targ;
+    local targ
     if (npcId == nil) then
-        targ = player:getCursorTarget();
+        targ = player:getCursorTarget()
         if (targ == nil or not targ:isNPC()) then
-            error(player, "You must either provide an npcID or target an NPC.");
-            return;
+            error(player, "You must either provide an npcID or target an NPC.")
+            return
         end
     else
-        targ = GetNPCByID(npcId);
+        targ = GetNPCByID(npcId)
         if (targ == nil) then
-            error(player, "Invalid npcID.");
-            return;
+            error(player, "Invalid npcID.")
+            return
         end
     end
 
     if (player:getZoneID() == targ:getZoneID()) then
-        targ:setPos( player:getXPos(), player:getYPos(), player:getZPos(), player:getRotPos(), player:getZoneID() );
-        targ:setStatus(tpz.status.NORMAL);
+        targ:setPos( player:getXPos(), player:getYPos(), player:getZPos(), player:getRotPos(), player:getZoneID() )
+        targ:setStatus(tpz.status.NORMAL)
     else
         if (noDepop == nil or noDepop == 0) then
-            targ:setStatus(tpz.status.DISAPPEAR);
-            player:PrintToPlayer("Despawned the NPC because of an error.");
+            targ:setStatus(tpz.status.DISAPPEAR)
+            player:PrintToPlayer("Despawned the NPC because of an error.")
         end
-        player:PrintToPlayer("NPC could not be moved to current pos - you are probably in the wrong zone.");
+        player:PrintToPlayer("NPC could not be moved to current pos - you are probably in the wrong zone.")
     end
-end;
+end

--- a/scripts/commands/pardon.lua
+++ b/scripts/commands/pardon.lua
@@ -7,26 +7,26 @@ cmdprops =
 {
     permission = 1,
     parameters = "s"
-};
+}
 
 function onTrigger(player, target)
     if (target == nil) then
-        player:PrintToPlayer("You must enter a valid player name.");
-        return;
+        player:PrintToPlayer("You must enter a valid player name.")
+        return
     end
 
     -- Validate the target..
-    local targ = GetPlayerByName( target );
+    local targ = GetPlayerByName( target )
     if (targ == nil) then
-        player:PrintToPlayer( string.format( "Invalid player '%s' given.", target ) );
-        return;
+        player:PrintToPlayer( string.format( "Invalid player '%s' given.", target ) )
+        return
     end
 
     if (targ:getCharVar( 'inJail' ) >= 1) then
-        local message = string.format( '%s is pardoning %s from jail.', player:getName(), targ:getName() );
-        printf( message );
+        local message = string.format( '%s is pardoning %s from jail.', player:getName(), targ:getName() )
+        printf( message )
 
-        targ:setCharVar( 'inJail', 0 );
-        targ:warp();
+        targ:setCharVar( 'inJail', 0 )
+        targ:warp()
     end
 end

--- a/scripts/commands/petgodmode.lua
+++ b/scripts/commands/petgodmode.lua
@@ -7,69 +7,69 @@ cmdprops =
 {
     permission = 1,
     parameters = ""
-};
+}
 
 function onTrigger(player)
     local pet = player:getPet()
     if (pet and pet:getLocalVar("GodMode") == 0) then
         -- Toggle GodMode on..
-        pet:setLocalVar("GodMode", 1);
+        pet:setLocalVar("GodMode", 1)
 
         -- Add bonus effects to the pet..
-        pet:addStatusEffect(tpz.effect.MAX_HP_BOOST,1000,0,0);
-        pet:addStatusEffect(tpz.effect.MAX_MP_BOOST,1000,0,0);
-        pet:addStatusEffect(tpz.effect.SENTINEL,100,0,0);
-        pet:addStatusEffect(tpz.effect.MIGHTY_STRIKES,1,0,0);
-        pet:addStatusEffect(tpz.effect.HUNDRED_FISTS,1,0,0);
-        pet:addStatusEffect(tpz.effect.CHAINSPELL,1,0,0);
-        pet:addStatusEffect(tpz.effect.PERFECT_DODGE,1,0,0);
-        pet:addStatusEffect(tpz.effect.INVINCIBLE,1,0,0);
-        pet:addStatusEffect(tpz.effect.MANAFONT,1,0,0);
-        pet:addStatusEffect(tpz.effect.REGAIN,150,1,0);
-        pet:addStatusEffect(tpz.effect.REFRESH,99,0,0);
-        pet:addStatusEffect(tpz.effect.REGEN,99,0,0);
+        pet:addStatusEffect(tpz.effect.MAX_HP_BOOST,1000,0,0)
+        pet:addStatusEffect(tpz.effect.MAX_MP_BOOST,1000,0,0)
+        pet:addStatusEffect(tpz.effect.SENTINEL,100,0,0)
+        pet:addStatusEffect(tpz.effect.MIGHTY_STRIKES,1,0,0)
+        pet:addStatusEffect(tpz.effect.HUNDRED_FISTS,1,0,0)
+        pet:addStatusEffect(tpz.effect.CHAINSPELL,1,0,0)
+        pet:addStatusEffect(tpz.effect.PERFECT_DODGE,1,0,0)
+        pet:addStatusEffect(tpz.effect.INVINCIBLE,1,0,0)
+        pet:addStatusEffect(tpz.effect.MANAFONT,1,0,0)
+        pet:addStatusEffect(tpz.effect.REGAIN,150,1,0)
+        pet:addStatusEffect(tpz.effect.REFRESH,99,0,0)
+        pet:addStatusEffect(tpz.effect.REGEN,99,0,0)
 
         -- Add bonus mods to the pet..
-        pet:addMod(tpz.mod.RACC,2500);
-        pet:addMod(tpz.mod.RATT,2500);
-        pet:addMod(tpz.mod.ACC,2500);
-        pet:addMod(tpz.mod.ATT,2500);
-        pet:addMod(tpz.mod.MATT,2500);
-        pet:addMod(tpz.mod.MACC,2500);
-        pet:addMod(tpz.mod.RDEF,2500);
-        pet:addMod(tpz.mod.DEF,2500);
-        pet:addMod(tpz.mod.MDEF,2500);
+        pet:addMod(tpz.mod.RACC,2500)
+        pet:addMod(tpz.mod.RATT,2500)
+        pet:addMod(tpz.mod.ACC,2500)
+        pet:addMod(tpz.mod.ATT,2500)
+        pet:addMod(tpz.mod.MATT,2500)
+        pet:addMod(tpz.mod.MACC,2500)
+        pet:addMod(tpz.mod.RDEF,2500)
+        pet:addMod(tpz.mod.DEF,2500)
+        pet:addMod(tpz.mod.MDEF,2500)
 
         -- Heal the pet from the new buffs..
-        pet:addHP( 50000 );
-        pet:setMP( 50000 );
+        pet:addHP( 50000 )
+        pet:setMP( 50000 )
     else
         -- Toggle GodMode off..
-        pet:setLocalVar("GodMode", 0);
+        pet:setLocalVar("GodMode", 0)
 
         -- Remove bonus effects..
-        pet:delStatusEffect(tpz.effect.MAX_HP_BOOST);
-        pet:delStatusEffect(tpz.effect.MAX_MP_BOOST);
-        pet:delStatusEffect(tpz.effect.SENTINEL);
-        pet:delStatusEffect(tpz.effect.MIGHTY_STRIKES);
-        pet:delStatusEffect(tpz.effect.HUNDRED_FISTS);
-        pet:delStatusEffect(tpz.effect.CHAINSPELL);
-        pet:delStatusEffect(tpz.effect.PERFECT_DODGE);
-        pet:delStatusEffect(tpz.effect.INVINCIBLE);
-        pet:delStatusEffect(tpz.effect.MANAFONT);
-        pet:delStatusEffect(tpz.effect.REGAIN);
-        pet:delStatusEffect(tpz.effect.REFRESH);
-        pet:delStatusEffect(tpz.effect.REGEN);
+        pet:delStatusEffect(tpz.effect.MAX_HP_BOOST)
+        pet:delStatusEffect(tpz.effect.MAX_MP_BOOST)
+        pet:delStatusEffect(tpz.effect.SENTINEL)
+        pet:delStatusEffect(tpz.effect.MIGHTY_STRIKES)
+        pet:delStatusEffect(tpz.effect.HUNDRED_FISTS)
+        pet:delStatusEffect(tpz.effect.CHAINSPELL)
+        pet:delStatusEffect(tpz.effect.PERFECT_DODGE)
+        pet:delStatusEffect(tpz.effect.INVINCIBLE)
+        pet:delStatusEffect(tpz.effect.MANAFONT)
+        pet:delStatusEffect(tpz.effect.REGAIN)
+        pet:delStatusEffect(tpz.effect.REFRESH)
+        pet:delStatusEffect(tpz.effect.REGEN)
 
         -- Remove bonus mods..
-        pet:delMod(tpz.mod.RACC,2500);
-        pet:delMod(tpz.mod.RATT,2500);
-        pet:delMod(tpz.mod.ACC,2500);
-        pet:delMod(tpz.mod.ATT,2500);
-        pet:delMod(tpz.mod.MATT,2500);
-        pet:delMod(tpz.mod.MACC,2500);
-        pet:delMod(tpz.mod.RDEF,2500);
-        pet:delMod(tpz.mod.DEF,2500);
-        pet:delMod(tpz.mod.MDEF,2500);
+        pet:delMod(tpz.mod.RACC,2500)
+        pet:delMod(tpz.mod.RATT,2500)
+        pet:delMod(tpz.mod.ACC,2500)
+        pet:delMod(tpz.mod.ATT,2500)
+        pet:delMod(tpz.mod.MATT,2500)
+        pet:delMod(tpz.mod.MACC,2500)
+        pet:delMod(tpz.mod.RDEF,2500)
+        pet:delMod(tpz.mod.DEF,2500)
+        pet:delMod(tpz.mod.MDEF,2500)
     end
 end

--- a/scripts/commands/pettp.lua
+++ b/scripts/commands/pettp.lua
@@ -7,27 +7,27 @@ cmdprops =
 {
     permission = 1,
     parameters = "i"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!pettp {amount}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!pettp {amount}")
+end
 
 function onTrigger(player, tp)
     -- validate target
-    local targ = player:getPet();
+    local targ = player:getPet()
     if (targ == nil) then
-        error(player, "You do not have a pet.");
-        return;
+        error(player, "You do not have a pet.")
+        return
     end
 
     -- validate tp amount
     if (tp == nil or tp < 0) then
-        error(player, "Invalid amount of tp.");
-        return;
+        error(player, "Invalid amount of tp.")
+        return
     end
 
     -- set pet tp
-    targ:setTP( tp );
+    targ:setTP( tp )
 end

--- a/scripts/commands/pos.lua
+++ b/scripts/commands/pos.lua
@@ -7,78 +7,78 @@ cmdprops =
 {
     permission = 1,
     parameters = "sssss"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!pos {x} {y} {z} {zone ID} {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!pos {x} {y} {z} {zone ID} {player}")
+end
 
 function onTrigger(player, arg1, arg2, arg3, arg4, arg5)
-    local target;
-    local zoneId;
-    local x;
-    local y;
-    local z;
-    local targ;
+    local target
+    local zoneId
+    local x
+    local y
+    local z
+    local targ
 
     -- shift arguments depending on number passed
     if (arg5 ~= nil) then
-        x = tonumber(arg1);
-        y = tonumber(arg2);
-        z = tonumber(arg3);
-        zoneId = arg4;
-        target = arg5;
+        x = tonumber(arg1)
+        y = tonumber(arg2)
+        z = tonumber(arg3)
+        zoneId = arg4
+        target = arg5
     elseif (arg4 ~= nil) then
-        x = tonumber(arg1);
-        y = tonumber(arg2);
-        z = tonumber(arg3);
+        x = tonumber(arg1)
+        y = tonumber(arg2)
+        z = tonumber(arg3)
         if (GetPlayerByName(arg4) == nil) then
-            zoneId = arg4;
+            zoneId = arg4
         else
-            target = arg4;
+            target = arg4
         end
     elseif (arg3 ~= nil) then
-        x = tonumber(arg1);
-        y = tonumber(arg2);
-        z = tonumber(arg3);
+        x = tonumber(arg1)
+        y = tonumber(arg2)
+        z = tonumber(arg3)
     elseif (arg1 ~= nil) then
-        target = arg1;
+        target = arg1
     end
 
     -- validate target
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format( "Player named '%s' not found!", target ) );
-            return;
+            error(player, string.format( "Player named '%s' not found!", target ) )
+            return
         end
     end
 
     -- validate zone
     if (zoneId ~= nil) then
-        zoneId = tonumber(zoneId);
+        zoneId = tonumber(zoneId)
         if (zoneId == nil or zoneId < 0 or zoneId > 298) then
-            error(player, "Invalid zone ID.");
-            return;
+            error(player, "Invalid zone ID.")
+            return
         end
     end
 
     -- report or move position
     if (x == nil or y == nil or z == nil) then
-        player:PrintToPlayer(string.format("%s's position: X %.4f  Y %.4f  Z %.4f", targ:getName(), targ:getXPos(), targ:getYPos(), targ:getZPos() ));
+        player:PrintToPlayer(string.format("%s's position: X %.4f  Y %.4f  Z %.4f", targ:getName(), targ:getXPos(), targ:getYPos(), targ:getZPos() ))
     else
         if (zoneId == nil) then
-            zoneId = targ:getZoneID();
-            targ:setPos(x, y, z, 0);
+            zoneId = targ:getZoneID()
+            targ:setPos(x, y, z, 0)
         else
-            targ:setPos(x, y, z, 0, zoneId);
+            targ:setPos(x, y, z, 0, zoneId)
         end
         if (player:getID() ~= targ:getID()) then
-            player:PrintToPlayer(string.format("Moved %s to (%.4f, %.4f, %.4f) in zone %i.", targ:getName(), x, y, z, zoneId));
+            player:PrintToPlayer(string.format("Moved %s to (%.4f, %.4f, %.4f) in zone %i.", targ:getName(), x, y, z, zoneId))
         end
     end
 
-end;
+end

--- a/scripts/commands/posfix.lua
+++ b/scripts/commands/posfix.lua
@@ -7,19 +7,19 @@ cmdprops =
 {
     permission = 1,
     parameters = "s"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!posfix <player>");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!posfix <player>")
+end
 
 function onTrigger(player, target)
     -- validate target
     if (target == nil) then
-        error(player, "You must supply the name of an offline player.");
+        error(player, "You must supply the name of an offline player.")
     else
-        player:resetPlayer( target );
-        player:PrintToPlayer(string.format("Fixed %s's position.", target));
+        player:resetPlayer( target )
+        player:PrintToPlayer(string.format("Fixed %s's position.", target))
     end
-end;
+end

--- a/scripts/commands/promote.lua
+++ b/scripts/commands/promote.lua
@@ -7,49 +7,49 @@ cmdprops =
 {
     permission = 1,
     parameters = "si"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!promote <player> <level>");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!promote <player> <level>")
+end
 
 function onTrigger(player, target, level)
     -- determine maximum level player can promote to
-    local maxLevel = player:getGMLevel() - 1;
+    local maxLevel = player:getGMLevel() - 1
     if (maxLevel < 1) then
-        maxLevel = 0;
+        maxLevel = 0
     end
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        error(player, "You must provide a player name.");
-        return;
+        error(player, "You must provide a player name.")
+        return
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format( "Player named '%s' not found!", target ) );
-            return;
+            error(player, string.format( "Player named '%s' not found!", target ) )
+            return
         end
     end
 
     -- catch players trying to change level of equal or higher tiered GMs.
     if (targ:getGMLevel() >= player:getGMLevel()) then
-        printf( "%s attempting to adjust same or higher tier GM %s.", player:getName(), targ:getName() );
-        targ:PrintToPlayer(string.format( "%s attempted to adjust your GM rank.", player:getName() ));
-        error(player, "You can not use this command on same or higher tiered GMs.");
-        return;
+        printf( "%s attempting to adjust same or higher tier GM %s.", player:getName(), targ:getName() )
+        targ:PrintToPlayer(string.format( "%s attempted to adjust your GM rank.", player:getName() ))
+        error(player, "You can not use this command on same or higher tiered GMs.")
+        return
     end
 
     -- validate level
     if (level == nil or level < 0 or level > maxLevel) then
-        error(player, string.format("Invalid level.  Must be 0 to %i.", maxLevel ));
-        return;
+        error(player, string.format("Invalid level.  Must be 0 to %i.", maxLevel ))
+        return
     end
 
     -- change target gm level
-    targ:setGMLevel(level);
-    player:PrintToPlayer(string.format( "%s set to tier %i.", targ:getName(), level ));
-    targ:PrintToPlayer(string.format( "You have been set to tier %i.", level ));
-end;
+    targ:setGMLevel(level)
+    player:PrintToPlayer(string.format( "%s set to tier %i.", targ:getName(), level ))
+    targ:PrintToPlayer(string.format( "You have been set to tier %i.", level ))
+end

--- a/scripts/commands/raise.lua
+++ b/scripts/commands/raise.lua
@@ -7,55 +7,55 @@ cmdprops =
 {
     permission = 1,
     parameters = "ss"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!raise {power} {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!raise {power} {player}")
+end
 
 function onTrigger(player, arg1, arg2)
-    local power;
-    local target;
-    local targ;
+    local power
+    local target
+    local targ
 
     -- decide inputs
     if (arg2 ~= nil) then
-        power = tonumber(arg1);
-        target = arg2;
+        power = tonumber(arg1)
+        target = arg2
     elseif (arg1 ~= nil) then
         if (GetPlayerByName(arg1) == nil) then
-            power = tonumber(arg1);
+            power = tonumber(arg1)
         else
-            target = arg1;
+            target = arg1
         end
     end
     
     -- validate power
     if (power == nil or power > 3) then
-        power = 3;
+        power = 3
     elseif (power < 1) then
-        power = 1;
+        power = 1
     end
 
     -- validate target
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format( "Player named '%s' not found!", target ) );
-            return;
+            error(player, string.format( "Player named '%s' not found!", target ) )
+            return
         end
     end
 
     -- raise target
     if (targ:isDead()) then
-        targ:sendRaise(power);
+        targ:sendRaise(power)
         if (targ:getID() ~= player:getID()) then
-            player:PrintToPlayer( string.format( "Raise %i sent to %s.", power, targ:getName() ) );
+            player:PrintToPlayer( string.format( "Raise %i sent to %s.", power, targ:getName() ) )
         end
     else
-        player:PrintToPlayer( string.format( "%s is not dead.", targ:getName() ) );
+        player:PrintToPlayer( string.format( "%s is not dead.", targ:getName() ) )
     end
-end;
+end

--- a/scripts/commands/reloadglobal.lua
+++ b/scripts/commands/reloadglobal.lua
@@ -15,19 +15,19 @@ cmdprops =
 {
     permission = 4,
     parameters = "ss"
-};
+}
 
 function onTrigger(player,globalLua,other)
     if (globalLua ~= nil and other == nil) then
-        local String = table.concat({"scripts/globals/",globalLua});
-        package.loaded[String] = nil;
-        require(String);
-        player:PrintToPlayer(string.format("Lua file '%s' has been reloaded.",String));
+        local String = table.concat({"scripts/globals/",globalLua})
+        package.loaded[String] = nil
+        require(String)
+        player:PrintToPlayer(string.format("Lua file '%s' has been reloaded.",String))
     elseif (other == "I_am_sure") then
-        package.loaded[globalLua] = nil;
-        require(globalLua);
-        player:PrintToPlayer(string.format("Lua file '%s' has been reloaded.",globalLua));
+        package.loaded[globalLua] = nil
+        require(globalLua)
+        player:PrintToPlayer(string.format("Lua file '%s' has been reloaded.",globalLua))
     else
-        player:PrintToPlayer("Must Specify a global lua file.");
+        player:PrintToPlayer("Must Specify a global lua file.")
     end
-end;
+end

--- a/scripts/commands/reset.lua
+++ b/scripts/commands/reset.lua
@@ -8,29 +8,29 @@ cmdprops =
 {
     permission = 1,
     parameters = "s"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!reset {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!reset {player}")
+end
 
 function onTrigger(player,target)
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format( "Player named '%s' not found!", target ) );
-            return;
+            error(player, string.format( "Player named '%s' not found!", target ) )
+            return
         end
     end
     
     -- reset target recasts
-    targ:resetRecasts();
+    targ:resetRecasts()
     if (targ:getID() ~= player:getID()) then
-        player:PrintToPlayer( string.format( "Reset %s's recast timers.", targ:getName() ) );
+        player:PrintToPlayer( string.format( "Reset %s's recast timers.", targ:getName() ) )
     end
-end;
+end

--- a/scripts/commands/return.lua
+++ b/scripts/commands/return.lua
@@ -9,37 +9,37 @@ cmdprops =
 {
     permission = 1,
     parameters = "s"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!return {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!return {player}")
+end
 
 function onTrigger(player, target)
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format( "Player named '%s' not found!", target ) );
-            return;
+            error(player, string.format( "Player named '%s' not found!", target ) )
+            return
         end
     end
 
     -- get previous zone
-    zoneId = targ:getPreviousZone();
+    zoneId = targ:getPreviousZone()
     if (zoneId == nil or zoneId == tpz.zone.UNKNOWN or zoneId == tpz.zone.RESIDENTIAL_AREA) then
-        error(player, "Previous zone was a Mog House or there was a problem fetching the ID.");
-        return;
+        error(player, "Previous zone was a Mog House or there was a problem fetching the ID.")
+        return
     end
 
     -- zone target
-    targ:setPos( 0, 0, 0, 0, zoneId );
+    targ:setPos( 0, 0, 0, 0, zoneId )
     if (targ:getID() ~= player:getID()) then
-        player:PrintToPlayer( string.format( "%s was returned to zone %i.", targ:getName(), zoneId ) );
+        player:PrintToPlayer( string.format( "%s was returned to zone %i.", targ:getName(), zoneId ) )
     end
 end

--- a/scripts/commands/send.lua
+++ b/scripts/commands/send.lua
@@ -4,13 +4,13 @@
 -- A) The given zone
 -- B) another player
 ---------------------------------------------------------------------------------------------------
-require("scripts/globals/zone");
+require("scripts/globals/zone")
 
 cmdprops =
 {
     permission = 1,
     parameters = "b"
-};
+}
 
 ---------------------------------------------------------------------------------------------------
 -- desc: List of zones with their auto-translated group and message id.
@@ -276,116 +276,116 @@ local zone_list =
     { 0x27, 0x59, 284 }, -- Celennia Memorial Library
     { 0x27, 0x5B, 285 }, -- Feretory
     { 0x14, 0x09, 288 }, -- Escha - Zi'Tah
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!send <player to send> <destination player or zone>");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!send <player to send> <destination player or zone>")
+end
 
 function getBytePos(s,needle)
-    local i;
-    local b;
+    local i
+    local b
     for i=1,string.len(s),1 do
         if (string.byte(s, i) == needle) then
-            return i;
+            return i
         end
     end
-    return nil;
-end;
+    return nil
+end
 
 ---------------------------------------------------------------------------------------------------
 -- func: onTrigger
 -- desc: Called when this command is invoked.
 ---------------------------------------------------------------------------------------------------
 function onTrigger(player, bytes)
-    local x = 0;
-    local y = 0;
-    local z = 0;
-    local rot = 0;
-    local zone;
+    local x = 0
+    local y = 0
+    local z = 0
+    local rot = 0
+    local zone
 
     if (bytes == nil) then
-        error(player, "You must provide the name of a player to send and a destination.");
-        return;
+        error(player, "You must provide the name of a player to send and a destination.")
+        return
     end
-    bytes = string.sub(bytes,6);
-    local atpos = getBytePos(bytes, 253);
-    local sppos = getBytePos(bytes, 32);
+    bytes = string.sub(bytes,6)
+    local atpos = getBytePos(bytes, 253)
+    local sppos = getBytePos(bytes, 32)
 
     -- validate player to send
-    local target;
-    local targ;
+    local target
+    local targ
     if (sppos == nil) then
-        error(player, "You must provide the name of a player to send and a destination.");
-        return;
+        error(player, "You must provide the name of a player to send and a destination.")
+        return
     else
-        target = string.sub(bytes,1,sppos-1);
-        targ = GetPlayerByName(target);
+        target = string.sub(bytes,1,sppos-1)
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format( "Player named '%s' not found!", target ));
-            return;
+            error(player, string.format( "Player named '%s' not found!", target ))
+            return
         end
     end
 
     -- validate destination
     if (atpos ~= nil) then
         -- destination is an auto-translate phrase
-        local groupId = string.byte(bytes, atpos + 3);
-        local messageId = string.byte(bytes, atpos + 4);
+        local groupId = string.byte(bytes, atpos + 3)
+        local messageId = string.byte(bytes, atpos + 4)
         for k, v in pairs(zone_list) do
             if (v[1] == groupId and v[2] == messageId) then
-                x = v[4] or 0;
-                y = v[5] or 0;
-                z = v[6] or 0;
-                rot = 0;
-                zone = v[3];
-                break;
+                x = v[4] or 0
+                y = v[5] or 0
+                z = v[6] or 0
+                rot = 0
+                zone = v[3]
+                break
             end
         end
         if (zone == nil) then
-            error(player,"Auto-translated phrase is not a zone.");
-            return;
+            error(player,"Auto-translated phrase is not a zone.")
+            return
         end
     else
-        local dest = string.sub(bytes, sppos+1);
+        local dest = string.sub(bytes, sppos+1)
         if (tonumber(dest) ~= nil) then
             -- destination is a zone ID.
-            zone = tonumber(dest);
+            zone = tonumber(dest)
             if (zone < 0 or zone >= tpz.zone.MAX_ZONE) then
-                error(player, "Invalid zone ID.");
-                return;
+                error(player, "Invalid zone ID.")
+                return
             end
             for k, v in pairs(zone_list) do
                 if (v[3] == zone) then
-                    x = v[4] or 0;
-                    y = v[5] or 0;
-                    z = v[6] or 0;
-                    rot = 0;
-                    zone = v[3];
-                    break;
+                    x = v[4] or 0
+                    y = v[5] or 0
+                    z = v[6] or 0
+                    rot = 0
+                    zone = v[3]
+                    break
                 end
             end
         else
             -- destination is a player name.
-            local target = dest;
-            dest = GetPlayerByName(dest);
+            local target = dest
+            dest = GetPlayerByName(dest)
             if (dest == nil) then
-                error(player, string.format( "Player named '%s' not found!", target ));
-                return;
+                error(player, string.format( "Player named '%s' not found!", target ))
+                return
             end
-            x = dest:getXPos();
-            y = dest:getYPos();
-            z = dest:getZPos();
-            rot = dest:getRotPos();
-            zone = dest:getZoneID();
+            x = dest:getXPos()
+            y = dest:getYPos()
+            z = dest:getZPos()
+            rot = dest:getRotPos()
+            zone = dest:getZoneID()
         end
     end
 
     -- send target to destination
-    targ:setPos(x, y, z, rot, zone);
+    targ:setPos(x, y, z, rot, zone)
     if (targ:getID() ~= player:getID()) then
-        player:PrintToPlayer( string.format("Sent %s to zone %i.", targ:getName(), zone) );
+        player:PrintToPlayer( string.format("Sent %s to zone %i.", targ:getName(), zone) )
     end
 end
 

--- a/scripts/commands/setflag.lua
+++ b/scripts/commands/setflag.lua
@@ -7,34 +7,34 @@ cmdprops =
 {
     permission = 1,
     parameters = "ss"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!setflag <flags> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!setflag <flags> {player}")
+end
 
 function onTrigger(player, flags, target)
 
     -- validate flags
     if (flags == nil) then
-        error(player, "You must enter a number for the flags (hex values work).");
-        return;
+        error(player, "You must enter a number for the flags (hex values work).")
+        return
     end
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format( "Player named '%s' not found!", target ) );
-            return;
+            error(player, string.format( "Player named '%s' not found!", target ) )
+            return
         end
     end
 
     -- set flags
-    targ:setFlag( flags );
+    targ:setFlag( flags )
 
-end;
+end

--- a/scripts/commands/setgil.lua
+++ b/scripts/commands/setgil.lua
@@ -7,19 +7,19 @@ cmdprops =
 {
     permission = 1,
     parameters = "i"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!setgil <amount>");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!setgil <amount>")
+end
 
 function onTrigger(player, amount)
     -- validate amount
     if (amount == nil or amount < 0) then
-        error(player, "Invalid amount.");
-        return;
+        error(player, "Invalid amount.")
+        return
     end
 
-    player:setGil( amount );
-end;
+    player:setGil( amount )
+end

--- a/scripts/commands/setlocalvar.lua
+++ b/scripts/commands/setlocalvar.lua
@@ -7,7 +7,7 @@ cmdprops =
 {
     permission = 3,
     parameters = "siss"
-};
+}
 
 function error(player, msg)
     player:PrintToPlayer(msg)

--- a/scripts/commands/setmentor.lua
+++ b/scripts/commands/setmentor.lua
@@ -7,33 +7,33 @@ cmdprops =
 {
     permission = 1,
     parameters = "is"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!setmentor <mode> {player}");
-    player:PrintToPlayer("mode: 0 = Not a mentor, 1 = Unlocked but inactive.");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!setmentor <mode> {player}")
+    player:PrintToPlayer("mode: 0 = Not a mentor, 1 = Unlocked but inactive.")
+end
 
 function onTrigger(player, mentorMode, target)
     -- validate mode
     if (mentorMode == nil or mentorMode < 0 or mentorMode > 1) then
-        error(player, "Invalid mode.");
-        return;
+        error(player, "Invalid mode.")
+        return
     end
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format( "Player named '%s' not found!", target ) );
-            return;
+            error(player, string.format( "Player named '%s' not found!", target ) )
+            return
         end
     end
 
     -- set mentor mode
-    targ:setMentor(mentorMode);
-end;
+    targ:setMentor(mentorMode)
+end

--- a/scripts/commands/setmerits.lua
+++ b/scripts/commands/setmerits.lua
@@ -7,34 +7,34 @@ cmdprops =
 {
     permission = 1,
     parameters = "is"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!setmerits <amount> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!setmerits <amount> {player}")
+end
 
 function onTrigger(player, amount, target)
 
     -- validate amount
     if (amount == nil or amount < 0) then
-        error(player, "Invalid amount.");
-        return;
+        error(player, "Invalid amount.")
+        return
     end
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format("Player named '%s' not found!", target));
-            return;
+            error(player, string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
     -- set merits
-    targ:setMerits(amount);
-    player:PrintToPlayer( string.format("%s now has %i merits.", targ:getName(), targ:getMeritCount() ) );
-end;
+    targ:setMerits(amount)
+    player:PrintToPlayer( string.format("%s now has %i merits.", targ:getName(), targ:getMeritCount() ) )
+end

--- a/scripts/commands/setmobflags.lua
+++ b/scripts/commands/setmobflags.lua
@@ -8,37 +8,37 @@ cmdprops =
 {
     permission = 1,
     parameters = "si"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!setmobflags <flags> {mob ID}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!setmobflags <flags> {mob ID}")
+end
 
 function onTrigger(player, flags, target)
     -- validate flags
     if (flags == nil) then
-        error(player, "You must supply a flags value.");
-        return;
+        error(player, "You must supply a flags value.")
+        return
     end
     
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player:getCursorTarget();
+        targ = player:getCursorTarget()
         if (targ == nil or not targ:isMob()) then
-            error(player, "You must either supply a mob ID or target a mob.");
-            return;
+            error(player, "You must either supply a mob ID or target a mob.")
+            return
         end
     else
-        targ = GetMobByID(target);
+        targ = GetMobByID(target)
         if (targ == nil) then
-            error(player, "Invalid mob ID.");
-            return;
+            error(player, "Invalid mob ID.")
+            return
         end
     end
 
     -- set flags
-    player:setMobFlags(flags, targ:getID());
-    player:PrintToPlayer( string.format("Set %s %i flags to %i.", targ:getName(), targ:getID(), flags) );
-end;
+    player:setMobFlags(flags, targ:getID())
+    player:PrintToPlayer( string.format("Set %s %i flags to %i.", targ:getName(), targ:getID(), flags) )
+end

--- a/scripts/commands/setmoblevel.lua
+++ b/scripts/commands/setmoblevel.lua
@@ -2,19 +2,19 @@
 -- func: setmoblevel
 -- desc: Sets the target monsters level.
 ---------------------------------------------------------------------------------------------------
-require("scripts/globals/msg");
+require("scripts/globals/msg")
 
 cmdprops =
 {
     permission = 1,
     parameters = "i"
-};
+}
 
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!setmoblevel <level>");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!setmoblevel <level>")
+end
 
 function onTrigger(player, lv)
     local target = player:getCursorTarget()
@@ -25,7 +25,7 @@ function onTrigger(player, lv)
             target:getMainJob(), target:getMainLvl(), target:getSubJob(), target:getSubLvl()), tpz.msg.channel.SYSTEM_3
         )
 
-        target:setMobLevel(lv);
+        target:setMobLevel(lv)
 
         player:PrintToPlayer(string.format("New MainJob(jID: %s) LV: %i / SubJob(jID: %s) LV: %i ",
             target:getMainJob(), target:getMainLvl(), target:getSubJob(), target:getSubLvl()), tpz.msg.channel.SYSTEM_3

--- a/scripts/commands/setmusic.lua
+++ b/scripts/commands/setmusic.lua
@@ -7,29 +7,29 @@ cmdprops =
 {
     permission = 1,
     parameters = "ii"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!setmusic <type ID> <song ID>");
-    player:PrintToPlayer("type IDs: 0 = BGM (Day), 1 = BGM (Night), 2 = Solo-Battle, 3 = Party-Battle, 4 = Chocobo");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!setmusic <type ID> <song ID>")
+    player:PrintToPlayer("type IDs: 0 = BGM (Day), 1 = BGM (Night), 2 = Solo-Battle, 3 = Party-Battle, 4 = Chocobo")
+end
 
 function onTrigger(player, typeId, songId)
 
     -- validate typeId
     if (typeId == nil or typeId < 0 or typeId > 4) then
-        error(player, "Invalid type ID.");
-        return;
+        error(player, "Invalid type ID.")
+        return
     end
     
     -- validate songId
     if (songId == nil or songId < 0) then
-        error(player, "Invalid song ID.");
-        return;
+        error(player, "Invalid song ID.")
+        return
     end
 
     -- change music
-    player:ChangeMusic(typeId, songId);
+    player:ChangeMusic(typeId, songId)
 
-end;
+end

--- a/scripts/commands/setplayerlevel.lua
+++ b/scripts/commands/setplayerlevel.lua
@@ -7,39 +7,39 @@ cmdprops =
 {
     permission = 1,
     parameters = "ss"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!setplayerlevel {player} <level>");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!setplayerlevel {player} <level>")
+end
 
 function onTrigger(player, arg1, arg2)
-    local targ;
-    local level;
+    local targ
+    local level
 
     -- validate target
     if (arg2 ~= nil) then
-        targ = GetPlayerByName(arg1);
+        targ = GetPlayerByName(arg1)
         if (targ == nil) then
-            error(player, string.format( "Player named '%s' not found!", arg1 ) );
-            return;
+            error(player, string.format( "Player named '%s' not found!", arg1 ) )
+            return
         end
-        level = tonumber(arg2);
+        level = tonumber(arg2)
     elseif (arg1 ~= nil) then
-        targ = player;
-        level = tonumber(arg1);
+        targ = player
+        level = tonumber(arg1)
     end
 
     -- validate level
     if (level == nil or level < 1 or level > 99) then
-        error(player, "Invalid level.  Must be between 1 and 99.");
-        return;
+        error(player, "Invalid level.  Must be between 1 and 99.")
+        return
     end
 
     -- set level
-    targ:setLevel( level );
+    targ:setLevel( level )
     if (targ:getID() ~= player:getID()) then
-        player:PrintToPlayer( string.format("Set %s's level to %i.", targ:getName(), level) );
+        player:PrintToPlayer( string.format("Set %s's level to %i.", targ:getName(), level) )
     end
 end

--- a/scripts/commands/setplayermodel.lua
+++ b/scripts/commands/setplayermodel.lua
@@ -7,36 +7,36 @@ cmdprops =
 {
     permission = 1,
     parameters = "iis"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!setplayermodel <model> <slot> {player}");
-    player:PrintToPlayer("Slots: 0=main 1=sub 2=ranged 3=ammo 4=head 5=body 6=hands 7=legs 8=feet");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!setplayermodel <model> <slot> {player}")
+    player:PrintToPlayer("Slots: 0=main 1=sub 2=ranged 3=ammo 4=head 5=body 6=hands 7=legs 8=feet")
+end
 
 function onTrigger(player, model, slot, target)
     -- validate model
     if (model == nil) then
-        error(player, "Invalid model ID.");
-        return;
+        error(player, "Invalid model ID.")
+        return
     end
     
     -- validate slot
     if (slot == nil or slot < 0 or slot > 8) then
-        error(player, "Invalid slot ID.");
-        return;
+        error(player, "Invalid slot ID.")
+        return
     end
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format("Player named '%s' not found!", target));
-            return;
+            error(player, string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
@@ -53,6 +53,6 @@ function onTrigger(player, model, slot, target)
     }
 
     -- set model
-    targ:setModelId(model, slot);
-    player:PrintToPlayer(string.format("Set %s's %s slot to model %i.", targ:getName(), slotNameByNum[slot], model));
-end;
+    targ:setModelId(model, slot)
+    player:PrintToPlayer(string.format("Set %s's %s slot to model %i.", targ:getName(), slotNameByNum[slot], model))
+end

--- a/scripts/commands/setplayernation.lua
+++ b/scripts/commands/setplayernation.lua
@@ -7,35 +7,35 @@ cmdprops =
 {
     permission = 1,
     parameters = "ss"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!setplayernation {player} <nation>");
-    player:PrintToPlayer("Nations: 0=San d'Oria 1=Bastok 2=Windurst");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!setplayernation {player} <nation>")
+    player:PrintToPlayer("Nations: 0=San d'Oria 1=Bastok 2=Windurst")
+end
 
 function onTrigger(player, arg1, arg2)
-    local targ;
-    local nation;
+    local targ
+    local nation
     
     -- validate target
     if (arg2 ~= nil) then
-        targ = GetPlayerByName(arg1);
+        targ = GetPlayerByName(arg1)
         if (targ == nil) then
-            error(player, string.format( "Player named '%s' not found!", arg1 ));
-            return;
+            error(player, string.format( "Player named '%s' not found!", arg1 ))
+            return
         end
-        nation = tonumber(arg2);
+        nation = tonumber(arg2)
     elseif (arg1 ~= nil) then
-        targ = player;
-        nation = tonumber(arg1);
+        targ = player
+        nation = tonumber(arg1)
     end
 
     -- validate nation
     if (nation == nil or nation < 0 or nation > 2) then
-        error(player, "Invalid nation ID.");
-        return;
+        error(player, "Invalid nation ID.")
+        return
     end
 
     local nationByNum = {
@@ -45,6 +45,6 @@ function onTrigger(player, arg1, arg2)
     }
 
     -- set nation
-    targ:setNation( nation );
-    player:PrintToPlayer( string.format("Set %s's home nation to %s.", targ:getName(), nationByNum[nation]) );
-end;
+    targ:setNation( nation )
+    player:PrintToPlayer( string.format("Set %s's home nation to %s.", targ:getName(), nationByNum[nation]) )
+end

--- a/scripts/commands/setplayervar.lua
+++ b/scripts/commands/setplayervar.lua
@@ -7,40 +7,40 @@ cmdprops =
 {
     permission = 1,
     parameters = "ssi"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!setplayervar <player> <variable> <value>");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!setplayervar <player> <variable> <value>")
+end
 
 function onTrigger(player, target, variable, value)
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        error(player, "You must provide a player name.");
-        return;
+        error(player, "You must provide a player name.")
+        return
     else
-        targ = GetPlayerByName( target );
+        targ = GetPlayerByName( target )
         if (targ == nil) then
-            error(player, string.format( "Player named '%s' not found!", target ) );
-            return;
+            error(player, string.format( "Player named '%s' not found!", target ) )
+            return
         end
     end
     
     -- validate var
     if (variable == nil) then
-        error(player, "You must provide a variable name.");
-        return;
+        error(player, "You must provide a variable name.")
+        return
     end
     
     -- validate value
     if (value == nil) then
-        error(player, "You must provide a value.");
-        return;
+        error(player, "You must provide a value.")
+        return
     end
 
-    targ:setCharVar(variable, value);
-    player:PrintToPlayer( string.format( "Set %s's variable '%s' to %i.", targ:getName(), variable, value ) );
+    targ:setCharVar(variable, value)
+    player:PrintToPlayer( string.format( "Set %s's variable '%s' to %i.", targ:getName(), variable, value ) )
 end

--- a/scripts/commands/setskill.lua
+++ b/scripts/commands/setskill.lua
@@ -28,7 +28,7 @@ function onTrigger(player, skillName, skillLV, target)
 
 
     local skillID = tonumber(skillName) or tpz.skill[string.upper(skillName)]
-    local targ;
+    local targ
 
     if skillID == nil or skillID == 0 or (skillID > 12 and skillID < 25)
     or skillID == 46 or skillID == 47 or skillID > 57 then

--- a/scripts/commands/setweather.lua
+++ b/scripts/commands/setweather.lua
@@ -3,18 +3,18 @@
 -- desc: Sets the current weather for the current zone.
 ---------------------------------------------------------------------------------------------------
 
-require("scripts/globals/weather");
+require("scripts/globals/weather")
 
 cmdprops =
 {
     permission = 1,
     parameters = "s"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!setweather <weather ID>");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!setweather <weather ID>")
+end
 
 function onTrigger(player, weather)
 
@@ -40,26 +40,26 @@ function onTrigger(player, weather)
         ["stellar glare"]   = 17,
         ["gloom"]           = 18,
         ["darkness"]        = 19
-    };
+    }
 
     -- validate weather
     if (weather == nil) then
-        error(player, "You must supply a weather ID.");
-        return;
+        error(player, "You must supply a weather ID.")
+        return
     end
-    weather = tonumber(weather) or tpz.weather[string.upper(weather)] or weatherList[string.lower(weather)];
+    weather = tonumber(weather) or tpz.weather[string.upper(weather)] or weatherList[string.lower(weather)]
     if (weather == nil or weather < 0 or weather > 19) then
-        error(player, "Invalid weather ID.");
-        return;
+        error(player, "Invalid weather ID.")
+        return
     end
 
     -- invert weather table
-    local weatherByNum={};
+    local weatherByNum={}
     for k,v in pairs(weatherList) do
-        weatherByNum[v]=k;
+        weatherByNum[v]=k
     end
 
     -- set weather
-    player:setWeather( weather );
-    player:PrintToPlayer( string.format("Set weather to %s.", weatherByNum[weather]) );
+    player:setWeather( weather )
+    player:PrintToPlayer( string.format("Set weather to %s.", weatherByNum[weather]) )
 end

--- a/scripts/commands/spawnmob.lua
+++ b/scripts/commands/spawnmob.lua
@@ -7,38 +7,38 @@ cmdprops =
 {
     permission = 1,
     parameters = "iii"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!spawnmob <mob ID> {despawntime} {respawntime}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!spawnmob <mob ID> {despawntime} {respawntime}")
+end
 
 function onTrigger(player, mobId, despawntime, respawntime)
 
     -- validate mobId
     if (mobId == nil) then
-        error(player, "You must provide a mob ID.");
-        return;
+        error(player, "You must provide a mob ID.")
+        return
     end
-    local targ = GetMobByID(mobId);
+    local targ = GetMobByID(mobId)
     if (targ == nil) then
-        error(player, "Invalid mob ID.");
-        return;
+        error(player, "Invalid mob ID.")
+        return
     end
     
     -- validate despawntime
     if (despawntime ~= nil and despawntime < 0) then
-        error(player, "Invalid despawn time.");
-        return;
+        error(player, "Invalid despawn time.")
+        return
     end
 
     -- validate respawntime
     if (respawntime ~= nil and respawntime < 0) then
-        error(player, "Invalid respawn time.");
-        return;
+        error(player, "Invalid respawn time.")
+        return
     end
 
-    SpawnMob( targ:getID(), despawntime, respawntime );
-    player:PrintToPlayer( string.format("Spawned %s %s.", targ:getName(), targ:getID()) );
+    SpawnMob( targ:getID(), despawntime, respawntime )
+    player:PrintToPlayer( string.format("Spawned %s %s.", targ:getName(), targ:getID()) )
 end

--- a/scripts/commands/speed.lua
+++ b/scripts/commands/speed.lua
@@ -7,22 +7,22 @@ cmdprops =
 {
     permission = 1,
     parameters = "i"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!speed <0-255>");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!speed <0-255>")
+end
 
 function onTrigger(player, speed)
 
     -- validate speed amount
     if (speed == nil or speed < 0 or speed > 255) then
-        error(player, "Invalid speed amount.");
-        return;
-    end;
+        error(player, "Invalid speed amount.")
+        return
+    end
     
     -- set speed
-    player:speed( speed );
+    player:speed( speed )
     
 end

--- a/scripts/commands/takegil.lua
+++ b/scripts/commands/takegil.lua
@@ -7,39 +7,39 @@ cmdprops =
 {
     permission = 1,
     parameters = "is"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!takegil <amount> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!takegil <amount> {player}")
+end
 
 function onTrigger(player, amount, target)
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format("Player named '%s' not found!", target));
-            return;
+            error(player, string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
     -- validate amount
-    local oldAmount = targ:getGil();
+    local oldAmount = targ:getGil()
     if (amount == nil or amount < 1) then
-        error(player, "Invalid amount of gil.");
-        return;
+        error(player, "Invalid amount of gil.")
+        return
     end
     if (amount > oldAmount) then
-        amount = oldAmount;
+        amount = oldAmount
     end
 
     -- remove gil
-    targ:delGil(amount);
-    player:PrintToPlayer(string.format("Removed %i gil from %s.  They now have %i gil.", amount, targ:getName(), targ:getGil()));
+    targ:delGil(amount)
+    player:PrintToPlayer(string.format("Removed %i gil from %s.  They now have %i gil.", amount, targ:getName(), targ:getGil()))
 
-end;
+end

--- a/scripts/commands/takexp.lua
+++ b/scripts/commands/takexp.lua
@@ -7,35 +7,35 @@ cmdprops =
 {
     permission = 1,
     parameters = "is"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!takexp <amount> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!takexp <amount> {player}")
+end
 
 function onTrigger(player, amount, target)
 
     -- validate amount
     if (amount == nil or amount < 1) then
-        error(player, "Invalid amount.");
-        return;
+        error(player, "Invalid amount.")
+        return
     end
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format("Player named '%s' not found!", target));
-            return;
+            error(player, string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
     -- take xp
-    targ:delExp(amount);
-    player:PrintToPlayer( string.format( "Removed %i exp from %s. They are now level %i.", amount, targ:getName(), targ:getMainLvl() ));
+    targ:delExp(amount)
+    player:PrintToPlayer( string.format( "Removed %i exp from %s. They are now level %i.", amount, targ:getName(), targ:getMainLvl() ))
 
-end;
+end

--- a/scripts/commands/timeoffset.lua
+++ b/scripts/commands/timeoffset.lua
@@ -7,25 +7,25 @@ cmdprops =
 {
     permission = 1,
     parameters = "i"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!timeoffset <offset>");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!timeoffset <offset>")
+end
 
 function onTrigger(player, offset)
 
     -- validate offset
     if (offset == nil) then
-        error(player, "Invalid offset.");
-        return;
+        error(player, "Invalid offset.")
+        return
     end
 
     -- time offset
-    local result = SetVanadielTimeOffset( offset );
+    local result = SetVanadielTimeOffset( offset )
     if (result == nil) then
-        error(player, "Time offset was not successful.");
-        return;
+        error(player, "Time offset was not successful.")
+        return
     end
 end

--- a/scripts/commands/togglegm.lua
+++ b/scripts/commands/togglegm.lua
@@ -7,43 +7,43 @@ cmdprops =
 {
     permission = 1,
     parameters = ""
-};
+}
 
 function onTrigger(player)
     -- GM Flag Definitions
-    local FLAG_GM               = 0x04000000;
-    local FLAG_GM_SENIOR        = 0x05000000;
-    local FLAG_GM_LEAD          = 0x06000000;
-    local FLAG_GM_PRODUCER      = 0x07000000;
-    local FLAG_SENIOR           = 0x01000000; -- Do NOT set these flags. These are here to
-    local FLAG_LEAD             = 0x02000000; -- ensure all GM status is removed.
+    local FLAG_GM               = 0x04000000
+    local FLAG_GM_SENIOR        = 0x05000000
+    local FLAG_GM_LEAD          = 0x06000000
+    local FLAG_GM_PRODUCER      = 0x07000000
+    local FLAG_SENIOR           = 0x01000000 -- Do NOT set these flags. These are here to
+    local FLAG_LEAD             = 0x02000000 -- ensure all GM status is removed.
 
     -- Configurable Options
-    local MINLVL_GM             = 1; -- For "whitelisting" players to have some commands, but not GM tier commands.
-    local MINLVL_GM_SENIOR      = 2; -- These are configurable so that commands may be restricted
-    local MINLVL_GM_LEAD        = 3; -- between different levels of GM's with the same icon.
-    local MINLVL_GM_PRODUCER    = 4;
+    local MINLVL_GM             = 1 -- For "whitelisting" players to have some commands, but not GM tier commands.
+    local MINLVL_GM_SENIOR      = 2 -- These are configurable so that commands may be restricted
+    local MINLVL_GM_LEAD        = 3 -- between different levels of GM's with the same icon.
+    local MINLVL_GM_PRODUCER    = 4
 
     if (player:checkNameFlags(FLAG_GM)) then
         if (player:checkNameFlags(FLAG_GM)) then
-            player:setFlag(FLAG_GM);
+            player:setFlag(FLAG_GM)
         end
         if (player:checkNameFlags(FLAG_SENIOR)) then
-            player:setFlag(FLAG_SENIOR);
+            player:setFlag(FLAG_SENIOR)
         end
         if (player:checkNameFlags(FLAG_LEAD)) then
-            player:setFlag(FLAG_LEAD);
+            player:setFlag(FLAG_LEAD)
         end
     else
-        local gmlvl = player:getGMLevel();
+        local gmlvl = player:getGMLevel()
         if (gmlvl >= MINLVL_GM_PRODUCER) then
-            player:setFlag(FLAG_GM_PRODUCER);
+            player:setFlag(FLAG_GM_PRODUCER)
         elseif (gmlvl >= MINLVL_GM_LEAD) then
-            player:setFlag(FLAG_GM_LEAD);
+            player:setFlag(FLAG_GM_LEAD)
         elseif (gmlvl >= MINLVL_GM_SENIOR) then
-            player:setFlag(FLAG_GM_SENIOR);
+            player:setFlag(FLAG_GM_SENIOR)
         elseif (gmlvl >= MINLVL_GM) then
-            player:setFlag(FLAG_GM);
+            player:setFlag(FLAG_GM)
         end
     end
 end

--- a/scripts/commands/tp.lua
+++ b/scripts/commands/tp.lua
@@ -7,43 +7,43 @@ cmdprops =
 {
     permission = 1,
     parameters = "is"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!tp <amount> {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!tp <amount> {player}")
+end
 
 function onTrigger(player, tp, target)
 
     -- validate amount
     if (tp == nil or tonumber(tp) == nil) then
-        error(player, "You must provide an amount.");
-        return;
+        error(player, "You must provide an amount.")
+        return
     elseif (tp < 0) then
-        error(player, "Invalid amount.");
-        return;
+        error(player, "Invalid amount.")
+        return
     end
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format( "Player named '%s' not found!", target ) );
-            return;
+            error(player, string.format( "Player named '%s' not found!", target ) )
+            return
         end
     end
 
     -- set tp
-    targ:setTP( tp );
-    local pet = targ:getPet();
+    targ:setTP( tp )
+    local pet = targ:getPet()
     if (pet ~= nil) then
-        pet:setTP( tp );
+        pet:setTP( tp )
     end
     if(targ:getID() ~= player:getID()) then
-        player:PrintToPlayer(string.format("Set %s's TP to %i.", targ:getName(), targ:getTP()));
+        player:PrintToPlayer(string.format("Set %s's TP to %i.", targ:getName(), targ:getTP()))
     end
-end;
+end

--- a/scripts/commands/updateconquest.lua
+++ b/scripts/commands/updateconquest.lua
@@ -3,25 +3,25 @@
 -- desc: Updates all conquest guard. (Need modify in db first.)
 ---------------------------------------------------------------------------------------------------
 
-require("scripts/globals/conquest");
+require("scripts/globals/conquest")
 
 cmdprops =
 {
     permission = 1,
     parameters = "i"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!updateconquest <type>");
-    player:PrintToPlayer("Type: 0 = Conquest_Tally_Start, 1 = Conquest_Tally_End, 2 = Conquest_Update");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!updateconquest <type>")
+    player:PrintToPlayer("Type: 0 = Conquest_Tally_Start, 1 = Conquest_Tally_End, 2 = Conquest_Update")
+end
 
 function onTrigger(player, updatetype)
     if (updatetype == nil or updatetype < 0 or updatetype > 2) then
-        error(player, "Invalid update type.");
-        return;
+        error(player, "Invalid update type.")
+        return
     end
     
-    WeekUpdateConquest(updatetype);
+    WeekUpdateConquest(updatetype)
 end

--- a/scripts/commands/updateservermessage.lua
+++ b/scripts/commands/updateservermessage.lua
@@ -7,8 +7,8 @@ cmdprops =
 {
     permission = 1,
     parameters = ""
-};
+}
 
 function onTrigger(player)
-    UpdateServerMessage();
+    UpdateServerMessage()
 end

--- a/scripts/commands/wallhack.lua
+++ b/scripts/commands/wallhack.lua
@@ -7,33 +7,33 @@ cmdprops =
 {
     permission = 1,
     parameters = "s"
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!wallhack {player}");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!wallhack {player}")
+end
 
 function onTrigger(player, target)
 
     -- validate target
-    local targ;
+    local targ
     if (target == nil) then
-        targ = player;
+        targ = player
     else
-        targ = GetPlayerByName(target);
+        targ = GetPlayerByName(target)
         if (targ == nil) then
-            error(player, string.format("Player named '%s' not found!", target));
-            return;
+            error(player, string.format("Player named '%s' not found!", target))
+            return
         end
     end
 
     -- toggle wallhack for target
     if (targ:checkNameFlags(0x00000200)) then
-        targ:setFlag(0x00000200);
-        player:PrintToPlayer( string.format("Toggled %s's wallhack flag OFF.", targ:getName()) );
+        targ:setFlag(0x00000200)
+        player:PrintToPlayer( string.format("Toggled %s's wallhack flag OFF.", targ:getName()) )
     else
-        targ:setFlag(0x00000200);
-        player:PrintToPlayer( string.format("Toggled %s's wallhack flag ON.", targ:getName()) );
+        targ:setFlag(0x00000200)
+        player:PrintToPlayer( string.format("Toggled %s's wallhack flag ON.", targ:getName()) )
     end
 end

--- a/scripts/commands/where.lua
+++ b/scripts/commands/where.lua
@@ -7,8 +7,8 @@ cmdprops =
 {
     permission = 1,
     parameters = ""
-};
+}
 
 function onTrigger(player)
-    player:showPosition();
+    player:showPosition()
 end

--- a/scripts/commands/zone.lua
+++ b/scripts/commands/zone.lua
@@ -2,13 +2,13 @@
 -- func: zone
 -- desc: Teleports a player to the given zone.
 ---------------------------------------------------------------------------------------------------
-require("scripts/globals/zone");
+require("scripts/globals/zone")
 
 cmdprops =
 {
     permission = 1,
     parameters = "b"
-};
+}
 
 ---------------------------------------------------------------------------------------------------
 -- desc: List of zones with their auto-translated group and message id.
@@ -274,80 +274,80 @@ local zone_list =
     { 0x27, 0x59, 284 }, -- Celennia Memorial Library
     { 0x27, 0x5B, 285 }, -- Feretory
     { 0x14, 0x09, 288 }, -- Escha - Zi'Tah
-};
+}
 
 function error(player, msg)
-    player:PrintToPlayer(msg);
-    player:PrintToPlayer("!zone <zone ID or autotranslate phrase>");
-end;
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!zone <zone ID or autotranslate phrase>")
+end
 
 function getBytePos(s,needle)
-    local i;
-    local b;
+    local i
+    local b
     for i=1,string.len(s),1 do
         if (string.byte(s, i) == needle) then
-            return i;
+            return i
         end
     end
-    return nil;
-end;
+    return nil
+end
 
 ---------------------------------------------------------------------------------------------------
 -- func: onTrigger
 -- desc: Called when this command is invoked.
 ---------------------------------------------------------------------------------------------------
 function onTrigger(player, bytes)
-    local x = 0;
-    local y = 0;
-    local z = 0;
-    local rot = 0;
-    local zone;
+    local x = 0
+    local y = 0
+    local z = 0
+    local rot = 0
+    local zone
 
     if (bytes == nil) then
-        error(player, "You must provide a zone ID or autotranslate phrase.");
-        return;
+        error(player, "You must provide a zone ID or autotranslate phrase.")
+        return
     end
-    bytes = string.sub(bytes,6);
-    local atpos = getBytePos(bytes, 253);
+    bytes = string.sub(bytes,6)
+    local atpos = getBytePos(bytes, 253)
 
     -- validate destination
     if (atpos ~= nil) then
         -- destination is an auto-translate phrase
-        local groupId = string.byte(bytes, atpos + 3);
-        local messageId = string.byte(bytes, atpos + 4);
+        local groupId = string.byte(bytes, atpos + 3)
+        local messageId = string.byte(bytes, atpos + 4)
         for k, v in pairs(zone_list) do
             if (v[1] == groupId and v[2] == messageId) then
-                x = v[4] or 0;
-                y = v[5] or 0;
-                z = v[6] or 0;
-                rot = 0;
-                zone = v[3];
-                break;
+                x = v[4] or 0
+                y = v[5] or 0
+                z = v[6] or 0
+                rot = 0
+                zone = v[3]
+                break
             end
         end
         if (zone == nil) then
-            error(player,"Auto-translated phrase is not a zone.");
-            return;
+            error(player,"Auto-translated phrase is not a zone.")
+            return
         end
     else
         -- destination is a zone ID.
-        zone = tonumber(bytes);
+        zone = tonumber(bytes)
         if (zone == nil or zone < 0 or zone >= tpz.zone.MAX_ZONE) then
-            error(player, "Invalid zone ID.");
-            return;
+            error(player, "Invalid zone ID.")
+            return
         end
         for k, v in pairs(zone_list) do
             if (v[3] == zone) then
-                x = v[4] or 0;
-                y = v[5] or 0;
-                z = v[6] or 0;
-                rot = 0;
-                zone = v[3];
-                break;
+                x = v[4] or 0
+                y = v[5] or 0
+                z = v[6] or 0
+                rot = 0
+                zone = v[3]
+                break
             end
         end
     end
 
     -- send player to destination
-    player:setPos(x, y, z, rot, zone);
+    player:setPos(x, y, z, rot, zone)
 end


### PR DESCRIPTION
This may not actually be every file, but I did the best I could.

Command applied:
    find . -type f -name "*.lua" | xargs -d '\n' sed -i 's/;//g'

Semicolons are not appropriate in Lua per the style guidelines:
    https://github.com/project-topaz/topaz/blob/master/CONTRIBUTING.md

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](https://github.com/project-topaz/topaz/blob/master/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

