### PR TITLE
Bulk remove semicolons from Lua in scripts/mixins.

### DIFF
--- a/scripts/mixins/families/amphiptere.lua
+++ b/scripts/mixins/families/amphiptere.lua
@@ -7,19 +7,19 @@ g_mixins.families = g_mixins.families or {}
 
 g_mixins.families.amphiptere = function(mob)
     mob:addListener("SPAWN", "AMPHIPTERE_SPAWN", function(mob)
-        mob:hideName(true);
-        mob:untargetable(true);
-        mob:AnimationSub(1);
+        mob:hideName(true)
+        mob:untargetable(true)
+        mob:AnimationSub(1)
     end)
     mob:addListener("ENGAGE", "AMPHIPTERE_ENGAGE", function(mob, target)
-        mob:hideName(false);
-        mob:untargetable(false);
-        mob:AnimationSub(0);
+        mob:hideName(false)
+        mob:untargetable(false)
+        mob:AnimationSub(0)
     end)
     mob:addListener("DISENGAGE", "AMPHIPTERE_DISENGAGE", function(mob, target)
-        mob:hideName(true);
-        mob:untargetable(true);
-        mob:AnimationSub(1);
+        mob:hideName(true)
+        mob:untargetable(true)
+        mob:AnimationSub(1)
     end)
 end
 

--- a/scripts/mixins/families/antlion_ambush.lua
+++ b/scripts/mixins/families/antlion_ambush.lua
@@ -7,19 +7,19 @@ g_mixins.families = g_mixins.families or {}
 
 g_mixins.families.antlion_ambush = function(mob)
     mob:addListener("SPAWN", "ANTLION_AMBUSH_SPAWN", function(mob)
-        mob:hideName(true);
-        mob:untargetable(true);
-        mob:AnimationSub(0);
-        mob:wait(2000);
+        mob:hideName(true)
+        mob:untargetable(true)
+        mob:AnimationSub(0)
+        mob:wait(2000)
     end)
     mob:addListener("ENGAGE", "ANTLION_AMBUSH_ENGAGE", function(mob, target)
-        mob:useMobAbility(278); -- Pit Ambush
+        mob:useMobAbility(278) -- Pit Ambush
     end)
     mob:addListener("DISENGAGE", "ANTLION_AMBUSH_DISENGAGE", function(mob)
-        mob:hideName(true);
-        mob:untargetable(true);
-        mob:AnimationSub(0);
-        mob:wait(2000);
+        mob:hideName(true)
+        mob:untargetable(true)
+        mob:AnimationSub(0)
+        mob:wait(2000)
     end)
 end
 

--- a/scripts/mixins/families/antlion_ambush_noaggro.lua
+++ b/scripts/mixins/families/antlion_ambush_noaggro.lua
@@ -11,12 +11,12 @@ g_mixins.families = g_mixins.families or {}
 
 g_mixins.families.antlion_ambush_noaggro = function(mob)
     mob:addListener("SPAWN", "ANTLION_AMBUSH_NOAGGRO_SPAWN", function(mob)
-        mob:hideName(true);
-        mob:untargetable(true);
-        mob:AnimationSub(0);
+        mob:hideName(true)
+        mob:untargetable(true)
+        mob:AnimationSub(0)
     end)
     mob:addListener("ENGAGE", "ANTLION_AMBUSH_NOAGGRO_ENGAGE", function(mob, target)
-        mob:useMobAbility(278); -- Pit Ambush
+        mob:useMobAbility(278) -- Pit Ambush
     end)
 end
 

--- a/scripts/mixins/families/avatar.lua
+++ b/scripts/mixins/families/avatar.lua
@@ -5,38 +5,38 @@ g_mixins.families = g_mixins.families or {}
 
 g_mixins.families.avatar = function(mob)
     mob:addListener("SPAWN", "AVATAR_SPAWN", function(mob)
-        mob:setModelId(math.random(791, 798));
-        mob:hideName(false);
-        mob:untargetable(true);
-        mob:setUnkillable(true);
-        mob:SetAutoAttackEnabled(false);
-        mob:SetMagicCastingEnabled(false);
+        mob:setModelId(math.random(791, 798))
+        mob:hideName(false)
+        mob:untargetable(true)
+        mob:setUnkillable(true)
+        mob:SetAutoAttackEnabled(false)
+        mob:SetMagicCastingEnabled(false)
     end)
 
     mob:addListener("ENGAGE", "AVATAR_ENGAGE", function(mob, target)
-        local abilityID = nil;
-        local modelID = mob:getModelId();
+        local abilityID = nil
+        local modelID = mob:getModelId()
 
         switch (modelID) : caseof
         {
-             [791] = function (x) abilityID = 919; end, -- Carbuncle
-             [792] = function (x) abilityID = 839; end, -- Fenrir
-             [793] = function (x) abilityID = 913; end, -- Ifrit
-             [794] = function (x) abilityID = 914; end, -- Titan
-             [795] = function (x) abilityID = 915; end, -- Leviathan
-             [796] = function (x) abilityID = 916; end, -- Garuda
-             [797] = function (x) abilityID = 917; end, -- Shiva
-             [798] = function (x) abilityID = 918; end, -- Ramuh
+             [791] = function (x) abilityID = 919 end, -- Carbuncle
+             [792] = function (x) abilityID = 839 end, -- Fenrir
+             [793] = function (x) abilityID = 913 end, -- Ifrit
+             [794] = function (x) abilityID = 914 end, -- Titan
+             [795] = function (x) abilityID = 915 end, -- Leviathan
+             [796] = function (x) abilityID = 916 end, -- Garuda
+             [797] = function (x) abilityID = 917 end, -- Shiva
+             [798] = function (x) abilityID = 918 end, -- Ramuh
         }
 
         if (abilityID ~= nil) then
-            mob:useMobAbility(abilityID);
+            mob:useMobAbility(abilityID)
         end
     end)
 
     mob:addListener("WEAPONSKILL_STATE_EXIT", "AVATAR_MOBSKILL_FINISHED", function(mob)
-        mob:setUnkillable(false);
-        mob:setHP(0);
+        mob:setUnkillable(false)
+        mob:setHP(0)
     end)
 end
 

--- a/scripts/mixins/families/chigoe.lua
+++ b/scripts/mixins/families/chigoe.lua
@@ -7,16 +7,16 @@ g_mixins.families = g_mixins.families or {}
 
 g_mixins.families.chigoe = function(mob)
     mob:addListener("SPAWN", "CHIGOE_SPAWN", function(mob)
-        mob:hideName(true);
-        mob:untargetable(true);
+        mob:hideName(true)
+        mob:untargetable(true)
     end)
     mob:addListener("ENGAGE", "CHIGOE_ENGAGE", function(mob, target)
-        mob:hideName(false);
-        mob:untargetable(false);
+        mob:hideName(false)
+        mob:untargetable(false)
     end)
     mob:addListener("DISENGAGE", "CHIGOE_DISENGAGE", function(mob, target)
-        mob:hideName(true);
-        mob:untargetable(true);
+        mob:hideName(true)
+        mob:untargetable(true)
     end)
 end
 

--- a/scripts/mixins/families/gears.lua
+++ b/scripts/mixins/families/gears.lua
@@ -7,30 +7,30 @@ g_mixins = g_mixins or {}
 g_mixins.gears = function(mob)
 
     mob:addListener("COMBAT_TICK", "GEARS_CTICK", function(mob)
-        local mobHPP = mob:getHPP();
+        local mobHPP = mob:getHPP()
         if (mobHPP >= 26 and mobHPP <= 49) then
             if mob:AnimationSub() ~= 1 then
-                mob:AnimationSub(1); -- double gear
+                mob:AnimationSub(1) -- double gear
                 mob:setMobMod(tpz.mobMod.SKILL_LIST, 151)
             end
         if mob:getLocalVar("Def1") == 0 then
-            mob:delMod(tpz.mod.MDEF, 10);
-            mob:delMod(tpz.mod.DEF, 20);
-            mob:setLocalVar("Def1",1);
+            mob:delMod(tpz.mod.MDEF, 10)
+            mob:delMod(tpz.mod.DEF, 20)
+            mob:setLocalVar("Def1",1)
         end
         elseif mobHPP <= 25 then
             if mob:AnimationSub() ~= 2 then
-                mob:AnimationSub(2); -- single gear
+                mob:AnimationSub(2) -- single gear
                 mob:setMobMod(tpz.mobMod.SKILL_LIST, 152)
             end
             if mob:getLocalVar("Def2") == 0 then
-                mob:delMod(tpz.mod.MDEF, 10);
-                mob:delMod(tpz.mod.DEF, 20);
-                mob:setLocalVar("Def2",1);
+                mob:delMod(tpz.mod.MDEF, 10)
+                mob:delMod(tpz.mod.DEF, 20)
+                mob:setLocalVar("Def2",1)
             end
         elseif mobHPP > 50 then
             if mob:AnimationSub() ~= 0 then
-                mob:AnimationSub(0); -- tripple gear
+                mob:AnimationSub(0) -- tripple gear
                 mob:setMobMod(tpz.mobMod.SKILL_LIST, 150)
             end
         end

--- a/scripts/mixins/families/phuabo.lua
+++ b/scripts/mixins/families/phuabo.lua
@@ -7,22 +7,22 @@ g_mixins.families = g_mixins.families or {}
 
 g_mixins.families.phuabo = function(mob)
     mob:addListener("SPAWN", "PHUABO_SPAWN", function(mob)
-        mob:hideName(true);
-        mob:untargetable(true);
-        mob:AnimationSub(5);
-        mob:wait(2000);
+        mob:hideName(true)
+        mob:untargetable(true)
+        mob:AnimationSub(5)
+        mob:wait(2000)
     end)
     mob:addListener("ENGAGE", "PHUABO_ENGAGE", function(mob, target)
-        mob:hideName(false);
-        mob:untargetable(false);
-        mob:AnimationSub(6);
-        mob:wait(2000);
+        mob:hideName(false)
+        mob:untargetable(false)
+        mob:AnimationSub(6)
+        mob:wait(2000)
     end)
     mob:addListener("DISENGAGE", "PHUABO_DISENGAGE", function(mob, target)
-        mob:hideName(true);
-        mob:untargetable(true);
-        mob:AnimationSub(5);
-        mob:wait(2000);
+        mob:hideName(true)
+        mob:untargetable(true)
+        mob:AnimationSub(5)
+        mob:wait(2000)
     end)
 end
 

--- a/scripts/mixins/fomor_hate.lua
+++ b/scripts/mixins/fomor_hate.lua
@@ -8,7 +8,7 @@ g_mixins.fomor_hate = function(mob)
         if player then
             local hate = player:getCharVar("FOMOR_HATE")
             local adj = mob:getLocalVar("fomorHateAdj")
-            if (adj == 0) then adj = 2 end; -- most fomor add 2 hate
+            if (adj == 0) then adj = 2 end -- most fomor add 2 hate
             player:setCharVar("FOMOR_HATE", utils.clamp(hate + adj, 0, 60))
         end
     end)

--- a/scripts/mixins/spawn_casket.lua
+++ b/scripts/mixins/spawn_casket.lua
@@ -21,7 +21,7 @@ g_mixins.spawn_casket = function(mob)
         else
             tpz.caskets.spawnCasket(player, mob, mobPos.x, mobPos.y, mobPos.z, mobPos.rot)
         end
-    end);
+    end)
 end
 
 return g_mixins.spawn_casket


### PR DESCRIPTION
Command applied:
find . -type f -name "*.lua" | xargs -d '\n' sed -i 's/;//g'

Semicolons are not appropriate in Lua per the style guidelines:
https://github.com/project-topaz/topaz/blob/master/CONTRIBUTING.md

This change is just a style change, no functionality has been changed.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](https://github.com/project-topaz/topaz/blob/master/CONTRIBUTOR_AGREEMENT.md), as written on this date