### PR TITLE
Bulk remove semicolons from most of the Lua in scripts/globals.

### DIFF
--- a/scripts/globals/ability.lua
+++ b/scripts/globals/ability.lua
@@ -3,10 +3,10 @@
 -- ABILITIES
 --
 -----------------------------------
-require("scripts/globals/status");
-require("scripts/globals/msg");
+require("scripts/globals/status")
+require("scripts/globals/msg")
 
-tpz = tpz or {};
+tpz = tpz or {}
 
 tpz.jobAbility =
 {
@@ -428,8 +428,8 @@ tpz.jobAbility =
     CHAOTIC_STRIKE     = 614,
     THUNDERSTORM       = 615,
     JUDGMENT_BOLT      = 616,
-};
-tpz.ja = tpz.jobAbility;
+}
+tpz.ja = tpz.jobAbility
 
 tpz.reaction =
 {
@@ -440,7 +440,7 @@ tpz.reaction =
     HIT      = 0x08,
     EVADE    = 0x09,
     GUARD    = 0x14,
-};
+}
 
 tpz.specEffect =
 {
@@ -450,11 +450,11 @@ tpz.specEffect =
     RAISE          = 0x11,
     RECOIL         = 0x20,
     CRITICAL_HIT   = 0x22,
-};
+}
 
 function corsairSetup(caster, ability, action, effect, job)
-    local roll = math.random(1,6);
-    caster:delStatusEffectSilent(tpz.effect.DOUBLE_UP_CHANCE);
+    local roll = math.random(1,6)
+    caster:delStatusEffectSilent(tpz.effect.DOUBLE_UP_CHANCE)
     caster:addStatusEffectEx(tpz.effect.DOUBLE_UP_CHANCE,
                              tpz.effect.DOUBLE_UP_CHANCE,
                              roll,
@@ -463,9 +463,9 @@ function corsairSetup(caster, ability, action, effect, job)
                              ability:getID(),
                              effect,
                              job,
-                             true);
-    caster:setLocalVar("corsairRollTotal", roll);
-    action:speceffect(caster:getID(), roll);
+                             true)
+    caster:setLocalVar("corsairRollTotal", roll)
+    action:speceffect(caster:getID(), roll)
     if (checkForElevenRoll(caster)) then
         action:recast(action:recast()/2)
     end
@@ -474,16 +474,16 @@ function corsairSetup(caster, ability, action, effect, job)
 end
 
 function atMaxCorsairBusts(caster)
-    local numBusts = caster:numBustEffects();
-    return (numBusts >= 2 and caster:getMainJob() == tpz.job.COR) or (numBusts >= 1 and caster:getMainJob() ~= tpz.job.COR);
+    local numBusts = caster:numBustEffects()
+    return (numBusts >= 2 and caster:getMainJob() == tpz.job.COR) or (numBusts >= 1 and caster:getMainJob() ~= tpz.job.COR)
 end
 
 function checkForJobBonus(caster, job)
     local jobBonus = 0
     if (caster:hasPartyJob(job) or math.random(0, 99) < caster:getMod(tpz.mod.JOB_BONUS_CHANCE)) then
-        jobBonus = 1;
+        jobBonus = 1
     end
-    caster:setLocalVar("corsairRollBonus", jobBonus);
+    caster:setLocalVar("corsairRollBonus", jobBonus)
 end
 
 function checkForElevenRoll(caster)
@@ -503,87 +503,87 @@ function checkForElevenRoll(caster)
 end
 
 function phantombuffMultiple(caster) -- Check for tpz.mod.PHANTOM_ROLL Value and apply non-stack logic.
-    local phantomValue = caster:getMod(tpz.mod.PHANTOM_ROLL);
-    local phantombuffValue = 0;
+    local phantomValue = caster:getMod(tpz.mod.PHANTOM_ROLL)
+    local phantombuffValue = 0
     if (phantomValue == 3) then
-        phantombuffMultiplier = 3;
+        phantombuffMultiplier = 3
     elseif ((phantomValue == 5) or (phantomValue == 8)) then
-        phantombuffMultiplier = 5;
+        phantombuffMultiplier = 5
     elseif ((phantomValue == 7) or (phantomValue == 10) or (phantomValue == 12) or (phantomValue == 15)) then
-        phantombuffMultiplier = 7;
+        phantombuffMultiplier = 7
     else
-        phantombuffMultiplier = 0;
+        phantombuffMultiplier = 0
     end
 
-    return phantombuffMultiplier;
+    return phantombuffMultiplier
 end
 
 function AbilityFinalAdjustments(dmg,mob,skill,target,skilltype,skillparam,shadowbehav)
     -- physical attack missed, skip rest
     local msg = skill:getMsg()
     if (msg == 158 or msg == 188 or msg == 31 or msg == 30) then
-        return 0;
+        return 0
     end
 
     --handle pd
     if ((target:hasStatusEffect(tpz.effect.PERFECT_DODGE) or target:hasStatusEffect(tpz.effect.TOO_HIGH) )
             and skilltype == tpz.attackType.PHYSICAL) then
-        skill:setMsg(tpz.msg.basic.JA_MISS_2);
-        return 0;
+        skill:setMsg(tpz.msg.basic.JA_MISS_2)
+        return 0
     end
 
     -- set message to damage
     -- this is for AoE because its only set once
-    skill:setMsg(tpz.msg.basic.USES_JA_TAKE_DAMAGE);
+    skill:setMsg(tpz.msg.basic.USES_JA_TAKE_DAMAGE)
 
     --Handle shadows depending on shadow behaviour / skilltype
     if (shadowbehav ~= MOBPARAM_WIPE_SHADOWS and shadowbehav ~= MOBPARAM_IGNORE_SHADOWS) then --remove 'shadowbehav' shadows.
 
-        dmg = utils.takeShadows(target, dmg, shadowbehav);
+        dmg = utils.takeShadows(target, dmg, shadowbehav)
 
         -- dealt zero damage, so shadows took hit
         if (dmg == 0) then
-            skill:setMsg(tpz.msg.basic.SHADOW_ABSORB);
-            return shadowbehav;
+            skill:setMsg(tpz.msg.basic.SHADOW_ABSORB)
+            return shadowbehav
         end
 
     elseif (shadowbehav == MOBPARAM_WIPE_SHADOWS) then --take em all!
-        target:delStatusEffect(tpz.effect.COPY_IMAGE);
-        target:delStatusEffect(tpz.effect.BLINK);
-        target:delStatusEffect(tpz.effect.THIRD_EYE);
+        target:delStatusEffect(tpz.effect.COPY_IMAGE)
+        target:delStatusEffect(tpz.effect.BLINK)
+        target:delStatusEffect(tpz.effect.THIRD_EYE)
     end
 
     --handle Third Eye using shadowbehav as a guide
     if (skilltype == tpz.attackType.PHYSICAL and utils.thirdeye(target)) then
-        skill:setMsg(tpz.msg.basic.ANTICIPATE);
-        return 0;
+        skill:setMsg(tpz.msg.basic.ANTICIPATE)
+        return 0
     end
 
     if (skilltype == tpz.attackType.PHYSICAL) then
-        dmg = target:physicalDmgTaken(dmg, skillparam);
+        dmg = target:physicalDmgTaken(dmg, skillparam)
     elseif (skilltype == tpz.attackType.MAGICAL) then
-        dmg = target:magicDmgTaken(dmg);
+        dmg = target:magicDmgTaken(dmg)
     elseif (skilltype == tpz.attackType.BREATH) then
-        dmg = target:breathDmgTaken(dmg);
+        dmg = target:breathDmgTaken(dmg)
     elseif (skilltype == tpz.attackType.RANGED) then
-        dmg = target:rangedDmgTaken(dmg);
+        dmg = target:rangedDmgTaken(dmg)
     end
 
     --handling phalanx
-    dmg = dmg - target:getMod(tpz.mod.PHALANX);
+    dmg = dmg - target:getMod(tpz.mod.PHALANX)
 
     if (dmg < 0) then
-        return 0;
+        return 0
     end
 
-    dmg = utils.stoneskin(target, dmg);
+    dmg = utils.stoneskin(target, dmg)
 
     if (dmg > 0) then
-        target:wakeUp();
-        target:updateEnmityFromDamage(mob,dmg);
+        target:wakeUp()
+        target:updateEnmityFromDamage(mob,dmg)
     end
 
-    return dmg;
+    return dmg
 end
 
 
@@ -607,7 +607,7 @@ function takeAbilityDamage(defender, attacker, params, primary, finaldmg, attack
     end
     local targetTPMult = params.targetTPMult or 1
     finaldmg = defender:takeWeaponskillDamage(attacker, finaldmg, attackType, damageType, slot, primary, tpHitsLanded, (extraHitsLanded * 10) + bonusTP, targetTPMult)
-    local enmityEntity = taChar or attacker;
+    local enmityEntity = taChar or attacker
     if (params.overrideCE and params.overrideVE) then
         defender:addEnmity(enmityEntity, params.overrideCE, params.overrideVE)
     else
@@ -615,5 +615,5 @@ function takeAbilityDamage(defender, attacker, params, primary, finaldmg, attack
         defender:updateEnmityFromDamage(enmityEntity, finaldmg * enmityMult)
     end
 
-    return finaldmg;
+    return finaldmg
 end

--- a/scripts/globals/abyssea.lua
+++ b/scripts/globals/abyssea.lua
@@ -4,7 +4,7 @@
 -- or change things to "elseif"!
 -----------------------------------
 
-require("scripts/globals/keyitems");
+require("scripts/globals/keyitems")
 
 -- weaponskills for red weakness
 local red_weakness =
@@ -86,83 +86,83 @@ end
 function spendTravStones(player, spentstones)
     if (spentstones == 4) then
         if (player:hasKeyItem(tpz.ki.TRAVERSER_STONE6)) then
-            spentstones = 3;
-            player:delKeyItem(tpz.ki.TRAVERSER_STONE6);
+            spentstones = 3
+            player:delKeyItem(tpz.ki.TRAVERSER_STONE6)
         elseif (player:hasKeyItem(tpz.ki.TRAVERSER_STONE5)) then
-            spentstones = 3;
-            player:delKeyItem(tpz.ki.TRAVERSER_STONE5);
+            spentstones = 3
+            player:delKeyItem(tpz.ki.TRAVERSER_STONE5)
         elseif (player:hasKeyItem(tpz.ki.TRAVERSER_STONE4)) then
-            spentstones = 3;
-            player:delKeyItem(tpz.ki.TRAVERSER_STONE4);
+            spentstones = 3
+            player:delKeyItem(tpz.ki.TRAVERSER_STONE4)
         elseif (player:hasKeyItem(tpz.ki.TRAVERSER_STONE3)) then
-            spentstones = 3;
-            player:delKeyItem(tpz.ki.TRAVERSER_STONE3);
+            spentstones = 3
+            player:delKeyItem(tpz.ki.TRAVERSER_STONE3)
         elseif (player:hasKeyItem(tpz.ki.TRAVERSER_STONE2)) then
-            spentstones = 3;
-            player:delKeyItem(tpz.ki.TRAVERSER_STONE2);
+            spentstones = 3
+            player:delKeyItem(tpz.ki.TRAVERSER_STONE2)
         elseif (player:hasKeyItem(tpz.ki.TRAVERSER_STONE1)) then
-            spentstones = 3;
-            player:delKeyItem(tpz.ki.TRAVERSER_STONE1);
+            spentstones = 3
+            player:delKeyItem(tpz.ki.TRAVERSER_STONE1)
         end
     end
     if (spentstones == 3) then
         if (player:hasKeyItem(tpz.ki.TRAVERSER_STONE6)) then
-            spentstones = 2;
-            player:delKeyItem(tpz.ki.TRAVERSER_STONE6);
+            spentstones = 2
+            player:delKeyItem(tpz.ki.TRAVERSER_STONE6)
         elseif (player:hasKeyItem(tpz.ki.TRAVERSER_STONE5)) then
-            spentstones = 2;
-            player:delKeyItem(tpz.ki.TRAVERSER_STONE5);
+            spentstones = 2
+            player:delKeyItem(tpz.ki.TRAVERSER_STONE5)
         elseif (player:hasKeyItem(tpz.ki.TRAVERSER_STONE4)) then
-            spentstones = 2;
-            player:delKeyItem(tpz.ki.TRAVERSER_STONE4);
+            spentstones = 2
+            player:delKeyItem(tpz.ki.TRAVERSER_STONE4)
         elseif (player:hasKeyItem(tpz.ki.TRAVERSER_STONE3)) then
-            spentstones = 2;
-            player:delKeyItem(tpz.ki.TRAVERSER_STONE3);
+            spentstones = 2
+            player:delKeyItem(tpz.ki.TRAVERSER_STONE3)
         elseif (player:hasKeyItem(tpz.ki.TRAVERSER_STONE2)) then
-            spentstones = 2;
-            player:delKeyItem(tpz.ki.TRAVERSER_STONE2);
+            spentstones = 2
+            player:delKeyItem(tpz.ki.TRAVERSER_STONE2)
         elseif (player:hasKeyItem(tpz.ki.TRAVERSER_STONE1)) then
-            spentstones = 2;
-            player:delKeyItem(tpz.ki.TRAVERSER_STONE1);
+            spentstones = 2
+            player:delKeyItem(tpz.ki.TRAVERSER_STONE1)
         end
     end
     if (spentstones == 2) then
         if (player:hasKeyItem(tpz.ki.TRAVERSER_STONE6)) then
-            spentstones = 1;
-            player:delKeyItem(tpz.ki.TRAVERSER_STONE6);
+            spentstones = 1
+            player:delKeyItem(tpz.ki.TRAVERSER_STONE6)
         elseif (player:hasKeyItem(tpz.ki.TRAVERSER_STONE5)) then
-            spentstones = 1;
-            player:delKeyItem(tpz.ki.TRAVERSER_STONE5);
+            spentstones = 1
+            player:delKeyItem(tpz.ki.TRAVERSER_STONE5)
         elseif (player:hasKeyItem(tpz.ki.TRAVERSER_STONE4)) then
-            spentstones = 1;
-            player:delKeyItem(tpz.ki.TRAVERSER_STONE4);
+            spentstones = 1
+            player:delKeyItem(tpz.ki.TRAVERSER_STONE4)
         elseif (player:hasKeyItem(tpz.ki.TRAVERSER_STONE3)) then
-            spentstones = 1;
-            player:delKeyItem(tpz.ki.TRAVERSER_STONE3);
+            spentstones = 1
+            player:delKeyItem(tpz.ki.TRAVERSER_STONE3)
         elseif (player:hasKeyItem(tpz.ki.TRAVERSER_STONE2)) then
-            spentstones = 1;
-            player:delKeyItem(tpz.ki.TRAVERSER_STONE2);
+            spentstones = 1
+            player:delKeyItem(tpz.ki.TRAVERSER_STONE2)
         elseif (player:hasKeyItem(tpz.ki.TRAVERSER_STONE1)) then
-            spentstones = 1;
-            player:delKeyItem(tpz.ki.TRAVERSER_STONE1);
+            spentstones = 1
+            player:delKeyItem(tpz.ki.TRAVERSER_STONE1)
         end
     end
     if (spentstones == 1) then
         if (player:hasKeyItem(tpz.ki.TRAVERSER_STONE6)) then
-            player:delKeyItem(tpz.ki.TRAVERSER_STONE6);
+            player:delKeyItem(tpz.ki.TRAVERSER_STONE6)
         elseif (player:hasKeyItem(tpz.ki.TRAVERSER_STONE5)) then
-            player:delKeyItem(tpz.ki.TRAVERSER_STONE5);
+            player:delKeyItem(tpz.ki.TRAVERSER_STONE5)
         elseif (player:hasKeyItem(tpz.ki.TRAVERSER_STONE4)) then
-            player:delKeyItem(tpz.ki.TRAVERSER_STONE4);
+            player:delKeyItem(tpz.ki.TRAVERSER_STONE4)
         elseif (player:hasKeyItem(tpz.ki.TRAVERSER_STONE3)) then
-            player:delKeyItem(tpz.ki.TRAVERSER_STONE3);
+            player:delKeyItem(tpz.ki.TRAVERSER_STONE3)
         elseif (player:hasKeyItem(tpz.ki.TRAVERSER_STONE2)) then
-            player:delKeyItem(tpz.ki.TRAVERSER_STONE2);
+            player:delKeyItem(tpz.ki.TRAVERSER_STONE2)
         elseif (player:hasKeyItem(tpz.ki.TRAVERSER_STONE1)) then
-            player:delKeyItem(tpz.ki.TRAVERSER_STONE1);
+            player:delKeyItem(tpz.ki.TRAVERSER_STONE1)
         end
     end
-end;
+end
 
 -- returns total "Abyssite of <thing>"
 function getAbyssiteTotal(player, abyssite)
@@ -195,43 +195,43 @@ end
 
 -- returns total value of Demulune KeyItems
 function getDemiluneAbyssite(player)
-    local Demilune = 0;
+    local Demilune = 0
     -- Todo: change this into proper bitmask
     if (player:hasKeyItem(tpz.ki.CLEAR_DEMILUNE_ABYSSITE)) then
-        Demilune = Demilune + 1;
+        Demilune = Demilune + 1
     end
     if (player:hasKeyItem(tpz.ki.COLORFUL_DEMILUNE_ABYSSITE)) then
-        Demilune = Demilune + 2;
+        Demilune = Demilune + 2
     end
     if (player:hasKeyItem(tpz.ki.SCARLET_DEMILUNE_ABYSSITE)) then
-        Demilune = Demilune + 4;
+        Demilune = Demilune + 4
     end
     if (player:hasKeyItem(tpz.ki.AZURE_DEMILUNE_ABYSSITE)) then
-        Demilune = Demilune + 8;
+        Demilune = Demilune + 8
     end
     if (player:hasKeyItem(tpz.ki.VIRIDIAN_DEMILUNE_ABYSSITE)) then
-        Demilune = Demilune + 16;
+        Demilune = Demilune + 16
     end
     if (player:hasKeyItem(tpz.ki.JADE_DEMILUNE_ABYSSITE)) then
-        Demilune = Demilune + 32;
+        Demilune = Demilune + 32
     end
     if (player:hasKeyItem(tpz.ki.SAPPHIRE_DEMILUNE_ABYSSITE)) then
-        Demilune = Demilune + 64;
+        Demilune = Demilune + 64
     end
     if (player:hasKeyItem(tpz.ki.CRIMSON_DEMILUNE_ABYSSITE)) then
-        Demilune = Demilune + 128;
+        Demilune = Demilune + 128
     end
     if (player:hasKeyItem(tpz.ki.EMERALD_DEMILUNE_ABYSSITE)) then
-        Demilune = Demilune + 256;
+        Demilune = Demilune + 256
     end
     if (player:hasKeyItem(tpz.ki.VERMILLION_DEMILUNE_ABYSSITE)) then
-        Demilune = Demilune + 512;
+        Demilune = Demilune + 512
     end
     if (player:hasKeyItem(tpz.ki.INDIGO_DEMILUNE_ABYSSITE)) then
-        Demilune = Demilune + 1024;
+        Demilune = Demilune + 1024
     end
-    return Demilune;
-end;
+    return Demilune
+end
 
 function getNewYellowWeakness(mob)
     local day = VanadielDayElement()
@@ -275,36 +275,36 @@ function abysseaOnTrade(player,npc,trade)
     local zoneId = player:getZoneID()
     local pop = zones[zoneId].npc.QM_POPS[npc:getID()]
     if (pop == nil) then
-        return false;
+        return false
     end
 
     -- validate trade-to-pop
-    local reqTrade = pop[2];
+    local reqTrade = pop[2]
     if (#reqTrade == 0 or trade:getItemCount() ~= #reqTrade) then
-        return false;
+        return false
     end
 
     -- validate traded items
     for k, v in pairs(reqTrade) do
         if (not trade:hasItemQty(v,1)) then
-            return false;
+            return false
         end
     end
 
     -- validate nm status
-    local nm = pop[4];
+    local nm = pop[4]
     if (GetMobByID(nm):isSpawned()) then
-        return false;
+        return false
     end
 
     -- complete trade and pop nm
-    player:tradeComplete();
-    local dx = player:getXPos() + math.random(-1,1);
-    local dy = player:getYPos();
-    local dz = player:getZPos() + math.random(-1,1);
-    GetMobByID(nm):setSpawn(dx,dy,dz);
-    SpawnMob(nm):updateClaim(player);
-    return true;
+    player:tradeComplete()
+    local dx = player:getXPos() + math.random(-1,1)
+    local dy = player:getYPos()
+    local dz = player:getZPos() + math.random(-1,1)
+    GetMobByID(nm):setSpawn(dx,dy,dz)
+    SpawnMob(nm):updateClaim(player)
+    return true
 end
 
 function abysseaOnTrigger(player,npc)
@@ -313,89 +313,89 @@ function abysseaOnTrigger(player,npc)
     local events = POP_EVENTS[zoneId]
     local pop = zones[zoneId].npc.QM_POPS[npc:getID()]
     if (pop == nil) then
-        return false;
+        return false
     end
 
     -- validate nm status
-    local nm = pop[4];
+    local nm = pop[4]
     if (GetMobByID(nm):isSpawned()) then
-        return false;
+        return false
     end
 
     -- validate trade-to-pop
-    local t = pop[2];
+    local t = pop[2]
     if (#t > 0) then
         for i = 1, 8, 1 do
             if (t[i] == nil) then
-                t[i] = 0;
+                t[i] = 0
             end
         end
-        player:startEvent(events[1],t[1],t[2],t[3],t[4],t[5],t[6],t[7],t[8]); -- report required trades
-        return true;
+        player:startEvent(events[1],t[1],t[2],t[3],t[4],t[5],t[6],t[7],t[8]) -- report required trades
+        return true
     end
 
     -- validate ki-to-pop
-    local kis = pop[3];
+    local kis = pop[3]
     if (#kis == 0) then
-        return false;
+        return false
     end
 
     -- validate kis
-    local validKis = true;
+    local validKis = true
     for k, v in pairs(kis) do
         if (not player:hasKeyItem(v)) then
-            validKis = false;
-            break;
+            validKis = false
+            break
         end
     end
 
     -- infill kis
     for i = 1, 8, 1 do
         if (kis[i] == nil) then
-            kis[i] = 0;
+            kis[i] = 0
         end
     end
 
     -- start event
     if (validKis) then
-        player:setLocalVar("abysseaQM", npc:getID());
-        player:startEvent(events[2],kis[1],kis[2],kis[3],kis[4],kis[5],kis[6],kis[7],kis[8]); -- player has all key items
-        return true;
+        player:setLocalVar("abysseaQM", npc:getID())
+        player:startEvent(events[2],kis[1],kis[2],kis[3],kis[4],kis[5],kis[6],kis[7],kis[8]) -- player has all key items
+        return true
     else
-        player:startEvent(events[3],kis[1],kis[2],kis[3],kis[4],kis[5],kis[6],kis[7],kis[8]); -- player is missing key items
-        return false;
+        player:startEvent(events[3],kis[1],kis[2],kis[3],kis[4],kis[5],kis[6],kis[7],kis[8]) -- player is missing key items
+        return false
     end
 end
 
 function abysseaOnEventUpdate(player,csid,option)
-    return false;
+    return false
 end
 
 function abysseaOnEventFinish(player,csid,option)
     local zoneId = player:getZoneID()
     local events = POP_EVENTS[zoneId]
     local pop = zones[zoneId].npc.QM_POPS[player:getLocalVar("abysseaQM")]
-    player:setLocalVar("abysseaQM", 0);
+    player:setLocalVar("abysseaQM", 0)
     if (pop == nil) then
-        return false;
+        return false
     end
 
     if (csid == events[2] and option == 1) then
         -- delete kis
-        local kis = pop[3];
+        local kis = pop[3]
         for k, v in pairs(kis) do
             if (player:hasKeyItem(v)) then
-                player:delKeyItem(v);
+                player:delKeyItem(v)
             end
         end
 
         -- pop nm
-        local nm = pop[4];
-        local dx = player:getXPos() + math.random(-1,1);
-        local dy = player:getYPos();
-        local dz = player:getZPos() + math.random(-1,1);
-        GetMobByID(nm):setSpawn(dx,dy,dz);
-        SpawnMob(nm):updateClaim(player);
-        return true;
+        local nm = pop[4]
+        local dx = player:getXPos() + math.random(-1,1)
+        local dy = player:getYPos()
+        local dz = player:getZPos() + math.random(-1,1)
+        GetMobByID(nm):setSpawn(dx,dy,dz)
+        SpawnMob(nm):updateClaim(player)
+        return true
     end
 end

--- a/scripts/globals/automatonweaponskills.lua
+++ b/scripts/globals/automatonweaponskills.lua
@@ -1,10 +1,10 @@
 -- Uses a mixture of mob and player WS formulas
-require("scripts/globals/weaponskills");
-require("scripts/globals/magicburst");
-require("scripts/globals/status");
-require("scripts/globals/utils");
-require("scripts/globals/magic");
-require("scripts/globals/msg");
+require("scripts/globals/weaponskills")
+require("scripts/globals/magicburst")
+require("scripts/globals/status")
+require("scripts/globals/utils")
+require("scripts/globals/magic")
+require("scripts/globals/msg")
 
 
 -- params contains: ftp100, ftp200, ftp300, str_wsc, dex_wsc, vit_wsc, int_wsc, mnd_wsc, canCrit, crit100, crit200, crit300, acc100, acc200, acc300, ignoresDef, ignore100, ignore200, ignore300, atkmulti, kick, accBonus, weaponType, weaponDamage
@@ -159,29 +159,29 @@ function doAutoRangedWeaponskill(attacker, target, wsID, wsParams, tp, primaryMs
 end
 
 function getAutoHitRate(attacker,defender,capHitRate,bonus,melee)
-    local acc = (melee and attacker:getACC() or attacker:getRACC()) + (bonus or 0);
-    local eva = defender:getEVA();
+    local acc = (melee and attacker:getACC() or attacker:getRACC()) + (bonus or 0)
+    local eva = defender:getEVA()
 
-    local levelbonus = 0;
+    local levelbonus = 0
     if (attacker:getMainLvl() > defender:getMainLvl()) then
-        levelbonus = 2 * (attacker:getMainLvl() - defender:getMainLvl());
+        levelbonus = 2 * (attacker:getMainLvl() - defender:getMainLvl())
     end
 
-    local hitrate = acc - eva + levelbonus + 75;
-    hitrate = hitrate/100;
+    local hitrate = acc - eva + levelbonus + 75
+    hitrate = hitrate/100
 
     -- Applying hitrate caps
     if (capHitRate) then -- this isn't capped for when acc varies with tp, as more penalties are due
-        hitrate = utils.clamp(hitrate, 0.2, 0.95);
+        hitrate = utils.clamp(hitrate, 0.2, 0.95)
     end
-    return hitrate;
-end;
+    return hitrate
+end
 
 -- Given the raw ratio value (atk/def) and levels, returns the cRatio (min then max)
 function getAutocRatio(attacker, defender, params, ignoredDef, melee)
     local cratio = (melee and attacker:getStat(tpz.mod.ATT) or attacker:getRATT()) * params.atkmulti / (defender:getStat(tpz.mod.DEF) - ignoredDef)
 
-    local levelbonus = 0;
+    local levelbonus = 0
     if attacker:getMainLvl() > defender:getMainLvl() then
         levelbonus = 0.05 * (attacker:getMainLvl() - defender:getMainLvl())
     end
@@ -237,9 +237,9 @@ function getAutocRatio(attacker, defender, params, ignoredDef, melee)
         elseif 0.5 <= cratio and cratio <= 0.7 then
             pdifmax = 1
         elseif 0.7 < cratio and cratio <= 1.2 then
-            pdifmax = cratio + 0.3;
+            pdifmax = cratio + 0.3
         elseif 1.2 < cratio and cratio <= 1.5 then
-            pdifmax = cratio * 0.25 + cratio;
+            pdifmax = cratio * 0.25 + cratio
         elseif 1.5 < cratio and cratio <= 2.625 then
             pdifmax = cratio + 0.375
         elseif 2.625 < cratio and cratio <= 3.25 then
@@ -260,7 +260,7 @@ function getAutocRatio(attacker, defender, params, ignoredDef, melee)
             pdifmin = cratio - 0.375
         end
 
-        local critbonus = attacker:getMod(tpz.mod.CRIT_DMG_INCREASE) - defender:getMod(tpz.mod.CRIT_DEF_BONUS);
+        local critbonus = attacker:getMod(tpz.mod.CRIT_DMG_INCREASE) - defender:getMod(tpz.mod.CRIT_DEF_BONUS)
         critbonus = utils.clamp(critbonus, 0, 100)
         pdifcrit[1] = pdifmin * (100 + critbonus) / 100
         pdifcrit[2] = pdifmax * (100 + critbonus) / 100
@@ -292,7 +292,7 @@ function getAutocRatio(attacker, defender, params, ignoredDef, melee)
         pdifmin = pdifmin * 1.25
         pdifmax = pdifmax * 1.25
 
-        local critbonus = attacker:getMod(tpz.mod.CRIT_DMG_INCREASE) - defender:getMod(tpz.mod.CRIT_DEF_BONUS);
+        local critbonus = attacker:getMod(tpz.mod.CRIT_DMG_INCREASE) - defender:getMod(tpz.mod.CRIT_DEF_BONUS)
         critbonus = utils.clamp(critbonus, 0, 100)
         pdifcrit[1] = pdifmin * (100 + critbonus) / 100
         pdifcrit[2] = pdifmax * (100 + critbonus) / 100

--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -117,15 +117,15 @@ function tpz.battlefield.SendTimePrompts(battlefield, players)
     players = players or battlefield:getPlayers()
 
     if lastTimeUpdate == 0 and remainingTime < 600 then
-        message = 600;
+        message = 600
     elseif lastTimeUpdate == 600 and remainingTime < 300 then
-        message = 300;
+        message = 300
     elseif lastTimeUpdate == 300 and remainingTime < 60 then
-        message = 60;
+        message = 60
     elseif lastTimeUpdate == 60 and remainingTime < 30 then
-        message = 30;
+        message = 30
     elseif lastTimeUpdate == 30 and remainingTime < 10 then
-        message = 10;
+        message = 10
     end
 
     if message ~= 0 then

--- a/scripts/globals/bcnm.lua
+++ b/scripts/globals/bcnm.lua
@@ -389,7 +389,7 @@ local battlefields = {
         { 6,  518, 1433},   -- Shattering Stars (DRK LB5)
         { 7,  519, 1435},   -- Shattering Stars (BRD LB5)
         { 8,  520, 1130},   -- Demolition Squad (BS60)
-     -- { 9,  521, 1552},   -- Die by the Sword (BS30) -- TODO: mob damage type rotation; mobskills furious flurry, smite of fury, whispers of ire
+     -- { 9,  521, 1552},   -- Die by the Sword (BS30) -- TODO: mob damage type rotation mobskills furious flurry, smite of fury, whispers of ire
         {10,  522, 1552},   -- Let Sleeping Dogs Die (BS30)
         {11,  523, 1130},   -- Brothers D'Aurphe (BS60)
         {12,  524, 1131},   -- Undying Promise (BS40) -- TODO: model size increases with each reraise

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -2,33 +2,33 @@ require("scripts/globals/status")
 require("scripts/globals/magic")
 
 -- The TP modifier
-TPMOD_NONE = 0;
-TPMOD_CRITICAL = 1;
-TPMOD_DAMAGE = 2;
-TPMOD_ACC = 3;
-TPMOD_ATTACK = 4;
+TPMOD_NONE = 0
+TPMOD_CRITICAL = 1
+TPMOD_DAMAGE = 2
+TPMOD_ACC = 3
+TPMOD_ATTACK = 4
 
 -- The SC the spell makes
-SC_IMPACTION = 0;
-SC_TRANSFIXION = 1;
-SC_DETONATION = 2;
-SC_REVERBERATION = 3;
-SC_SCISSION = 4;
-SC_INDURATION = 5;
-SC_LIQUEFACTION = 6;
-SC_COMPRESSION = 7;
+SC_IMPACTION = 0
+SC_TRANSFIXION = 1
+SC_DETONATION = 2
+SC_REVERBERATION = 3
+SC_SCISSION = 4
+SC_INDURATION = 5
+SC_LIQUEFACTION = 6
+SC_COMPRESSION = 7
 
-SC_FUSION = 8;
-SC_FRAGMENTATION = 9;
-SC_DISTORTION = 10;
-SC_GRAVITATION = 11;
+SC_FUSION = 8
+SC_FRAGMENTATION = 9
+SC_DISTORTION = 10
+SC_GRAVITATION = 11
 
-SC_DARK = 12;
-SC_LIGHT = 13;
+SC_DARK = 12
+SC_LIGHT = 13
 
-INT_BASED = 1;
-CHR_BASED = 2;
-MND_BASED = 3;
+INT_BASED = 1
+CHR_BASED = 2
+MND_BASED = 3
 
 -- Get the damage for a blue magic physical spell.
 -- caster - The entity casting the spell.
@@ -54,7 +54,7 @@ MND_BASED = 3;
 --      .agi_wsc - Same as above.
 function BluePhysicalSpell(caster, target, spell, params)
     -- store related values
-    local magicskill = caster:getSkillLevel(tpz.skill.BLUE_MAGIC); -- skill + merits + equip bonuses
+    local magicskill = caster:getSkillLevel(tpz.skill.BLUE_MAGIC) -- skill + merits + equip bonuses
     -- TODO: Under Chain affinity?
     -- TODO: Under Efflux?
     -- TODO: Merits.
@@ -66,154 +66,154 @@ function BluePhysicalSpell(caster, target, spell, params)
     -- worked out from http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
     -- Final D value ??= floor(D+fSTR+WSC) * Multiplier
 
-    local D =  math.floor((magicskill * 0.11)) * 2 + 3;
+    local D =  math.floor((magicskill * 0.11)) * 2 + 3
     -- cap D
     if (D > params.duppercap) then
-        D = params.duppercap;
+        D = params.duppercap
     end
 
-    -- print("D val is ".. D);
+    -- print("D val is ".. D)
 
-    local fStr = BluefSTR(caster:getStat(tpz.mod.STR) - target:getStat(tpz.mod.VIT));
+    local fStr = BluefSTR(caster:getStat(tpz.mod.STR) - target:getStat(tpz.mod.VIT))
     if (fStr > 22) then
-        fStr = 22; -- TODO: Smite of Rage doesn't have this cap applied.
+        fStr = 22 -- TODO: Smite of Rage doesn't have this cap applied.
     end
 
-    -- print("fStr val is ".. fStr);
+    -- print("fStr val is ".. fStr)
 
-    local WSC = BlueGetWsc(caster, params);
+    local WSC = BlueGetWsc(caster, params)
 
-    -- print("wsc val is ".. WSC);
+    -- print("wsc val is ".. WSC)
 
-    local multiplier = params.multiplier;
+    local multiplier = params.multiplier
 
     -- If under CA, replace multiplier with fTP(multiplier, tp150, tp300)
-    local chainAffinity = caster:getStatusEffect(tpz.effect.CHAIN_AFFINITY);
+    local chainAffinity = caster:getStatusEffect(tpz.effect.CHAIN_AFFINITY)
     if chainAffinity ~= nil then
         -- Calculate the total TP available for the fTP multiplier.
-        local tp = caster:getTP() + caster:getMerit(tpz.merit.ENCHAINMENT);
+        local tp = caster:getTP() + caster:getMerit(tpz.merit.ENCHAINMENT)
         if tp > 3000 then
-            tp = 3000;
-        end;
+            tp = 3000
+        end
 
-        multiplier = BluefTP(tp, multiplier, params.tp150, params.tp300);
-    end;
+        multiplier = BluefTP(tp, multiplier, params.tp150, params.tp300)
+    end
 
     -- TODO: Modify multiplier to account for family bonus/penalty
-    local finalD = math.floor(D + fStr + WSC) * multiplier;
+    local finalD = math.floor(D + fStr + WSC) * multiplier
 
-    -- print("Final D is ".. finalD);
+    -- print("Final D is ".. finalD)
 
     ----------------------------------------------
     -- Get the possible pDIF range and hit rate --
     ----------------------------------------------
     if (params.offcratiomod == nil) then -- default to attack. Pretty much every physical spell will use this, Cannonball being the exception.
         params.offcratiomod = caster:getStat(tpz.mod.ATT)
-    end;
+    end
     -- print(params.offcratiomod)
-    local cratio = BluecRatio(params.offcratiomod / target:getStat(tpz.mod.DEF), caster:getMainLvl(), target:getMainLvl());
-    local hitrate = BlueGetHitRate(caster,target,true);
+    local cratio = BluecRatio(params.offcratiomod / target:getStat(tpz.mod.DEF), caster:getMainLvl(), target:getMainLvl())
+    local hitrate = BlueGetHitRate(caster,target,true)
 
-    -- print("Hit rate "..hitrate);
-    -- print("pdifmin "..cratio[1].." pdifmax "..cratio[2]);
+    -- print("Hit rate "..hitrate)
+    -- print("pdifmin "..cratio[1].." pdifmax "..cratio[2])
 
     -------------------------
     -- Perform the attacks --
     -------------------------
-    local hitsdone = 0;
-    local hitslanded = 0;
-    local finaldmg = 0;
+    local hitsdone = 0
+    local hitslanded = 0
+    local finaldmg = 0
 
     while (hitsdone < params.numhits) do
-        local chance = math.random();
+        local chance = math.random()
         if (chance <= hitrate) then -- it hit
             -- TODO: Check for shadow absorbs.
 
             -- Generate a random pDIF between min and max
-            local pdif = math.random((cratio[1]*1000),(cratio[2]*1000));
-            pdif = pdif/1000;
+            local pdif = math.random((cratio[1]*1000),(cratio[2]*1000))
+            pdif = pdif/1000
 
             -- Apply it to our final D
             if (hitsdone == 0) then -- only the first hit benefits from multiplier
-                finaldmg = finaldmg + (finalD * pdif);
+                finaldmg = finaldmg + (finalD * pdif)
             else
-                finaldmg = finaldmg + ((math.floor(D + fStr + WSC)) * pdif); -- same as finalD but without multiplier (it should be 1.0)
+                finaldmg = finaldmg + ((math.floor(D + fStr + WSC)) * pdif) -- same as finalD but without multiplier (it should be 1.0)
             end
 
-            hitslanded = hitslanded + 1;
+            hitslanded = hitslanded + 1
 
             -- increment target's TP (100TP per hit landed)
-            target:addTP(100);
+            target:addTP(100)
         end
 
-        hitsdone = hitsdone + 1;
+        hitsdone = hitsdone + 1
     end
 
-    -- print("Hits landed "..hitslanded.."/"..hitsdone.." for total damage: "..finaldmg);
+    -- print("Hits landed "..hitslanded.."/"..hitsdone.." for total damage: "..finaldmg)
 
-    return finaldmg;
-end;
+    return finaldmg
+end
 
 -- Blue Magical type spells
 
 function BlueMagicalSpell(caster, target, spell, params, statMod)
-    local D = caster:getMainLvl() + 2;
+    local D = caster:getMainLvl() + 2
 
     if (D > params.duppercap) then
-        D = params.duppercap;
+        D = params.duppercap
     end
 
-    local ST = BlueGetWsc(caster, params); -- According to Wiki ST is the same as WSC, essentially Blue mage spells that are magical use the dmg formula of Magical type Weapon skills
+    local ST = BlueGetWsc(caster, params) -- According to Wiki ST is the same as WSC, essentially Blue mage spells that are magical use the dmg formula of Magical type Weapon skills
 
     if (caster:hasStatusEffect(tpz.effect.BURST_AFFINITY)) then
-        ST = ST * 2;
+        ST = ST * 2
     end
 
-    local convergenceBonus = 1.0;
+    local convergenceBonus = 1.0
     if (caster:hasStatusEffect(tpz.effect.CONVERGENCE)) then
-        convergenceEffect = getStatusEffect(tpz.effect.CONVERGENCE);
-        local convLvl = convergenceEffect:getPower();
+        convergenceEffect = getStatusEffect(tpz.effect.CONVERGENCE)
+        local convLvl = convergenceEffect:getPower()
         if (convLvl == 1) then
-            convergenceBonus = 1.05;
+            convergenceBonus = 1.05
         elseif (convLvl == 2) then
-            convergenceBonus = 1.1;
+            convergenceBonus = 1.1
         elseif (convLvl == 3) then
-            convergenceBonus = 1.15;
+            convergenceBonus = 1.15
         end
     end
 
-    local statBonus = 0;
-    local dStat = 0; -- Please make sure to add an additional stat check if there is to be a spell that uses neither INT, MND, or CHR. None currently exist.
+    local statBonus = 0
+    local dStat = 0 -- Please make sure to add an additional stat check if there is to be a spell that uses neither INT, MND, or CHR. None currently exist.
     if (statMod == INT_BASED) then -- Stat mod is INT
         dStat = caster:getStat(tpz.mod.INT) - target:getStat(tpz.mod.INT)
-        statBonus = (dStat)* params.tMultiplier;
+        statBonus = (dStat)* params.tMultiplier
     elseif (statMod == CHR_BASED) then -- Stat mod is CHR
         dStat = caster:getStat(tpz.mod.CHR) - target:getStat(tpz.mod.CHR)
-        statBonus = (dStat)* params.tMultiplier;
+        statBonus = (dStat)* params.tMultiplier
     elseif (statMod == MND_BASED) then -- Stat mod is MND
         dStat = caster:getStat(tpz.mod.MND) - target:getStat(tpz.mod.MND)
-        statBonus = (dStat)* params.tMultiplier;
+        statBonus = (dStat)* params.tMultiplier
     end
 
-    D =(((D + ST) * params.multiplier * convergenceBonus) + statBonus);
+    D =(((D + ST) * params.multiplier * convergenceBonus) + statBonus)
 
     -- At this point according to wiki we apply standard magic attack calculations
 
-    local magicAttack = 1.0;
-    local multTargetReduction = 1.0; -- TODO: Make this dynamically change, temp static till implemented.
-    magicAttack = math.floor(D * multTargetReduction);
+    local magicAttack = 1.0
+    local multTargetReduction = 1.0 -- TODO: Make this dynamically change, temp static till implemented.
+    magicAttack = math.floor(D * multTargetReduction)
 
-    local rparams = {};
-    rparams.diff = dStat;
-    rparams.skillType = tpz.skill.BLUE_MAGIC;
-    magicAttack = math.floor(magicAttack * applyResistance(caster, target, spell, rparams));
+    local rparams = {}
+    rparams.diff = dStat
+    rparams.skillType = tpz.skill.BLUE_MAGIC
+    magicAttack = math.floor(magicAttack * applyResistance(caster, target, spell, rparams))
 
-    dmg = math.floor(addBonuses(caster, spell, target, magicAttack));
+    dmg = math.floor(addBonuses(caster, spell, target, magicAttack))
 
-    caster:delStatusEffectSilent(tpz.effect.BURST_AFFINITY);
+    caster:delStatusEffectSilent(tpz.effect.BURST_AFFINITY)
 
-    return dmg;
-end;
+    return dmg
+end
 
 function BlueFinalAdjustments(caster, target, spell, dmg, params)
     if (dmg < 0) then
@@ -246,53 +246,53 @@ function BlueGetWsc(attacker, params)
     wsc = (attacker:getStat(tpz.mod.STR) * params.str_wsc + attacker:getStat(tpz.mod.DEX) * params.dex_wsc +
          attacker:getStat(tpz.mod.VIT) * params.vit_wsc + attacker:getStat(tpz.mod.AGI) * params.agi_wsc +
          attacker:getStat(tpz.mod.INT) * params.int_wsc + attacker:getStat(tpz.mod.MND) * params.mnd_wsc +
-         attacker:getStat(tpz.mod.CHR) * params.chr_wsc) * BlueGetAlpha(attacker:getMainLvl());
-    return wsc;
-end;
+         attacker:getStat(tpz.mod.CHR) * params.chr_wsc) * BlueGetAlpha(attacker:getMainLvl())
+    return wsc
+end
 
 -- Given the raw ratio value (atk/def) and levels, returns the cRatio (min then max)
 function BluecRatio(ratio,atk_lvl,def_lvl)
     -- Level penalty...
-    local levelcor = 0;
+    local levelcor = 0
     if (atk_lvl < def_lvl) then
-        levelcor = 0.05 * (def_lvl - atk_lvl);
+        levelcor = 0.05 * (def_lvl - atk_lvl)
     end
-    ratio = ratio - levelcor;
+    ratio = ratio - levelcor
 
     -- apply caps
     if (ratio<0) then
-        ratio = 0;
+        ratio = 0
     elseif (ratio>2) then
-        ratio = 2;
+        ratio = 2
     end
 
     -- Obtaining cRatio_MIN
-    local cratiomin = 0;
+    local cratiomin = 0
     if (ratio<1.25) then
-        cratiomin = 1.2 * ratio - 0.5;
+        cratiomin = 1.2 * ratio - 0.5
     elseif (ratio>=1.25 and ratio<=1.5) then
-        cratiomin = 1;
+        cratiomin = 1
     elseif (ratio>1.5 and ratio<=2) then
-        cratiomin = 1.2 * ratio - 0.8;
+        cratiomin = 1.2 * ratio - 0.8
     end
 
     -- Obtaining cRatio_MAX
-    local cratiomax = 0;
+    local cratiomax = 0
     if (ratio<0.5) then
-        cratiomax = 0.4 + 1.2 * ratio;
+        cratiomax = 0.4 + 1.2 * ratio
     elseif (ratio<=0.833 and ratio>=0.5) then
-        cratiomax = 1;
+        cratiomax = 1
     elseif (ratio<=2 and ratio>0.833) then
-        cratiomax = 1.2 * ratio;
+        cratiomax = 1.2 * ratio
     end
-    cratio = {};
+    cratio = {}
     if (cratiomin < 0) then
-        cratiomin = 0;
+        cratiomin = 0
     end
-    cratio[1] = cratiomin;
-    cratio[2] = cratiomax;
-    return cratio;
-end;
+    cratio[1] = cratiomin
+    cratio[2] = cratiomax
+    return cratio
+end
 
 -- Gets the fTP multiplier by applying 2 straight lines between ftp1-ftp2 and ftp2-ftp3
 -- tp - The current TP
@@ -301,150 +301,150 @@ end;
 -- ftp3 - The TP 300% value
 function BluefTP(tp,ftp1,ftp2,ftp3)
     if (tp >= 0 and tp < 1500) then
-        return ftp1 + ( ((ftp2-ftp1)/100) * (tp / 10));
+        return ftp1 + ( ((ftp2-ftp1)/100) * (tp / 10))
     elseif (tp >= 1500 and tp <= 3000) then
         -- generate a straight line between ftp2 and ftp3 and find point @ tp
-        return ftp2 + ( ((ftp3-ftp2)/100) * ((tp-1500) / 10));
+        return ftp2 + ( ((ftp3-ftp2)/100) * ((tp-1500) / 10))
     else
-        print("blue fTP error: TP value is not between 0-3000!");
+        print("blue fTP error: TP value is not between 0-3000!")
     end
-    return 1; -- no ftp mod
-end;
+    return 1 -- no ftp mod
+end
 
 function BluefSTR(dSTR)
-    local fSTR2 = nil;
+    local fSTR2 = nil
     if (dSTR >= 12) then
-        fSTR2 = ((dSTR+4)/2);
+        fSTR2 = ((dSTR+4)/2)
     elseif (dSTR >= 6) then
-        fSTR2 = ((dSTR+6)/2);
+        fSTR2 = ((dSTR+6)/2)
     elseif (dSTR >= 1) then
-        fSTR2 = ((dSTR+7)/2);
+        fSTR2 = ((dSTR+7)/2)
     elseif (dSTR >= -2) then
-        fSTR2 = ((dSTR+8)/2);
+        fSTR2 = ((dSTR+8)/2)
     elseif (dSTR >= -7) then
-        fSTR2 = ((dSTR+9)/2);
+        fSTR2 = ((dSTR+9)/2)
     elseif (dSTR >= -15) then
-        fSTR2 = ((dSTR+10)/2);
+        fSTR2 = ((dSTR+10)/2)
     elseif (dSTR >= -21) then
-        fSTR2 = ((dSTR+12)/2);
+        fSTR2 = ((dSTR+12)/2)
     else
-        fSTR2 = ((dSTR+13)/2);
+        fSTR2 = ((dSTR+13)/2)
     end
 
-    return fSTR2;
-end;
+    return fSTR2
+end
 
 function BlueGetHitRate(attacker,target,capHitRate)
-    local acc = attacker:getACC();
-    local eva = target:getEVA();
+    local acc = attacker:getACC()
+    local eva = target:getEVA()
 
     if (attacker:getMainLvl() > target:getMainLvl()) then -- acc bonus!
-        acc = acc + ((attacker:getMainLvl()-target:getMainLvl())*4);
+        acc = acc + ((attacker:getMainLvl()-target:getMainLvl())*4)
     elseif (attacker:getMainLvl() < target:getMainLvl()) then -- acc penalty :(
-        acc = acc - ((target:getMainLvl()-attacker:getMainLvl())*4);
+        acc = acc - ((target:getMainLvl()-attacker:getMainLvl())*4)
     end
 
-    local hitdiff = 0;
-    local hitrate = 75;
+    local hitdiff = 0
+    local hitrate = 75
     if (acc>eva) then
-    hitdiff = (acc-eva)/2;
+    hitdiff = (acc-eva)/2
     end
     if (eva>acc) then
-    hitdiff = ((-1)*(eva-acc))/2;
+    hitdiff = ((-1)*(eva-acc))/2
     end
 
-    hitrate = hitrate+hitdiff;
-    hitrate = hitrate/100;
+    hitrate = hitrate+hitdiff
+    hitrate = hitrate/100
 
 
     -- Applying hitrate caps
     if (capHitRate) then -- this isn't capped for when acc varies with tp, as more penalties are due
         if (hitrate>0.95) then
-            hitrate = 0.95;
+            hitrate = 0.95
         end
         if (hitrate<0.2) then
-            hitrate = 0.2;
+            hitrate = 0.2
         end
     end
-    return hitrate;
-end;
+    return hitrate
+end
 
 -- Function to stagger duration of effects by using the resistance to change the value
 function getBlueEffectDuration(caster,resist,effect)
-    local duration = 0;
+    local duration = 0
 
     if (resist == 0.125) then
-        resist = 1;
+        resist = 1
     elseif (resist == 0.25) then
-        resist = 2;
+        resist = 2
     elseif (resist == 0.5) then
-        resist = 3;
+        resist = 3
     else
-        resist = 4;
+        resist = 4
     end
 
     if (effect == tpz.effect.BIND) then
-        duration = math.random(0,5) + resist * 5;
+        duration = math.random(0,5) + resist * 5
     elseif (effect == tpz.effect.STUN) then
-        duration = math.random(2,3) + resist;
-        -- printf("Duration of stun is %i",duration);
+        duration = math.random(2,3) + resist
+        -- printf("Duration of stun is %i",duration)
     elseif (effect == tpz.effect.WEIGHT) then
-        duration = math.random(20,24) + resist * 9; -- 20-24
+        duration = math.random(20,24) + resist * 9 -- 20-24
     elseif (effect == tpz.effect.PARALYSIS) then
-        duration = math.random(50,60) + resist * 15; -- 50- 60
+        duration = math.random(50,60) + resist * 15 -- 50- 60
     elseif (effect == tpz.effect.SLOW) then
-        duration = math.random(60,120) + resist * 15; -- 60- 120 -- Needs confirmation but capped max duration based on White Magic Spell Slow
+        duration = math.random(60,120) + resist * 15 -- 60- 120 -- Needs confirmation but capped max duration based on White Magic Spell Slow
     elseif (effect == tpz.effect.SILENCE) then
-        duration = math.random(60,180) + resist * 15; -- 60- 180 -- Needs confirmation but capped max duration based on White Magic Spell Silence
+        duration = math.random(60,180) + resist * 15 -- 60- 180 -- Needs confirmation but capped max duration based on White Magic Spell Silence
     elseif (effect == tpz.effect.POISON) then
-        duration = math.random(20,30) + resist * 9; -- 20-30 -- based on magic spell poison
+        duration = math.random(20,30) + resist * 9 -- 20-30 -- based on magic spell poison
     end
 
-    return duration;
-end;
+    return duration
+end
 
 -- obtains alpha, used for working out WSC
 function BlueGetAlpha(level)
-    local alpha = 1.00;
+    local alpha = 1.00
     if (level <= 5) then
-        alpha = 1.00;
+        alpha = 1.00
     elseif (level <= 11) then
-        alpha = 0.99;
+        alpha = 0.99
     elseif (level <= 17) then
-        alpha = 0.98;
+        alpha = 0.98
     elseif (level <= 23) then
-        alpha = 0.97;
+        alpha = 0.97
     elseif (level <= 29) then
-        alpha = 0.96;
+        alpha = 0.96
     elseif (level <= 35) then
-        alpha = 0.95;
+        alpha = 0.95
     elseif (level <= 41) then
-        alpha = 0.94;
+        alpha = 0.94
     elseif (level <= 47) then
-        alpha = 0.93;
+        alpha = 0.93
     elseif (level <= 53) then
-        alpha = 0.92;
+        alpha = 0.92
     elseif (level <= 59) then
-        alpha = 0.91;
+        alpha = 0.91
     elseif (level <= 61) then
-        alpha = 0.90;
+        alpha = 0.90
     elseif (level <= 63) then
-        alpha = 0.89;
+        alpha = 0.89
     elseif (level <= 65) then
-        alpha = 0.88;
+        alpha = 0.88
     elseif (level <= 67) then
-        alpha = 0.87;
+        alpha = 0.87
     elseif (level <= 69) then
-        alpha = 0.86;
+        alpha = 0.86
     elseif (level <= 71) then
-        alpha = 0.85;
+        alpha = 0.85
     elseif (level <= 73) then
-        alpha = 0.84;
+        alpha = 0.84
     elseif (level <= 75) then
-        alpha = 0.83;
+        alpha = 0.83
     elseif (level <= 99) then
-        alpha = 0.85;
+        alpha = 0.85
     end
-    return alpha;
-end;
+    return alpha
+end
 

--- a/scripts/globals/campaign.lua
+++ b/scripts/globals/campaign.lua
@@ -10,7 +10,7 @@ require("scripts/globals/teleports")
 -- -------------------------------------------------------------------
 
 function getMedalRank(player)
-    local rank = 0;
+    local rank = 0
     local medals =
     {
          924, 925, 926, 927, 928, 929, 930,
@@ -18,18 +18,18 @@ function getMedalRank(player)
          938, 939, 940, 941, 942, 943
     }
     while (player:hasKeyItem(medals[rank + 1]) == true) do
-        rank = rank + 1;
-    end;
-    return rank;
-end;
+        rank = rank + 1
+    end
+    return rank
+end
 
 -- -------------------------------------------------------------------
 -- get[nation]NotesItem()
 -- Returns the item ID and cost of the Allied Notes indexed item
 -- (the same value as that used by the vendor event)
 -- Format:
--- ListName_AN_item[optionID] = itemID; -- ItemName
--- ListName_AN_price[optionID] = cost; -- ItemName
+-- ListName_AN_item[optionID] = itemID -- ItemName
+-- ListName_AN_price[optionID] = cost -- ItemName
 -- -------------------------------------------------------------------
 
 function getSandOriaNotesItem(i)
@@ -71,9 +71,9 @@ function getSandOriaNotesItem(i)
         [82] = {id = 17684, price = 150000}, -- Griffinclaw
         [338] = {id = 11636, price = 75000} -- Royal Knight Sigil Ring
     }
-    local item = SandOria_AN[i];
-    return item.id, item.price;
-end;
+    local item = SandOria_AN[i]
+    return item.id, item.price
+end
 
 function getBastokNotesItem(i)
     local Bastok_AN =
@@ -114,9 +114,9 @@ function getBastokNotesItem(i)
         [82] = {id = 17685, price = 150000}, -- Lex Talionis
         [338] = {id = 11545, price = 75000} -- Fourth Mantle
     }
-    local item = Bastok_AN[i];
-    return item.id, item.price;
-end;
+    local item = Bastok_AN[i]
+    return item.id, item.price
+end
 
 function getWindurstNotesItem(i)
     local Windurst_AN =
@@ -159,9 +159,9 @@ function getWindurstNotesItem(i)
         [82] = {id = 17684, price = 150000}, -- Samudra
         [338] = {id = 11636, price = 75000} -- Mercenary Major Charm
     }
-    local item = Windurst_AN[i];
-    return item.id, item.price;
-end;
+    local item = Windurst_AN[i]
+    return item.id, item.price
+end
 
 -- -------------------------------------------------------------------
 -- getSigilTimeStamp(player)
@@ -170,12 +170,12 @@ end;
 -- -------------------------------------------------------------------
 
 function getSigilTimeStamp(player)
-    local timeStamp = 0; -- zero'd till math is done.
+    local timeStamp = 0 -- zero'd till math is done.
 
     -- TODO: calculate time stamp for menu display of when it wears off
 
-    return timeStamp;
-end;
+    return timeStamp
+end
 
 -- TODO:
 -- Past nation teleport

--- a/scripts/globals/caskets.lua
+++ b/scripts/globals/caskets.lua
@@ -890,7 +890,7 @@ tpz.caskets.onEventFinish = function(player, csid, option, npc)
     -- Basic chest var's
     ------------------------------------------------------------------
     local npc               = player:getEventTarget()
-    local chestId           = npc:getID();
+    local chestId           = npc:getID()
     local spawnStatus       = npc:getLocalVar("[caskets]SPAWNSTATUS")
     local locked            = npc:getLocalVar("[caskets]LOCKED")
     local lootType          = npc:getLocalVar("[caskets]LOOT_TYPE")

--- a/scripts/globals/crafting.lua
+++ b/scripts/globals/crafting.lua
@@ -26,16 +26,16 @@ guild =
 -- Table for Test Item
 -----------------------------------
 
-local TI_Alchemy = {937,4157,4163,947,16543,4116,16479,4120,16609,10792};
-local TI_Bonecraft = {13442,13441,13323,13459,13091,17299,16420,12508,13987,11058}; --  Way of The Boneworker + Hajduk Ring
-local TI_Clothcraft = {13583,13584,13204,13075,12723,13586,13752,12612,14253,11000};
-local TI_Cooking = {4355,4416,4489,4381,4413,4558,4546,4440,4561,}; -- Sprightly Soup + Way of the Culinarian
-local TI_Fishing = {4401,4379,4469,4480,4462,4479,4471,4478,4474,5817,}; -- Tiger shark
-local TI_Goldsmithing = {12496,12497,12495,13082,13446,13084,12545,13125,16515,}; --  Evader Earring**Guild item must be made with an Inferno Crystal
-local TI_Leathercraft = {13594,16386,13588,13195,12571,12572,12980,12702,12447,}; --  Urja Trousers(Signed with Terra Crystal)
-local TI_Smithing = {16530,12299,16512,16650,16651,16559,12427,16577,12428,}; -- Gorkhali Kukri
-local TI_Woodworking = {22,23,17354,17348,17053,17156,17054,56,17101,}; -- Vejovis wand signed
-local TI_Synergy = {};
+local TI_Alchemy = {937,4157,4163,947,16543,4116,16479,4120,16609,10792}
+local TI_Bonecraft = {13442,13441,13323,13459,13091,17299,16420,12508,13987,11058} --  Way of The Boneworker + Hajduk Ring
+local TI_Clothcraft = {13583,13584,13204,13075,12723,13586,13752,12612,14253,11000}
+local TI_Cooking = {4355,4416,4489,4381,4413,4558,4546,4440,4561,} -- Sprightly Soup + Way of the Culinarian
+local TI_Fishing = {4401,4379,4469,4480,4462,4479,4471,4478,4474,5817,} -- Tiger shark
+local TI_Goldsmithing = {12496,12497,12495,13082,13446,13084,12545,13125,16515,} --  Evader Earring**Guild item must be made with an Inferno Crystal
+local TI_Leathercraft = {13594,16386,13588,13195,12571,12572,12980,12702,12447,} --  Urja Trousers(Signed with Terra Crystal)
+local TI_Smithing = {16530,12299,16512,16650,16651,16559,12427,16577,12428,} -- Gorkhali Kukri
+local TI_Woodworking = {22,23,17354,17348,17053,17156,17054,56,17101,} -- Vejovis wand signed
+local TI_Synergy = {}
 
 local HQCrystals = {
     [1] = {
@@ -78,23 +78,23 @@ local HQCrystals = {
 
 function isGuildMember(player,guild)
 
-    local guildOK = player:getCharVar("Guild_Member");
-    local bit = {};
+    local guildOK = player:getCharVar("Guild_Member")
+    local bit = {}
 
     for i = 12,1,-1 do
         twop = 2^i
 
         if (guildOK >= twop) then
-            bit[i]=1; guildOK = guildOK - twop;
+            bit[i]=1 guildOK = guildOK - twop
         else
-            bit[i]=0;
+            bit[i]=0
         end
-        --printf("bit %u: %u",i,bit[i]);
-    end;
+        --printf("bit %u: %u",i,bit[i])
+    end
 
-    return bit[guild];
+    return bit[guild]
 
-end;
+end
 
 -----------------------------------
 -- signupGuild Action
@@ -102,7 +102,7 @@ end;
 
 function signupGuild(player, nbr)
     player:addCharVar("Guild_Member", nbr)
-end;
+end
 
 -----------------------------------
 -- getTestItem Action
@@ -110,25 +110,25 @@ end;
 
 function getTestItem(player,npc,craftID)
 
-    local TItemList = {};
-    local NextRank = player:getSkillRank(craftID) + 1;
+    local TItemList = {}
+    local NextRank = player:getSkillRank(craftID) + 1
 
     switch (npc:getName()): caseof
     {
-        ["Abd-al-Raziq"] = function (x)     TItemList = TI_Alchemy; end,
-        ["Peshi_Yohnts"] = function (x)     TItemList = TI_Bonecraft; end,
-        ["Ponono"] = function (x)             TItemList = TI_Clothcraft; end,
-        ["Piketo-Puketo"] = function (x)     TItemList = TI_Cooking; end,
-        ["Thubu_Parohren"] = function (x)     TItemList = TI_Fishing; end,
-        ["Reinberta"] = function (x)         TItemList = TI_Goldsmithing; end,
-        ["Faulpie"] = function (x)             TItemList = TI_Leathercraft; end,
-        ["Mevreauche"] = function (x)         TItemList = TI_Smithing; end,
-        ["Ghemp"] = function (x)             TItemList = TI_Smithing; end,
-        ["Cheupirudaux"] = function (x)     TItemList = TI_Woodworking; end,
+        ["Abd-al-Raziq"] = function (x)     TItemList = TI_Alchemy end,
+        ["Peshi_Yohnts"] = function (x)     TItemList = TI_Bonecraft end,
+        ["Ponono"] = function (x)             TItemList = TI_Clothcraft end,
+        ["Piketo-Puketo"] = function (x)     TItemList = TI_Cooking end,
+        ["Thubu_Parohren"] = function (x)     TItemList = TI_Fishing end,
+        ["Reinberta"] = function (x)         TItemList = TI_Goldsmithing end,
+        ["Faulpie"] = function (x)             TItemList = TI_Leathercraft end,
+        ["Mevreauche"] = function (x)         TItemList = TI_Smithing end,
+        ["Ghemp"] = function (x)             TItemList = TI_Smithing end,
+        ["Cheupirudaux"] = function (x)     TItemList = TI_Woodworking end,
     }
 
-    return TItemList[NextRank];
-end;
+    return TItemList[NextRank]
+end
 
 -----------------------------------
 -- canGetNewRank Action
@@ -136,8 +136,8 @@ end;
 
 function canGetNewRank(player,skillLvL,craftID)
 
-    local Rank = player:getSkillRank(craftID) + 1;
-    local canGet = 0;
+    local Rank = player:getSkillRank(craftID) + 1
+    local canGet = 0
 
     -- 0 fonctionne pas en lua donc rank + 1
     if (Rank == 1 and skillLvL >= 256 or
@@ -150,12 +150,12 @@ function canGetNewRank(player,skillLvL,craftID)
        Rank == 8 and skillLvL >= 2503 or
        Rank == 9 and skillLvL >= 2824) then
 --       Rank == 10 and skillLvL >= 3145) then
-            canGet = 1;
+            canGet = 1
     end
 
-    return canGet;
+    return canGet
 
-end;
+end
 
 -----------------------------------
 -- tradeTestItem Action
@@ -163,24 +163,24 @@ end;
 
 function tradeTestItem(player,npc,trade,craftID)
 
-    local guildID = craftID - 48;
+    local guildID = craftID - 48
     local skillLvL = player:getSkillLevel(craftID)
-    local myTI = getTestItem(player,npc,craftID);
-    local newRank = 0;
+    local myTI = getTestItem(player,npc,craftID)
+    local newRank = 0
 
     if (canGetNewRank(player,skillLvL,craftID) == 1 and
         trade:hasItemQty(myTI,1) and
         trade:getItemCount() == 1) then
-        newRank = player:getSkillRank(craftID) + 1;
-        player:tradeComplete();
+        newRank = player:getSkillRank(craftID) + 1
+        player:tradeComplete()
         if player:getCharVar('[GUILD]currentGuild') == guildID + 1 then
-            player:setCharVar('[GUILD]daily_points',-1);
+            player:setCharVar('[GUILD]daily_points',-1)
         end
     end
 
-    return newRank;
+    return newRank
 
-end;
+end
 
 -- 1: test item
 -- 2: skill point
@@ -209,84 +209,84 @@ function getAdvImageSupportCost(player,craftID)
 end
 
 function unionRepresentativeTrigger(player, guildID, csid, currency, keyitems)
-    local gpItem, remainingPoints = player:getCurrentGPItem(guildID);
-    local rank = player:getSkillRank(guildID + 48);
-    local cap = (rank + 1) * 10;
-    local kibits = 0;
+    local gpItem, remainingPoints = player:getCurrentGPItem(guildID)
+    local rank = player:getSkillRank(guildID + 48)
+    local cap = (rank + 1) * 10
+    local kibits = 0
 
     for kbit,ki in pairs(keyitems) do
         if (rank >= ki.rank) then
             if not player:hasKeyItem(ki.id) then
-                kibits = bit.bor(kibits, bit.lshift(1,kbit));
+                kibits = bit.bor(kibits, bit.lshift(1,kbit))
             end
         end
     end
 
-    player:startEvent(csid, player:getCurrency(currency), player:getCharVar('[GUILD]currentGuild') - 1, gpItem, remainingPoints, cap, 0, kibits);
+    player:startEvent(csid, player:getCurrency(currency), player:getCharVar('[GUILD]currentGuild') - 1, gpItem, remainingPoints, cap, 0, kibits)
 end
 
 function unionRepresentativeTriggerFinish(player, option, target, guildID, currency, keyitems, items)
-    local rank = player:getSkillRank(guildID + 48);
-    local category = bit.band(bit.rshift(option, 2),3);
+    local rank = player:getSkillRank(guildID + 48)
+    local category = bit.band(bit.rshift(option, 2),3)
     local text = zones[player:getZoneID()].text
 
     if (bit.tobit(option) == -1 and rank >= 3) then
-        local oldGuild = player:getCharVar('[GUILD]currentGuild') - 1;
-        player:setCharVar('[GUILD]currentGuild',guildID + 1);
+        local oldGuild = player:getCharVar('[GUILD]currentGuild') - 1
+        player:setCharVar('[GUILD]currentGuild',guildID + 1)
 
         if (oldGuild == -1) then
-            player:messageSpecial(text.GUILD_NEW_CONTRACT, guildID);
+            player:messageSpecial(text.GUILD_NEW_CONTRACT, guildID)
         else
-            player:messageSpecial(text.GUILD_TERMINATE_CONTRACT, guildID, oldGuild);
-            player:setCharVar('[GUILD]daily_points',-1);
+            player:messageSpecial(text.GUILD_TERMINATE_CONTRACT, guildID, oldGuild)
+            player:setCharVar('[GUILD]daily_points',-1)
         end
     elseif (category == 3) then -- keyitem
-        local ki = keyitems[bit.band(bit.rshift(option, 5), 15) - 1];
+        local ki = keyitems[bit.band(bit.rshift(option, 5), 15) - 1]
         if (ki and rank >= ki.rank) then
             if (player:getCurrency(currency) >= ki.cost) then
-                player:delCurrency(currency, ki.cost);
-                player:addKeyItem(ki.id);
-                player:messageSpecial(text.KEYITEM_OBTAINED, ki.id);
+                player:delCurrency(currency, ki.cost)
+                player:addKeyItem(ki.id)
+                player:messageSpecial(text.KEYITEM_OBTAINED, ki.id)
             else
-               player:messageText(target, text.NOT_HAVE_ENOUGH_GP, false, 6);
+               player:messageText(target, text.NOT_HAVE_ENOUGH_GP, false, 6)
             end
         end
     elseif (category == 2 or category == 1) then -- item
-        local idx = bit.band(option, 3);
-        local i = items[(category - 1) * 4 + idx];
-        local quantity = math.min(bit.rshift(option, 9), 12);
-        local cost = quantity * i.cost;
+        local idx = bit.band(option, 3)
+        local i = items[(category - 1) * 4 + idx]
+        local quantity = math.min(bit.rshift(option, 9), 12)
+        local cost = quantity * i.cost
         if (i and rank >= i.rank) then
             if (player:getCurrency(currency) >= cost) then
-                local delivered = 0;
+                local delivered = 0
                 for count = 1, quantity do -- addItem does not appear to honor quantity if the item doesn't stack.
                     if (player:addItem(i.id, true)) then
-                        player:delCurrency(currency, i.cost);
-                        player:messageSpecial(text.ITEM_OBTAINED, i.id);
-                        delivered = delivered + 1;
+                        player:delCurrency(currency, i.cost)
+                        player:messageSpecial(text.ITEM_OBTAINED, i.id)
+                        delivered = delivered + 1
                     end
                 end
                 if (delivered == 0) then
-                    player:messageSpecial(text.ITEM_CANNOT_BE_OBTAINED, i.id);
+                    player:messageSpecial(text.ITEM_CANNOT_BE_OBTAINED, i.id)
                 end
             else
-               player:messageText(target, text.NOT_HAVE_ENOUGH_GP, false, 6);
+               player:messageText(target, text.NOT_HAVE_ENOUGH_GP, false, 6)
             end
         end
     elseif (category == 0 and option ~= 1073741824) then -- HQ crystal
-        local i = HQCrystals[bit.band(bit.rshift(option, 5), 15)];
-        local quantity = bit.rshift(option, 9);
-        local cost = quantity * i.cost;
+        local i = HQCrystals[bit.band(bit.rshift(option, 5), 15)]
+        local quantity = bit.rshift(option, 9)
+        local cost = quantity * i.cost
         if (i and rank >= 3) then
             if (player:getCurrency(currency) >= cost) then
                 if (player:addItem(i.id, quantity)) then
-                    player:delCurrency(currency, cost);
-                    player:messageSpecial(text.ITEM_OBTAINED, i.id);
+                    player:delCurrency(currency, cost)
+                    player:messageSpecial(text.ITEM_OBTAINED, i.id)
                 else
-                    player:messageSpecial(text.ITEM_CANNOT_BE_OBTAINED, i.id);
+                    player:messageSpecial(text.ITEM_CANNOT_BE_OBTAINED, i.id)
                 end
             else
-               player:messageText(target, text.NOT_HAVE_ENOUGH_GP, false, 6);
+               player:messageText(target, text.NOT_HAVE_ENOUGH_GP, false, 6)
             end
         end
     end

--- a/scripts/globals/dynamis.lua
+++ b/scripts/globals/dynamis.lua
@@ -684,40 +684,40 @@ end
 --------------------------------------------------
 
 function getDynamisMapList(player)
-    local bitmask = 0;
+    local bitmask = 0
     if (player:hasKeyItem(tpz.ki.MAP_OF_DYNAMIS_SANDORIA) == true) then
-        bitmask = bitmask + 2;
+        bitmask = bitmask + 2
     end
     if (player:hasKeyItem(tpz.ki.MAP_OF_DYNAMIS_BASTOK) == true) then
-        bitmask = bitmask + 4;
+        bitmask = bitmask + 4
     end
     if (player:hasKeyItem(tpz.ki.MAP_OF_DYNAMIS_WINDURST) == true) then
-        bitmask = bitmask + 8;
+        bitmask = bitmask + 8
     end
     if (player:hasKeyItem(tpz.ki.MAP_OF_DYNAMIS_JEUNO) == true) then
-        bitmask = bitmask + 16;
+        bitmask = bitmask + 16
     end
     if (player:hasKeyItem(tpz.ki.MAP_OF_DYNAMIS_BEAUCEDINE) == true) then
-        bitmask = bitmask + 32;
+        bitmask = bitmask + 32
     end
     if (player:hasKeyItem(tpz.ki.MAP_OF_DYNAMIS_XARCABARD) == true) then
-        bitmask = bitmask + 64;
+        bitmask = bitmask + 64
     end
     if (player:hasKeyItem(tpz.ki.MAP_OF_DYNAMIS_VALKURM) == true) then
-        bitmask = bitmask + 128;
+        bitmask = bitmask + 128
     end
     if (player:hasKeyItem(tpz.ki.MAP_OF_DYNAMIS_BUBURIMU) == true) then
-        bitmask = bitmask + 256;
+        bitmask = bitmask + 256
     end
     if (player:hasKeyItem(tpz.ki.MAP_OF_DYNAMIS_QUFIM) == true) then
-        bitmask = bitmask + 512;
+        bitmask = bitmask + 512
     end
     if (player:hasKeyItem(tpz.ki.MAP_OF_DYNAMIS_TAVNAZIA) == true) then
-        bitmask = bitmask + 1024;
+        bitmask = bitmask + 1024
     end
 
-    return bitmask;
-end;
+    return bitmask
+end
 
 -- todo: fix these to use tables
 function dynamis.getExtensions(player)

--- a/scripts/globals/effects/battlefield.lua
+++ b/scripts/globals/effects/battlefield.lua
@@ -20,7 +20,7 @@ function onEffectLose(target,effect)
         pet:leaveBattlefield(1)
     end
     target:setLocalVar("[battlefield]area", 0)
-end;
+end
 
 function onEventUpdate(player,csid,option)
     -- printf("onUpdate CSID: %u",csid)

--- a/scripts/globals/effects/dynamis.lua
+++ b/scripts/globals/effects/dynamis.lua
@@ -10,7 +10,7 @@ require("scripts/globals/keyitems")
 
 function onEffectGain(target,effect)
     target:setLocalVar("dynamis_lasttimeupdate", effect:getTimeRemaining() / 1000)
-end;
+end
 
 -----------------------------------
 -- onEffectTick Action
@@ -22,15 +22,15 @@ function onEffectTick(target,effect)
     local message = 0
 
     if lastTimeUpdate > 600 and remainingTimeLimit < 600 then
-        message = 600;
+        message = 600
     elseif lastTimeUpdate > 300 and remainingTimeLimit < 300 then
-        message = 300;
+        message = 300
     elseif lastTimeUpdate > 60 and remainingTimeLimit < 60 then
-        message = 60;
+        message = 60
     elseif lastTimeUpdate > 30 and remainingTimeLimit < 30 then
-        message = 30;
+        message = 30
     elseif lastTimeUpdate > 10 and remainingTimeLimit < 10 then
-        message = 10;
+        message = 10
     end
 
     if message ~= 0 then
@@ -47,7 +47,7 @@ function onEffectTick(target,effect)
         end
         target:setLocalVar("dynamis_lasttimeupdate", message)
     end
-end;
+end
 
 -----------------------------------
 -- onEffectLose Action
@@ -64,14 +64,14 @@ function onEffectLose(target,effect)
         target:disengage()
         target:startEvent(100)
     end
-end;
+end
 
 function onEventUpdate(target,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-end;
+    -- printf("onUpdate CSID: %u",csid)
+    -- printf("onUpdate RESULT: %u",option)
+end
 
 function onEventFinish(target,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-end;
+    -- printf("onFinish CSID: %u",csid)
+    -- printf("onFinish RESULT: %u",option)
+end

--- a/scripts/globals/effects/level_restriction.lua
+++ b/scripts/globals/effects/level_restriction.lua
@@ -5,9 +5,9 @@
 -----------------------------------
 
 function onEffectGain(target,effect)
-    target:levelRestriction(effect:getPower());
-    target:messageBasic(314, effect:getPower()); -- <target>'s level is restricted to <param>
-end;
+    target:levelRestriction(effect:getPower())
+    target:messageBasic(314, effect:getPower()) -- <target>'s level is restricted to <param>
+end
 
 
 function onEffectTick(target,effect)

--- a/scripts/globals/effects/sj_restriction.lua
+++ b/scripts/globals/effects/sj_restriction.lua
@@ -7,8 +7,8 @@ require("scripts/globals/status")
 -----------------------------------
 
 function onEffectGain(target,effect)
-    target:recalculateStats();
-end;
+    target:recalculateStats()
+end
 
 
 function onEffectTick(target,effect)

--- a/scripts/globals/equipment.lua
+++ b/scripts/globals/equipment.lua
@@ -1,4 +1,4 @@
-require("scripts/globals/status");
+require("scripts/globals/status")
 
 BaseNyzulWeapons = {
                        18492, -- (WAR) Sturdy Axe
@@ -21,7 +21,7 @@ BaseNyzulWeapons = {
                        18754, -- (PUP) Inferno Claws
                        19102, -- (DNC) Main Gauche
                        18592  -- (SCH) Elder Staff
-                   };
+                   }
 
 -----------------------------------
 -- Place convenience functions
@@ -29,46 +29,46 @@ BaseNyzulWeapons = {
 -----------------------------------
 
 function isArtifactArmor(itemid)
-    retval = false;
-    if    ((itemid >= 12511 and itemid <= 12520) or (itemid >= 13855 and itemid <= 13857) or (itemid >= 13868 and itemid <= 13869)) then retval = true; -- normal head sets
-    elseif ((itemid >= 12638 and itemid <= 12650) or (itemid >= 13781 and itemid <= 13782)) then retval = true; -- normal body sets
-    elseif (itemid >= 13961 and itemid <= 13975) then retval = true; -- normal hand sets
-    elseif (itemid >= 14089 and itemid <= 14103) then retval = true; -- normal feet sets
-    elseif (itemid >= 14214 and itemid <= 14228) then retval = true; -- normal legs sets
+    retval = false
+    if    ((itemid >= 12511 and itemid <= 12520) or (itemid >= 13855 and itemid <= 13857) or (itemid >= 13868 and itemid <= 13869)) then retval = true -- normal head sets
+    elseif ((itemid >= 12638 and itemid <= 12650) or (itemid >= 13781 and itemid <= 13782)) then retval = true -- normal body sets
+    elseif (itemid >= 13961 and itemid <= 13975) then retval = true -- normal hand sets
+    elseif (itemid >= 14089 and itemid <= 14103) then retval = true -- normal feet sets
+    elseif (itemid >= 14214 and itemid <= 14228) then retval = true -- normal legs sets
 
-    elseif (itemid >= 15265 and itemid <= 15267) then retval = true; -- ToAU head sets
-    elseif (itemid >= 14521 and itemid <= 14523) then retval = true; -- ToAU body sets
-    elseif (itemid >= 14928 and itemid <= 14930) then retval = true; -- ToAU hand sets
-    elseif (itemid >= 15684 and itemid <= 15686) then retval = true; -- ToAU feet sets
-    elseif (itemid >= 15600 and itemid <= 15602) then retval = true; -- ToAU legs sets
+    elseif (itemid >= 15265 and itemid <= 15267) then retval = true -- ToAU head sets
+    elseif (itemid >= 14521 and itemid <= 14523) then retval = true -- ToAU body sets
+    elseif (itemid >= 14928 and itemid <= 14930) then retval = true -- ToAU hand sets
+    elseif (itemid >= 15684 and itemid <= 15686) then retval = true -- ToAU feet sets
+    elseif (itemid >= 15600 and itemid <= 15602) then retval = true -- ToAU legs sets
 
-    elseif (itemid >= 16138 and itemid <= 16140) then retval = true; -- WotG head sets
-    elseif (itemid >= 14578 and itemid <= 14580) then retval = true; -- WotG body sets
-    elseif (itemid >= 15002 and itemid <= 15004) then retval = true; -- WotG hand sets
-    elseif (itemid >= 15746 and itemid <= 15748) then retval = true; -- WotG feet sets
-    elseif (itemid >= 15659 and itemid <= 15661) then retval = true; -- WotG legs sets
+    elseif (itemid >= 16138 and itemid <= 16140) then retval = true -- WotG head sets
+    elseif (itemid >= 14578 and itemid <= 14580) then retval = true -- WotG body sets
+    elseif (itemid >= 15002 and itemid <= 15004) then retval = true -- WotG hand sets
+    elseif (itemid >= 15746 and itemid <= 15748) then retval = true -- WotG feet sets
+    elseif (itemid >= 15659 and itemid <= 15661) then retval = true -- WotG legs sets
     end
-    return retval;
-end;
+    return retval
+end
 
 function isBaseNyzulWeapon(itemId)
 
     for i, wepId in pairs(BaseNyzulWeapons) do
         if (itemId == wepId) then
-            return true;
+            return true
         end
     end
     
-    return false;
+    return false
     
-end;
+end
 
 -- Provides a power for using a chocobo shirt with bunch of gysahl greens
 function ChocoboShirt(player)
-    local body = player:getEquipID(tpz.slot.BODY);
-    local power = 0;
+    local body = player:getEquipID(tpz.slot.BODY)
+    local power = 0
     if (body == 10293) then -- Chocobo Shirt
-        power = power + 1;
+        power = power + 1
     end
-    return power;
-end;
+    return power
+end

--- a/scripts/globals/events/harvest_festivals.lua
+++ b/scripts/globals/events/harvest_festivals.lua
@@ -4,83 +4,83 @@
 ---------------------------------------------------------
 ---------------------------------------------------------
 
-require("scripts/globals/status");
-require("scripts/globals/settings");
+require("scripts/globals/status")
+require("scripts/globals/settings")
 
 ---------------------------------------------------------
 ---------------------------------------------------------
 
 
 function isHalloweenEnabled()
-    local option = 0;
-    local month = tonumber(os.date("%m"));
-    local day = tonumber(os.date("%d"));
+    local option = 0
+    local month = tonumber(os.date("%m"))
+    local day = tonumber(os.date("%d"))
     if (month == 10 and day >= 20 or month == 11 and day == 1 or HALLOWEEN_YEAR_ROUND ~= 0) then -- According to wiki Harvest Fest is Oct 20 - Nov 1.
         if (HALLOWEEN_2005 == 1) then
-            option = 1;
+            option = 1
         elseif (HALLOWEEN_2008 == 1) then
-            option = 2;
+            option = 2
         elseif (HALLOWEEN_2009 == 1) then
-            option = 3;
+            option = 3
         elseif (HALLOWEEN_2010 == 1) then
-            option = 4;
+            option = 4
         end
     end
-    return option;
-end;
+    return option
+end
 
 
 function halloweenItemsCheck(player)
-    local headSlot = player:getEquipID(tpz.slot.HEAD);
-    local mainHand = player:getEquipID(tpz.slot.MAIN);
-    local reward = 0;
+    local headSlot = player:getEquipID(tpz.slot.HEAD)
+    local mainHand = player:getEquipID(tpz.slot.MAIN)
+    local reward = 0
 
     -- Normal Quality Rewards
     local pumpkinHead = 13916
-    local pumpkinHead2 = 15176;
-    local trickStaff = 17565;
-    local trickStaff2 = 17587;
+    local pumpkinHead2 = 15176
+    local trickStaff = 17565
+    local trickStaff2 = 17587
 
-    reward_list = {pumpkinHead,pumpkinHead2,trickStaff,trickStaff2};
+    reward_list = {pumpkinHead,pumpkinHead2,trickStaff,trickStaff2}
 
     -- Checks for HQ Upgrade
     for ri = 1, #reward_list do
         if (headSlot == reward_list[ri] or mainHand == reward_list[ri]) then
             if (headSlot == pumpkinHead and player:hasItem(13917) == false) then
-                reward = 13917; -- Horror Head
+                reward = 13917 -- Horror Head
             elseif (headSlot == pumpkinHead2 and player:hasItem(15177) == false) then
-                reward = 15177; -- Horror Head II
+                reward = 15177 -- Horror Head II
             elseif (mainHand == trickStaff and player:hasItem(17566) == false) then
-                reward =  17566; -- Treat Staff
+                reward =  17566 -- Treat Staff
             elseif (mainHand == trickStaff2 and player:hasItem(17588) == false) then
-                reward = 17588; -- Treat Staff II
+                reward = 17588 -- Treat Staff II
             end
-            return reward;
+            return reward
         end
     end
 
     -- Checks the possible item rewards to ensure player doesnt already have the item we are about to give them
-    local cnt = #reward_list;
+    local cnt = #reward_list
 
     while cnt ~= 0 do
-        local picked = reward_list[math.random(1,#reward_list)];
+        local picked = reward_list[math.random(1,#reward_list)]
         if (player:hasItem(picked) == false) then
-            reward = picked;
-            cnt = 0;
+            reward = picked
+            cnt = 0
         else
-            table.remove(reward_list,picked);
-            cnt = cnt - 1;
+            table.remove(reward_list,picked)
+            cnt = cnt - 1
         end
-    return reward;
-    end;
-end;
+    return reward
+    end
+end
 
 function onHalloweenTrade(player,trade,npc)
-    local zone = player:getZoneName();
+    local zone = player:getZoneName()
     local ID = zones[player:getZoneID()]
 
-    local contentEnabled = isHalloweenEnabled();
-    local item = trade:getItemId();
+    local contentEnabled = isHalloweenEnabled()
+    local item = trade:getItemId()
     -------------------
     -- 2005 edition ---
     -------------------
@@ -133,30 +133,30 @@ function onHalloweenTrade(player,trade,npc)
             5631, -- Pumpkin Cake
             5577, -- Sutlac
             5627, -- Yogurt Cake
-        };
+        }
 
         for itemInList = 1, #treats_table  do
 
             if (item == treats_table[itemInList]) then
-                local itemReward = halloweenItemsCheck(player);
-                local varName = "harvestFestTreats";
-                local harvestFestTreats;
+                local itemReward = halloweenItemsCheck(player)
+                local varName = "harvestFestTreats"
+                local harvestFestTreats
                 if (itemInList < 32) then -- The size of the list is too big for int 32 used that stores the bit mask, as such there are two lists
 
-                    harvestFestTreats = player:getCharVar(varName);
+                    harvestFestTreats = player:getCharVar(varName)
                 else
 
-                    varName = "harvestFestTreats2";
-                    harvestFestTreats = player:getCharVar(varName); --  this is the second list
-                    itemInList = itemInList - 32;
+                    varName = "harvestFestTreats2"
+                    harvestFestTreats = player:getCharVar(varName) --  this is the second list
+                    itemInList = itemInList - 32
                 end
 
-                local AlreadyTradedChk = player:getMaskBit(harvestFestTreats,itemInList);
+                local AlreadyTradedChk = player:getMaskBit(harvestFestTreats,itemInList)
                 if (itemReward ~= 0 and player:getFreeSlotsCount() >= 1 and math.random(1,3) < 2) then -- Math.random added so you have 33% chance on getting item
 
-                    player:messageSpecial(ID.text.HERE_TAKE_THIS);
-                    player:addItem(itemReward);
-                    player:messageSpecial(ID.text.ITEM_OBTAINED,itemReward);
+                    player:messageSpecial(ID.text.HERE_TAKE_THIS)
+                    player:addItem(itemReward)
+                    player:messageSpecial(ID.text.ITEM_OBTAINED,itemReward)
 
                 elseif target:canUseMisc(tpz.zoneMisc.COSTUME) and not AlreadyTradedChk then
                 -- Other neat looking halloween type costumes
@@ -172,19 +172,19 @@ function onHalloweenTrade(player,trade,npc)
                 -- 564/579 skele
 
                     -- Possible costume values:
-                    local Yagudo = math.random(580,607);
-                    local Quadav = math.random(644,671);
-                    local Shade = math.random(535,538);
-                    local Orc = math.random(612,639);
-                    local Ghost = 368;
-                    local Hound = 365;
-                    local Skeleton = 564;
-                    local Dark_Stalker = math.random(531,534);
+                    local Yagudo = math.random(580,607)
+                    local Quadav = math.random(644,671)
+                    local Shade = math.random(535,538)
+                    local Orc = math.random(612,639)
+                    local Ghost = 368
+                    local Hound = 365
+                    local Skeleton = 564
+                    local Dark_Stalker = math.random(531,534)
 
-                    local halloween_costume_list = {Quadav,Orc,Yagudo,Shade,Ghost,Hound,Skeleton,Dark_Stalker};
+                    local halloween_costume_list = {Quadav,Orc,Yagudo,Shade,Ghost,Hound,Skeleton,Dark_Stalker}
 
-                    local costumePicked = halloween_costume_list[math.random(1,#halloween_costume_list)]; -- will randomly pick one of the costumes in the list
-                    player:addStatusEffect(tpz.effect.COSTUME,costumePicked,0,3600);
+                    local costumePicked = halloween_costume_list[math.random(1,#halloween_costume_list)] -- will randomly pick one of the costumes in the list
+                    player:addStatusEffect(tpz.effect.COSTUME,costumePicked,0,3600)
 
                     -- pitchForkCostumeList defines the special costumes per zone that can trigger the pitch fork requirement
                     -- zone, costumeID
@@ -196,34 +196,34 @@ function onHalloweenTrade(player,trade,npc)
                         231, Hound, Skeleton, -- Northern Sandoria
                         241, Ghost, Shade,    -- Windurst Woods
                         238, Shade, Hound     -- Windurst Woods
-                    };
+                    }
 
                     for zi = 1, #pitchForkCostumeList, 3 do
 
                         if (zone == pitchForkCostumeList[zi] and (costumePicked == pitchForkCostumeList[zi + 1] or zone == pitchForkCostumeList[zi] and costumePicked == pitchForkCostumeList[zi + 2])) then -- Gives special hint for pitch fork costume
-                            player:messageSpecial(ID.text.IF_YOU_WEAR_THIS);
+                            player:messageSpecial(ID.text.IF_YOU_WEAR_THIS)
 
                         elseif (zi == 16) then
-                            player:messageSpecial(ID.text.THANK_YOU_TREAT);
+                            player:messageSpecial(ID.text.THANK_YOU_TREAT)
 
                         end
 
                     end
                 else
-                    player:messageSpecial(ID.text.THANK_YOU);
+                    player:messageSpecial(ID.text.THANK_YOU)
                 end
 
                 if (AlreadyTradedChk == false) then
-                    player:setMaskBit(harvestFestTreats,varName,itemInList,true);
+                    player:setMaskBit(harvestFestTreats,varName,itemInList,true)
                 end
 
-                player:tradeComplete();
+                player:tradeComplete()
 
-                break;
+                break
             end
         end
     end
-end;
+end
 
 function applyHalloweenNpcCostumes(zoneid)
     if isHalloweenEnabled() ~= 0 then

--- a/scripts/globals/gear_sets.lua
+++ b/scripts/globals/gear_sets.lua
@@ -2,7 +2,7 @@
 -- Gear sets
 -- Allows the use of gear sets with modifiers
 -----------------------------------
-require("scripts/globals/status");
+require("scripts/globals/status")
 -----------------------------------
 
 local matchtype = {
@@ -13,13 +13,13 @@ local matchtype = {
 }
 
 -- placeholder for unknown mod types
-local MOD_UNKNOWN = 0;
+local MOD_UNKNOWN = 0
 
 -- apparently these are static, so i'll leave them here
-local extraDamageChance = 35;
-local extraAttackChance = 25;
-local nullDamageChance = 15;
-local instantCastChance = 15;
+local extraDamageChance = 35
+local extraAttackChance = 25
+local nullDamageChance = 15
+local instantCastChance = 15
 
 
 --              {id, {item, ids, in, no, particular, order}, minimum matches required, match type, mods{id, value, modvalue for each additional match, additional whole set bonus}
@@ -189,44 +189,44 @@ local HipsterSets = {
 -- Checks for gear sets present on a player
 -------------------------------------------
 function checkForGearSet(player)
-    -- print("---Removed existing gear set mods!---\n");
-    player:clearGearSetMods();
+    -- print("---Removed existing gear set mods!---\n")
+    player:clearGearSetMods()
 
     -- cause we dont want hundreds of function calls
-    local equip = {};
+    local equip = {}
     for slot = 0, tpz.MAX_SLOTID do
-        equip[slot+1] = player:getEquipID(slot);
+        equip[slot+1] = player:getEquipID(slot)
     end
 
     for index, gearset in pairs(GearSets) do
-        local matches = 0;
+        local matches = 0
         if (player:hasGearSetMod(gearset.id) == false) then
-            local slot = 0;
-            local gearMatch = {};
+            local slot = 0
+            local gearMatch = {}
 
             for _, id in pairs(gearset.items) do
                 for slot = 1, tpz.MAX_SLOTID do
-                    local equipId = equip[slot];
+                    local equipId = equip[slot]
 
                     -- check the item matches
                     if (equipId == id) then
-                        matches = matches + 1;
-                        gearMatch[slot] = equipId;
-                        break;
+                        matches = matches + 1
+                        gearMatch[slot] = equipId
+                        break
                     end
-                end;
+                end
             end
 
             -- doesnt count as a match if the same item is in both slots
             if (gearMatch[tpz.slot.EAR1+1] == gearMatch[tpz.slot.EAR2+1] and gearMatch[tpz.slot.EAR1+1] ~= nil) then
-                matches = matches - 1;
-            end;
+                matches = matches - 1
+            end
             if (gearMatch[tpz.slot.RING1+1] == gearMatch[tpz.slot.RING2+1] and gearMatch[tpz.slot.RING1+1] ~= nil) then
-                matches = matches - 1;
-            end;
+                matches = matches - 1
+            end
             if (gearMatch[tpz.slot.MAIN+1] == gearMatch[tpz.slot.SUB+1] and gearMatch[tpz.slot.MAIN+1] ~= nil) then
-                matches = matches - 1;
-            end;
+                matches = matches - 1
+            end
 
             if (matches >= gearset.matches) then
                 if (FindMatchByType(gearset, gearMatch) == true) then
@@ -235,25 +235,25 @@ function checkForGearSet(player)
             end
         end
     end
-end;
+end
 
 function FindMatchByType(gearset, gearMatch)
     if (gearset.matchType == matchtype.any) then
-        return true;
+        return true
     elseif (gearset.matchType == matchtype.ring_armor and (gearMatch[tpz.slot.HEAD+1] ~= nil or gearMatch[tpz.slot.BODY+1] ~= nil or gearMatch[tpz.slot.HANDS+1] ~= nil or gearMatch[tpz.slot.LEGS+1] ~= nil or gearMatch[tpz.slot.FEET+1] ~= nil) and (gearMatch[tpz.slot.RING1+1] ~= nil or gearMatch[tpz.slot.RING2+1] ~= nil)) then
-        return true;
+        return true
     end
 
     for _, id in ipairs(gearMatch) do
         if (gearset.matchType == matchtype.earring_weapon and (gearMatch[tpz.slot.MAIN+1] ~= nil or gearMatch[tpz.slot.SUB+1] ~= nil) and (gearMatch[tpz.slot.EAR1+1] ~= nil or gearMatch[tpz.slot.EAR2+1] ~= nil)) then
-            return true;
+            return true
         elseif (gearset.matchType == matchtype.weapon_weapon and (gearMatch[tpz.slot.MAIN+1] ~= nil and gearMatch[tpz.slot.SUB+1] ~= nil)) then
-            return true;
+            return true
         end
     end
 
-    return false;
-end;
+    return false
+end
 
 ---------------------------------------
 -- Applys a gear set mod
@@ -262,92 +262,92 @@ function ApplyMod(player, gearset, matches)
 
     for _, set in pairs(HipsterSets) do
         if (set.id == gearset.id) then
-            HandleHipsterSet(player, gearset, matches);
-            return;
+            HandleHipsterSet(player, gearset, matches)
+            return
         end
     end
 
     -- find any additional matches
-    local addMatches = matches - gearset.matches;
+    local addMatches = matches - gearset.matches
 
     -- just in case some d00d decides to custom shit up and complain the script is b0rked
     if (addMatches < 0) then
-        return;
-    end;
+        return
+    end
 
-    local i = 0;
+    local i = 0
     for _, mod in pairs(gearset.mods) do
-        local modId = mod[1];
-        local modValue = mod[2];
+        local modId = mod[1]
+        local modValue = mod[2]
 
         -- value/multiplier for additional pieces
-        local addMatchValue = mod[3];
+        local addMatchValue = mod[3]
 
         -- additional bonus for complete set
-        local addSetBonus = 0;
+        local addSetBonus = 0
 
         -- cause we need all pieces to form a complete set
         if (matches == #gearset.items) then
-            addSetBonus = mod[4];
-        end;
+            addSetBonus = mod[4]
+        end
 
         -- add bonus mods per piece
         if (addMatches ~= 0 and addMatchValue ~= 0) then
-            modValue = modValue + (addMatchValue * addMatches);
+            modValue = modValue + (addMatchValue * addMatches)
         end
-        -- printf("gearset: %u, mod: %u, value %u", gearset.id, modId, modValue + addSetBonus);
-        player:addGearSetMod(gearset.id + i, modId, modValue + addSetBonus);
-        i = i + 1;
+        -- printf("gearset: %u, mod: %u, value %u", gearset.id, modId, modValue + addSetBonus)
+        player:addGearSetMod(gearset.id + i, modId, modValue + addSetBonus)
+        i = i + 1
     end
-    -- print("Gear set! Mod applied: ModNameId:" .. modNameId .. " ModId:" .. modId .. " Value:" .. modValue .. "\n");
-end;
+    -- print("Gear set! Mod applied: ModNameId:" .. modNameId .. " ModId:" .. modId .. " Value:" .. modValue .. "\n")
+end
 
 -- fkin hipsters
 function HandleHipsterSet(player, gearset, matches)
     -- Rubeus Armor Set
     if (gearset.id == 34) then
-        local modValue = 0;
+        local modValue = 0
 
         if (matches > 1 and matches < 4) then
-            modValue = 4; -- 2 or 3 pieces
+            modValue = 4 -- 2 or 3 pieces
         elseif (matches > 3) then
-            modValue = 10; -- 4 or 5 pieces
-        end;
-        -- printf("we have a special snowflake | gearset: %u | mod %u %u", gearset.id, tpz.mod.FASTCAST, modValue);
-        player:addGearSetMod(gearset.id, tpz.mod.FASTCAST, modValue);
-        return;
+            modValue = 10 -- 4 or 5 pieces
+        end
+        -- printf("we have a special snowflake | gearset: %u | mod %u %u", gearset.id, tpz.mod.FASTCAST, modValue)
+        player:addGearSetMod(gearset.id, tpz.mod.FASTCAST, modValue)
+        return
     -- AF1 119+2/+3 ACC/RACC/MACC Sets EXCEPT SMN
     elseif (gearset.id >= 133 and gearset.id <= 199 and gearset.id ~= 175) then
-        local modValue = 0;
+        local modValue = 0
         
         if (matches == 2) then
-            modValue = 15; -- 2 matches
+            modValue = 15 -- 2 matches
         elseif (matches == 3) then
-            modValue = 30; -- 3 matches
+            modValue = 30 -- 3 matches
         elseif (matches == 4) then
-            modValue = 45; -- 4 matches
+            modValue = 45 -- 4 matches
         elseif (matches >= 5) then
-            modValue = 60; -- 5 or more matches
-        end;
-        player:addGearSetMod(gearset.id, tpz.mod.ACC, modValue);
-        player:addGearSetMod(gearset.id + 1, tpz.mod.RACC, modValue);
-        player:addGearSetMod(gearset.id + 2, tpz.mod.MACC, modValue);
-        return;
+            modValue = 60 -- 5 or more matches
+        end
+        player:addGearSetMod(gearset.id, tpz.mod.ACC, modValue)
+        player:addGearSetMod(gearset.id + 1, tpz.mod.RACC, modValue)
+        player:addGearSetMod(gearset.id + 2, tpz.mod.MACC, modValue)
+        return
     -- AF1 119 +2/+3 SMN Avatar:ACC/RACC/MACC (unimplemented)
     elseif (gearset.id == 175) then
-        local modValue = 0;
+        local modValue = 0
         
         if (matches == 2) then
-            modValue = 15; -- 2 matches
+            modValue = 15 -- 2 matches
         elseif (matches == 3) then
-            modValue = 30; -- 3 matches
+            modValue = 30 -- 3 matches
         elseif (matches == 4) then
-            modValue = 45; -- 4 matches
+            modValue = 45 -- 4 matches
         elseif (matches >= 5) then
-            modValue = 60; -- 5 or more matches
-        end;
+            modValue = 60 -- 5 or more matches
+        end
         --Unimplemented method to add pet mods
-        return;
+        return
     end
 end
 

--- a/scripts/globals/icanheararainbow.lua
+++ b/scripts/globals/icanheararainbow.lua
@@ -1,135 +1,135 @@
 -- Functions below used in quest: I Can Hear a Rainbow
 
-require( "scripts/globals/status");
-require( "scripts/globals/quests");
-require( "scripts/globals/weather");
+require( "scripts/globals/status")
+require( "scripts/globals/quests")
+require( "scripts/globals/weather")
 
-colorsAvailable = { 102, 103, 104, 105, 106, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 123, 124, 125}; -- Zone IDs
+colorsAvailable = { 102, 103, 104, 105, 106, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 123, 124, 125} -- Zone IDs
 
 -- Data below from http://wiki.ffxiclopedia.org/wiki/I_Can_Hear_a_Rainbow - Feb. 02, 2013
 
-colorsAvailable[100] = { false, true,  false, false, false, false, false}; -- West Ronfaure
-colorsAvailable[101] = { false, true,  false, false, false, false, false}; -- East Ronfaure
-colorsAvailable[102] = { false, false, false, true,  true,  false, false}; -- La Theine Plateau
-colorsAvailable[103] = { true,  false, true,  false, false, false, false}; -- Valkurm Dunes
-colorsAvailable[104] = { false, false, false, false, true,  false, true }; -- Jugner Forest
-colorsAvailable[105] = { false, false, true,  false, false, true,  false}; -- Batallia Downs
-colorsAvailable[106] = { false, true,  false, false, false, false, false}; -- North Gustaberg
-colorsAvailable[107] = { false, true,  false, false, false, false, false}; -- South Gustaberg
-colorsAvailable[108] = { false, false, true,  false, false, false, true }; -- Konschtat Highlands
-colorsAvailable[109] = { false, false, false, false, true,  false, true }; -- Pashhow Marshlands
-colorsAvailable[110] = { true,  false, false, false, true,  false, false}; -- Rolanberry Fields
-colorsAvailable[111] = { false, false, false, false, false, true,  false}; -- Beaucedine Glacier
-colorsAvailable[112] = { false, false, false, false, false, true,  false}; -- Xarcabard
-colorsAvailable[113] = { true,  false, false, true,  false, false, false}; -- Cape Teriggan
-colorsAvailable[114] = { true,  true,  true,  false, false, false, false}; -- Eastern Altepa Desert
-colorsAvailable[115] = { false, true,  false, false, false, false, false}; -- West Sarutabaruta
-colorsAvailable[116] = { false, true,  false, false, false, false, false}; -- East Sarutabaruta
-colorsAvailable[117] = { false, false, true,  true,  false, false, false}; -- Tahrongi Canyon
-colorsAvailable[118] = { false, true,  false, true,  true,  false, false}; -- Buburimu Peninsula
-colorsAvailable[119] = { true,  false, true,  false, false, false, false}; -- Meriphataud Mountains
-colorsAvailable[120] = { false, false, true,  false, false, false, true }; -- Sauromugue Champaign
-colorsAvailable[121] = { false, false, false, false, true,  false, true }; -- The Sanctuary of Zi'Tah
-colorsAvailable[123] = { true,  false, false, false, true,  false, false}; -- Yuhtunga Jungle
-colorsAvailable[124] = { true,  true,  false, false, true,  false, false}; -- Yhoator Jungle
-colorsAvailable[125] = { true,  false, true,  false, false, false, false}; -- Western Altepa Desert
+colorsAvailable[100] = { false, true,  false, false, false, false, false} -- West Ronfaure
+colorsAvailable[101] = { false, true,  false, false, false, false, false} -- East Ronfaure
+colorsAvailable[102] = { false, false, false, true,  true,  false, false} -- La Theine Plateau
+colorsAvailable[103] = { true,  false, true,  false, false, false, false} -- Valkurm Dunes
+colorsAvailable[104] = { false, false, false, false, true,  false, true } -- Jugner Forest
+colorsAvailable[105] = { false, false, true,  false, false, true,  false} -- Batallia Downs
+colorsAvailable[106] = { false, true,  false, false, false, false, false} -- North Gustaberg
+colorsAvailable[107] = { false, true,  false, false, false, false, false} -- South Gustaberg
+colorsAvailable[108] = { false, false, true,  false, false, false, true } -- Konschtat Highlands
+colorsAvailable[109] = { false, false, false, false, true,  false, true } -- Pashhow Marshlands
+colorsAvailable[110] = { true,  false, false, false, true,  false, false} -- Rolanberry Fields
+colorsAvailable[111] = { false, false, false, false, false, true,  false} -- Beaucedine Glacier
+colorsAvailable[112] = { false, false, false, false, false, true,  false} -- Xarcabard
+colorsAvailable[113] = { true,  false, false, true,  false, false, false} -- Cape Teriggan
+colorsAvailable[114] = { true,  true,  true,  false, false, false, false} -- Eastern Altepa Desert
+colorsAvailable[115] = { false, true,  false, false, false, false, false} -- West Sarutabaruta
+colorsAvailable[116] = { false, true,  false, false, false, false, false} -- East Sarutabaruta
+colorsAvailable[117] = { false, false, true,  true,  false, false, false} -- Tahrongi Canyon
+colorsAvailable[118] = { false, true,  false, true,  true,  false, false} -- Buburimu Peninsula
+colorsAvailable[119] = { true,  false, true,  false, false, false, false} -- Meriphataud Mountains
+colorsAvailable[120] = { false, false, true,  false, false, false, true } -- Sauromugue Champaign
+colorsAvailable[121] = { false, false, false, false, true,  false, true } -- The Sanctuary of Zi'Tah
+colorsAvailable[123] = { true,  false, false, false, true,  false, false} -- Yuhtunga Jungle
+colorsAvailable[124] = { true,  true,  false, false, true,  false, false} -- Yhoator Jungle
+colorsAvailable[125] = { true,  false, true,  false, false, false, false} -- Western Altepa Desert
 
 -- The Event IDs to trigger the light cutscene for the following 3 zones is currently unknown.
 -- They are included only because they are listed at http://wiki.ffxiclopedia.org/wiki/I_Can_Hear_a_Rainbow
 
--- colorsAvailable[128] = { false, false, false, true,  false, false, false}; -- Valley of Sorrows
--- colorsAvailable[136] = { false, false, false, false, false, true,  false}; -- Beaucedine Glacier (S)
--- colorsAvailable[205] = { true,  false, false, false, false, false, false}; -- Ifrit's Cauldron
+-- colorsAvailable[128] = { false, false, false, true,  false, false, false} -- Valley of Sorrows
+-- colorsAvailable[136] = { false, false, false, false, false, true,  false} -- Beaucedine Glacier (S)
+-- colorsAvailable[205] = { true,  false, false, false, false, false, false} -- Ifrit's Cauldron
 
 -----------------------------------
 -- triggerLightCutscene
 -----------------------------------
 
 function triggerLightCutscene( player)
-    local cutsceneTriggered = false;
-    local RED    = 1;
-    local ORANGE = 2;
-    local YELLOW = 3;
-    local GREEN  = 4;
-    local BLUE   = 5;
-    local INDIGO = 6;
-    local VIOLET = 7;
-    local zone   = player:getZoneID();
-    local weather = player:getWeather();
+    local cutsceneTriggered = false
+    local RED    = 1
+    local ORANGE = 2
+    local YELLOW = 3
+    local GREEN  = 4
+    local BLUE   = 5
+    local INDIGO = 6
+    local VIOLET = 7
+    local zone   = player:getZoneID()
+    local weather = player:getWeather()
 
     if (player:hasItem( 1125, 0)) then -- Player has Carbuncle's Ruby?
         if (player:getQuestStatus(WINDURST, tpz.quest.id.windurst.I_CAN_HEAR_A_RAINBOW) == QUEST_ACCEPTED) then
             if (player:getMaskBit(player:getCharVar("I_CAN_HEAR_A_RAINBOW"),0) == false and (weather == tpz.weather.HOT_SPELL or weather == tpz.weather.HEAT_WAVE)) then
                 if (colorsAvailable[zone][RED]) then
-                    cutsceneTriggered = true;
-                    player:setMaskBit(player:getCharVar("I_CAN_HEAR_A_RAINBOW"),"I_CAN_HEAR_A_RAINBOW",0,true);
-                    player:setCharVar( "I_CAN_HEAR_A_RAINBOW_Weather", weather);
+                    cutsceneTriggered = true
+                    player:setMaskBit(player:getCharVar("I_CAN_HEAR_A_RAINBOW"),"I_CAN_HEAR_A_RAINBOW",0,true)
+                    player:setCharVar( "I_CAN_HEAR_A_RAINBOW_Weather", weather)
                 end
             elseif (player:getMaskBit(player:getCharVar("I_CAN_HEAR_A_RAINBOW"),1) == false and (weather == tpz.weather.NONE or weather == tpz.weather.SUNSHINE)) then
                 if (colorsAvailable[zone][ORANGE]) then
-                    cutsceneTriggered = true;
-                    player:setMaskBit(player:getCharVar("I_CAN_HEAR_A_RAINBOW"),"I_CAN_HEAR_A_RAINBOW",1,true);
-                    player:setCharVar( "I_CAN_HEAR_A_RAINBOW_Weather", weather);
+                    cutsceneTriggered = true
+                    player:setMaskBit(player:getCharVar("I_CAN_HEAR_A_RAINBOW"),"I_CAN_HEAR_A_RAINBOW",1,true)
+                    player:setCharVar( "I_CAN_HEAR_A_RAINBOW_Weather", weather)
                 end
             elseif (player:getMaskBit(player:getCharVar("I_CAN_HEAR_A_RAINBOW"),2) == false and (weather == tpz.weather.DUST_STORM or weather == tpz.weather.SAND_STORM)) then
                 if (colorsAvailable[zone][YELLOW]) then
-                    cutsceneTriggered = true;
-                    player:setMaskBit(player:getCharVar("I_CAN_HEAR_A_RAINBOW"),"I_CAN_HEAR_A_RAINBOW",2,true);
-                    player:setCharVar( "I_CAN_HEAR_A_RAINBOW_Weather", weather);
+                    cutsceneTriggered = true
+                    player:setMaskBit(player:getCharVar("I_CAN_HEAR_A_RAINBOW"),"I_CAN_HEAR_A_RAINBOW",2,true)
+                    player:setCharVar( "I_CAN_HEAR_A_RAINBOW_Weather", weather)
                 end
             elseif (player:getMaskBit(player:getCharVar("I_CAN_HEAR_A_RAINBOW"),3)  == false and (weather == tpz.weather.WIND or weather == tpz.weather.GALES)) then
                 if (colorsAvailable[zone][GREEN]) then
-                    cutsceneTriggered = true;
-                    player:setMaskBit(player:getCharVar("I_CAN_HEAR_A_RAINBOW"),"I_CAN_HEAR_A_RAINBOW",3,true);
-                    player:setCharVar( "I_CAN_HEAR_A_RAINBOW_Weather", weather);
+                    cutsceneTriggered = true
+                    player:setMaskBit(player:getCharVar("I_CAN_HEAR_A_RAINBOW"),"I_CAN_HEAR_A_RAINBOW",3,true)
+                    player:setCharVar( "I_CAN_HEAR_A_RAINBOW_Weather", weather)
                 end
             elseif (player:getMaskBit(player:getCharVar("I_CAN_HEAR_A_RAINBOW"),4)   == false and (weather == tpz.weather.RAIN or weather == tpz.weather.SQUALL)) then
                 if (colorsAvailable[zone][BLUE]) then
-                    cutsceneTriggered = true;
-                    player:setMaskBit(player:getCharVar("I_CAN_HEAR_A_RAINBOW"),"I_CAN_HEAR_A_RAINBOW",4,true);
-                    player:setCharVar( "I_CAN_HEAR_A_RAINBOW_Weather", weather);
+                    cutsceneTriggered = true
+                    player:setMaskBit(player:getCharVar("I_CAN_HEAR_A_RAINBOW"),"I_CAN_HEAR_A_RAINBOW",4,true)
+                    player:setCharVar( "I_CAN_HEAR_A_RAINBOW_Weather", weather)
                 end
             elseif (player:getMaskBit(player:getCharVar("I_CAN_HEAR_A_RAINBOW"),5) == false and (weather == tpz.weather.SNOW or weather == tpz.weather.BLIZZARDS)) then
                 if (colorsAvailable[zone][INDIGO]) then
-                    cutsceneTriggered = true;
-                    player:setMaskBit(player:getCharVar("I_CAN_HEAR_A_RAINBOW"),"I_CAN_HEAR_A_RAINBOW",5,true);
-                    player:setCharVar( "I_CAN_HEAR_A_RAINBOW_Weather", weather);
+                    cutsceneTriggered = true
+                    player:setMaskBit(player:getCharVar("I_CAN_HEAR_A_RAINBOW"),"I_CAN_HEAR_A_RAINBOW",5,true)
+                    player:setCharVar( "I_CAN_HEAR_A_RAINBOW_Weather", weather)
                 end
             elseif (player:getMaskBit(player:getCharVar("I_CAN_HEAR_A_RAINBOW"),6) == false and (weather == tpz.weather.THUNDER or weather == tpz.weather.THUNDERSTORMS)) then
                 if (colorsAvailable[zone][VIOLET]) then
-                    cutsceneTriggered = true;
-                    player:setMaskBit(player:getCharVar("I_CAN_HEAR_A_RAINBOW"),"I_CAN_HEAR_A_RAINBOW",6,true);
-                    player:setCharVar( "I_CAN_HEAR_A_RAINBOW_Weather", weather);
+                    cutsceneTriggered = true
+                    player:setMaskBit(player:getCharVar("I_CAN_HEAR_A_RAINBOW"),"I_CAN_HEAR_A_RAINBOW",6,true)
+                    player:setCharVar( "I_CAN_HEAR_A_RAINBOW_Weather", weather)
                 end
             end
         end
     end
 
-    return cutsceneTriggered;
-end;
+    return cutsceneTriggered
+end
 
 -----------------------------------
 -- lightCutsceneUpdate
 -----------------------------------
 
 function lightCutsceneUpdate( player)
-    local weather = player:getCharVar( "I_CAN_HEAR_A_RAINBOW_Weather");
+    local weather = player:getCharVar( "I_CAN_HEAR_A_RAINBOW_Weather")
 
     if (weather == tpz.weather.SUNSHINE) then -- In some zones the light cutscene does not handle tpz.weather.SUNSHINE properly
-        weather = tpz.weather.NONE;
+        weather = tpz.weather.NONE
     end
 
     if (player:getCharVar("I_CAN_HEAR_A_RAINBOW") < 127) then
-        player:updateEvent( 0, 0, weather);
+        player:updateEvent( 0, 0, weather)
     else
-        player:updateEvent( 0, 0, weather, 6);
+        player:updateEvent( 0, 0, weather, 6)
     end
-end;
+end
 
 -----------------------------------
 -- lightCutsceneFinish
 -----------------------------------
 
 function lightCutsceneFinish( player)
-    player:setCharVar("I_CAN_HEAR_A_RAINBOW_Weather", 0);
-end;
+    player:setCharVar("I_CAN_HEAR_A_RAINBOW_Weather", 0)
+end

--- a/scripts/globals/instance.lua
+++ b/scripts/globals/instance.lua
@@ -1,64 +1,64 @@
 
 function updateInstanceTime(instance, elapsed, texttable)
-    local players = instance:getChars();
-    local lastTimeUpdate = instance:getLastTimeUpdate();
-    local remainingTimeLimit = (instance:getTimeLimit()) * 60 - (elapsed / 1000);
-    local wipeTime = instance:getWipeTime();
-    local message = 0;
+    local players = instance:getChars()
+    local lastTimeUpdate = instance:getLastTimeUpdate()
+    local remainingTimeLimit = (instance:getTimeLimit()) * 60 - (elapsed / 1000)
+    local wipeTime = instance:getWipeTime()
+    local message = 0
     
     if (remainingTimeLimit < 0) then
-        instance:fail();
-        return;
+        instance:fail()
+        return
     end
     
     if (wipeTime == 0) then
-        local wipe = true;
+        local wipe = true
         for i,v in pairs(players) do
             if v:getHP() ~= 0 then
-                wipe = false;
-                break;
+                wipe = false
+                break
             end
         end
         if (wipe) then
             for i,v in pairs(players) do
-                v:messageSpecial(texttable.PARTY_FALLEN, 3);
+                v:messageSpecial(texttable.PARTY_FALLEN, 3)
             end
-            instance:setWipeTime(elapsed);
+            instance:setWipeTime(elapsed)
         end
     else
         if (elapsed - wipeTime) / 1000 > 180 then
-            instance:fail();
-            return;
+            instance:fail()
+            return
         else
             for i,v in pairs(players) do
                 if v:getHP() ~= 0 then
-                    instance:setWipeTime(0);
-                    break;
+                    instance:setWipeTime(0)
+                    break
                 end
             end
         end
     end
 
     if (lastTimeUpdate == 0 and remainingTimeLimit < 600) then
-        message = 600;
+        message = 600
     elseif (lastTimeUpdate == 600 and remainingTimeLimit < 300) then
-        message = 300;
+        message = 300
     elseif (lastTimeUpdate == 300 and remainingTimeLimit < 60) then
-        message = 60;
+        message = 60
     elseif (lastTimeUpdate == 60 and remainingTimeLimit < 30) then
-        message = 30;
+        message = 30
     elseif (lastTimeUpdate == 30 and remainingTimeLimit < 10) then
-        message = 10;
+        message = 10
     end
     
     if (message ~= 0) then
         for i,v in pairs(players) do
             if (remainingTimeLimit >= 60) then
-                v:messageSpecial(texttable.TIME_REMAINING_MINUTES, remainingTimeLimit / 60);
+                v:messageSpecial(texttable.TIME_REMAINING_MINUTES, remainingTimeLimit / 60)
             else
-                v:messageSpecial(texttable.TIME_REMAINING_SECONDS, remainingTimeLimit);
+                v:messageSpecial(texttable.TIME_REMAINING_SECONDS, remainingTimeLimit)
             end
         end
-        instance:setLastTimeUpdate(message);
+        instance:setLastTimeUpdate(message)
     end
 end

--- a/scripts/globals/items/bean_daifuku.lua
+++ b/scripts/globals/items/bean_daifuku.lua
@@ -31,33 +31,33 @@ function onItemUse(target)
 end
 
 function onEffectGain(target, effect)
-    target:addMod(tpz.mod.HP, 20);
-    target:addMod(tpz.mod.VIT, 3);
-    target:addMod(tpz.mod.FOOD_ACCP, 10);
-    target:addMod(tpz.mod.FOOD_ACC_CAP, 50);
-    target:addMod(tpz.mod.FOOD_RACCP, 10);
-    target:addMod(tpz.mod.FOOD_RACC_CAP, 50);
-    target:addPetMod(tpz.mod.HP, 20);
-    target:addPetMod(tpz.mod.VIT, 3);
-    target:addPetMod(tpz.mod.FOOD_ACCP, 10);
-    target:addPetMod(tpz.mod.FOOD_ACC_CAP, 75);
-    target:addPetMod(tpz.mod.FOOD_RACCP, 10);
-    target:addPetMod(tpz.mod.FOOD_RACC_CAP, 75);
-    target:addPetMod(tpz.mod.HASTE_GEAR, 300);
-end;
+    target:addMod(tpz.mod.HP, 20)
+    target:addMod(tpz.mod.VIT, 3)
+    target:addMod(tpz.mod.FOOD_ACCP, 10)
+    target:addMod(tpz.mod.FOOD_ACC_CAP, 50)
+    target:addMod(tpz.mod.FOOD_RACCP, 10)
+    target:addMod(tpz.mod.FOOD_RACC_CAP, 50)
+    target:addPetMod(tpz.mod.HP, 20)
+    target:addPetMod(tpz.mod.VIT, 3)
+    target:addPetMod(tpz.mod.FOOD_ACCP, 10)
+    target:addPetMod(tpz.mod.FOOD_ACC_CAP, 75)
+    target:addPetMod(tpz.mod.FOOD_RACCP, 10)
+    target:addPetMod(tpz.mod.FOOD_RACC_CAP, 75)
+    target:addPetMod(tpz.mod.HASTE_GEAR, 300)
+end
 
 function onEffectLose(target, effect)
-    target:delMod(tpz.mod.HP, 20);
-    target:delMod(tpz.mod.VIT, 3);
-    target:delMod(tpz.mod.FOOD_ACCP, 10);
-    target:delMod(tpz.mod.FOOD_ACC_CAP, 50);
-    target:delMod(tpz.mod.FOOD_RACCP, 10);
-    target:delMod(tpz.mod.FOOD_RACC_CAP, 50);
-    target:delPetMod(tpz.mod.HP, 20);
-    target:delPetMod(tpz.mod.VIT, 3);
-    target:delPetMod(tpz.mod.FOOD_ACCP, 10);
-    target:delPetMod(tpz.mod.FOOD_ACC_CAP, 75);
-    target:delPetMod(tpz.mod.FOOD_RACCP, 10);
-    target:delPetMod(tpz.mod.FOOD_RACC_CAP, 75);
-    target:delPetMod(tpz.mod.HASTE_GEAR, 300);
-end;
+    target:delMod(tpz.mod.HP, 20)
+    target:delMod(tpz.mod.VIT, 3)
+    target:delMod(tpz.mod.FOOD_ACCP, 10)
+    target:delMod(tpz.mod.FOOD_ACC_CAP, 50)
+    target:delMod(tpz.mod.FOOD_RACCP, 10)
+    target:delMod(tpz.mod.FOOD_RACC_CAP, 50)
+    target:delPetMod(tpz.mod.HP, 20)
+    target:delPetMod(tpz.mod.VIT, 3)
+    target:delPetMod(tpz.mod.FOOD_ACCP, 10)
+    target:delPetMod(tpz.mod.FOOD_ACC_CAP, 75)
+    target:delPetMod(tpz.mod.FOOD_RACCP, 10)
+    target:delPetMod(tpz.mod.FOOD_RACC_CAP, 75)
+    target:delPetMod(tpz.mod.HASTE_GEAR, 300)
+end

--- a/scripts/globals/items/bean_daifuku_+1.lua
+++ b/scripts/globals/items/bean_daifuku_+1.lua
@@ -31,33 +31,33 @@ function onItemUse(target)
 end
 
 function onEffectGain(target, effect)
-    target:addMod(tpz.mod.HP, 30);
-    target:addMod(tpz.mod.VIT, 4);
-    target:addMod(tpz.mod.FOOD_ACCP, 11);
-    target:addMod(tpz.mod.FOOD_ACC_CAP, 54);
-    target:addMod(tpz.mod.FOOD_RACCP, 11);
-    target:addMod(tpz.mod.FOOD_RACC_CAP, 54);
-    target:addPetMod(tpz.mod.HP, 30);
-    target:addPetMod(tpz.mod.VIT, 4);
-    target:addPetMod(tpz.mod.FOOD_ACCP, 11);
-    target:addPetMod(tpz.mod.FOOD_ACC_CAP, 81);
-    target:addPetMod(tpz.mod.FOOD_RACCP, 11);
-    target:addPetMod(tpz.mod.FOOD_RACC_CAP, 81);
-    target:addPetMod(tpz.mod.HASTE_GEAR, 400);
-end;
+    target:addMod(tpz.mod.HP, 30)
+    target:addMod(tpz.mod.VIT, 4)
+    target:addMod(tpz.mod.FOOD_ACCP, 11)
+    target:addMod(tpz.mod.FOOD_ACC_CAP, 54)
+    target:addMod(tpz.mod.FOOD_RACCP, 11)
+    target:addMod(tpz.mod.FOOD_RACC_CAP, 54)
+    target:addPetMod(tpz.mod.HP, 30)
+    target:addPetMod(tpz.mod.VIT, 4)
+    target:addPetMod(tpz.mod.FOOD_ACCP, 11)
+    target:addPetMod(tpz.mod.FOOD_ACC_CAP, 81)
+    target:addPetMod(tpz.mod.FOOD_RACCP, 11)
+    target:addPetMod(tpz.mod.FOOD_RACC_CAP, 81)
+    target:addPetMod(tpz.mod.HASTE_GEAR, 400)
+end
 
 function onEffectLose(target, effect)
-    target:delMod(tpz.mod.HP, 30);
-    target:delMod(tpz.mod.VIT, 4);
-    target:delMod(tpz.mod.FOOD_ACCP, 11);
-    target:delMod(tpz.mod.FOOD_ACC_CAP, 54);
-    target:delMod(tpz.mod.FOOD_RACCP, 11);
-    target:delMod(tpz.mod.FOOD_RACC_CAP, 54);
-    target:delPetMod(tpz.mod.HP, 30);
-    target:delPetMod(tpz.mod.VIT, 4);
-    target:delPetMod(tpz.mod.FOOD_ACCP, 11);
-    target:delPetMod(tpz.mod.FOOD_ACC_CAP, 81);
-    target:delPetMod(tpz.mod.FOOD_RACCP, 11);
-    target:delPetMod(tpz.mod.FOOD_RACC_CAP, 81);
-    target:delPetMod(tpz.mod.HASTE_GEAR, 400);
-end;
+    target:delMod(tpz.mod.HP, 30)
+    target:delMod(tpz.mod.VIT, 4)
+    target:delMod(tpz.mod.FOOD_ACCP, 11)
+    target:delMod(tpz.mod.FOOD_ACC_CAP, 54)
+    target:delMod(tpz.mod.FOOD_RACCP, 11)
+    target:delMod(tpz.mod.FOOD_RACC_CAP, 54)
+    target:delPetMod(tpz.mod.HP, 30)
+    target:delPetMod(tpz.mod.VIT, 4)
+    target:delPetMod(tpz.mod.FOOD_ACCP, 11)
+    target:delPetMod(tpz.mod.FOOD_ACC_CAP, 81)
+    target:delPetMod(tpz.mod.FOOD_RACCP, 11)
+    target:delPetMod(tpz.mod.FOOD_RACC_CAP, 81)
+    target:delPetMod(tpz.mod.HASTE_GEAR, 400)
+end

--- a/scripts/globals/items/bronze_bed.lua
+++ b/scripts/globals/items/bronze_bed.lua
@@ -2,8 +2,8 @@
 -- ID: 5
 -- Item: Bronze Bed
 -----------------------------------------
-require("scripts/globals/common");
-require("scripts/globals/quests");
+require("scripts/globals/common")
+require("scripts/globals/quests")
 -----------------------------------------
 
 function onFurniturePlaced(player)

--- a/scripts/globals/items/mahogany_bed.lua
+++ b/scripts/globals/items/mahogany_bed.lua
@@ -2,8 +2,8 @@
 -- ID: 4
 -- Item: Mahogany Bed
 -----------------------------------------
-require("scripts/globals/common");
-require("scripts/globals/quests");
+require("scripts/globals/common")
+require("scripts/globals/quests")
 -----------------------------------------
 
 function onFurniturePlaced(player)

--- a/scripts/globals/items/nobles_bed.lua
+++ b/scripts/globals/items/nobles_bed.lua
@@ -2,8 +2,8 @@
 -- ID: 6
 -- Item: Noble's Bed
 -----------------------------------------
-require("scripts/globals/common");
-require("scripts/globals/quests");
+require("scripts/globals/common")
+require("scripts/globals/quests")
 -----------------------------------------
 
 function onFurniturePlaced(player)

--- a/scripts/globals/log_ids.lua
+++ b/scripts/globals/log_ids.lua
@@ -8,216 +8,216 @@ SANDORIA =
     ['mission_log']= 0,
     ['quest_log']= 0,
     ['fame_area']= 0
-};
+}
 BASTOK =
 {
     ['full_name'] = "Bastok",
     ['mission_log']= 1,
     ['quest_log']= 1,
     ['fame_area']= 1
-};
+}
 WINDURST =
 {
     ['full_name'] = "Windurst",
     ['mission_log']= 2,
     ['quest_log']= 2,
     ['fame_area']= 2
-};
+}
 JEUNO =
 {
     ['full_name'] = "Jeuno",
     ['quest_log']= 3,
     ['fame_area']= 3
-};
+}
 SELBINA =
 {
     ['full_name'] = "Selbina",
     ['quest_log']= 4,
     ['fame_area']= 4
-};
+}
 MHAURA =
 {
     ['full_name'] = "Mhaura",
     ['quest_log']= 4,
     ['fame_area']= 2
-};
+}
 RABAO =
 {
     ['full_name'] = "Rabao",
     ['quest_log']= 5,
     ['fame_area']= 4
-};
+}
 KAZHAM =
 {
     ['full_name'] = "Kazham",
     ['quest_log']= 5,
     ['fame_area']= 2
-};
+}
 NORG =
 {
     ['full_name'] = "Norg",
     ['quest_log']= 5,
     ['fame_area']= 5
-};
+}
 OTHER_AREAS_LOG =
 {
     ['full_name'] = "Other Areas",
     ['quest_log']= 4
-};
+}
 TAVNAZIA =
 {
     ['full_name'] = "Tavnazian Safehold",
     ['quest_log']= 4
-};
+}
 OUTLANDS =
 {
     ['full_name'] = "Outlands",
     ['quest_log']= 5
-};
+}
 ZILART =
 {
     ['full_name'] = "Rise of the Zilart",
     ['mission_log']= 3,
     ['quest_log']= 5
-};
+}
 COP =
 {
     ['full_name'] = "Chains of Promathia",
     ['mission_log']= 6,
     ['quest_log']= 4
-};
+}
 TOAU =
 {
     ['full_name'] = "Treasures of Aht Urhgan",
     ['mission_log']= 4,
     ['quest_log']= 6
-};
+}
 AHT_URHGAN =
 {
     ['full_name'] = "Aht Urhgan",
     ['mission_log']= 4,
     ['quest_log']= 6
-};
+}
 ASSAULT =
 {
     ['full_name'] = "Assault",
     ['mission_log']= 7
-};
+}
 WOTG =
 {
     ['full_name'] = "Wings of the Goddess",
     ['mission_log']= 5,
     ['quest_log']= 7
-};
+}
 CRYSTAL_WAR =
 {
     ['full_name'] = "Crystal War",
     ['mission_log']= 5,
     ['quest_log']= 7
-};
+}
 CAMPAIGN =
 {
     ['full_name'] = "Campaign",
     ['mission_log']= 8
-};
+}
 ACP =
 {
     ['full_name'] = "A Crystalline Prophecy",
     ['mission_log']= 9
-};
+}
 AMK =
 {
     ['full_name'] = "A Moogle Kupo d'Etat",
     ['mission_log']= 10
-};
+}
 ASA =
 {
     ['full_name'] = "A Shantotto Ascension",
     ['mission_log']= 11
-};
+}
 ABYSSEA =
 {
     ['full_name'] = "Abyssea",
     ['quest_log']= 8
-};
+}
 ABYSSEA_KONSCHTAT =
 {
     ['full_name'] = "Abyssea - Konschtat",
     ['quest_log']= 8,
     ['fame_area']= 6
-};
+}
 ABYSSEA_TAHRONGI =
 {
     ['full_name'] = "Abyssea - Tahrongi",
     ['quest_log']= 8,
     ['fame_area']= 7
-};
+}
 ABYSSEA_LATHEINE =
 {
     ['full_name'] = "Abyssea - La'Theine",
     ['quest_log']= 8,
     ['fame_area']= 8
-};
+}
 ABYSSEA_MISAREAUX =
 {
     ['full_name'] = "Abyssea - Misareaux",
     ['quest_log']= 8,
     ['fame_area']= 9
-};
+}
 ABYSSEA_VUNKERL =
 {
     ['full_name'] = "Abyssea - Vunkerl",
     ['quest_log']= 8,
     ['fame_area']= 10
-};
+}
 ABYSSEA_ATTOHWA =
 {
     ['full_name'] = "Abyssea - Attohwa",
     ['quest_log']= 8,
     ['fame_area']= 11
-};
+}
 ABYSSEA_ALTEPA =
 {
     ['full_name'] = "Abyssea - Altepa",
     ['quest_log']= 8,
     ['fame_area']= 12
-};
+}
 ABYSSEA_GRAUBERG =
 {
     ['full_name'] = "Abyssea - Grauberg",
     ['quest_log']= 8,
     ['fame_area']= 13
-};
+}
 ABYSSEA_ULEGUERAND =
 {
     ['full_name'] = "Abyssea - Uleguerand",
     ['quest_log']= 8,
     ['fame_area']= 14
-};
+}
 SOA =
 {
     ['full_name'] = "Seekers of Adoulin",
     ['mission_log']= 12,
     ['quest_log']= 9,
     ['fame_area']= 15
-};
+}
 ADOULIN =
 {
     ['full_name'] = "Adoulin",
     ['mission_log']= 12,
     ['quest_log']= 9,
     ['fame_area']= 15
-};
+}
 COALITION =
 {
     ['full_name'] = "Coalition",
     ['quest_log']= 10
-};
+}
 ROV =
 {
     ['full_name'] = "Rhapsodies of Vana'diel",
     ['mission_log']= 13
-};
+}
 
 QUEST_LOGS = {
     [0] = "SANDORIA",
@@ -231,7 +231,7 @@ QUEST_LOGS = {
     [8] = "ABYSSEA",
     [9] = "SOA",
     [10] = "COALITION",
-};
+}
 
 MISSION_LOGS = {
     [0] = "SANDORIA",
@@ -248,49 +248,49 @@ MISSION_LOGS = {
     [11] = "ASA",
     [12] = "SOA",
     [13] = "ROV",
-};
+}
 
 function GetQMLogInfo(cmdParamText, logNameTable)
     -- Returns the table from this file after validating
     if (cmdParamText == nil) then return nil end
     if (type(logNameTable) ~= "table") then return nil end
-    local logName;
-    local ret = nil;
-    local logIdNum = tonumber(cmdParamText);
+    local logName
+    local ret = nil
+    local logIdNum = tonumber(cmdParamText)
     if (logIdNum ~= nil) then
-        logName = logNameTable[logIdNum];
+        logName = logNameTable[logIdNum]
     else
-        logName = string.upper(cmdParamText);
+        logName = string.upper(cmdParamText)
     end
     if (logName ~= nil) then
-        ret = _G[logName];
+        ret = _G[logName]
         if ((type(ret) == "table") and (type(ret.full_name) == "string")) then
-            return ret;
+            return ret
         else
-            logName = logName .. "_LOG";
-            ret = _G[logName];
+            logName = logName .. "_LOG"
+            ret = _G[logName]
             if ((type(ret) == "table") and (type(ret.full_name) == "string")) then
-                return ret;
+                return ret
             end
         end
     end
-    return nil;
+    return nil
 end
 
 function GetQuestLogInfo(cmdParamText)
-    local ret = GetQMLogInfo(cmdParamText, QUEST_LOGS);
+    local ret = GetQMLogInfo(cmdParamText, QUEST_LOGS)
     if ((type(ret) == "table") and (type(ret.quest_log) == "number")) then
-        return ret;
+        return ret
     else
-        return nil;
+        return nil
     end
 end
 
 function GetMissionLogInfo(cmdParamText)
-    local ret = GetQMLogInfo(cmdParamText, MISSION_LOGS);
+    local ret = GetQMLogInfo(cmdParamText, MISSION_LOGS)
     if ((type(ret) == "table") and (type(ret.mission_log)) == "number") then
-        return ret;
+        return ret
     else
-        return nil;
+        return nil
     end
 end

--- a/scripts/globals/magiantrials.lua
+++ b/scripts/globals/magiantrials.lua
@@ -7,101 +7,101 @@
 -----------------------------------
 -- once fully filled out, these info tables might get large enough to need their own file, we'll see...
 function getTrialInfo(ItemID)
-    local TrialInfo = {};
+    local TrialInfo = {}
     if (ItemID == 19327) then -- Pugilists
-        TrialInfo.t1 = 68;
-        TrialInfo.t2 = 82;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 68
+        TrialInfo.t2 = 82
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 19332) then -- Peeler
-        TrialInfo.t1 = 2;
-        TrialInfo.t2 = 16;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 2
+        TrialInfo.t2 = 16
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 19337) then -- Side-sword
-        TrialInfo.t1 = 150;
-        TrialInfo.t2 = 164;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 150
+        TrialInfo.t2 = 164
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 19342) then -- Break Blade
-        TrialInfo.t1 = 216;
-        TrialInfo.t2 = 230;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 216
+        TrialInfo.t2 = 230
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 19347) then -- Chopper
-        TrialInfo.t1 = 282;
-        TrialInfo.t2 = 296;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 282
+        TrialInfo.t2 = 296
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 19352) then -- Lumberjack
-        TrialInfo.t1 = 364;
-        TrialInfo.t2 = 378;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 364
+        TrialInfo.t2 = 378
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 19357) then -- Farmhand
-        TrialInfo.t1 = 512;
-        TrialInfo.t2 = 526;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 512
+        TrialInfo.t2 = 526
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 19362) then -- Ranseur
-        TrialInfo.t1 = 430;
-        TrialInfo.t2 = 444;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 430
+        TrialInfo.t2 = 444
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 19367) then -- KibaShiri
-        TrialInfo.t1 = 578;
-        TrialInfo.t2 = 592;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 578
+        TrialInfo.t2 = 592
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 19372) then -- Donto
-        TrialInfo.t1 = 644;
-        TrialInfo.t2 = 658;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 644
+        TrialInfo.t2 = 658
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 19377) then -- Stenz
-        TrialInfo.t1 = 710;
-        TrialInfo.t2 = 724;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 710
+        TrialInfo.t2 = 724
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 19382) then -- Crook
-        TrialInfo.t1 = 776;
-        TrialInfo.t2 = 790;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 776
+        TrialInfo.t2 = 790
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 19387) then -- Sparrow
-        TrialInfo.t1 = 0;
-        TrialInfo.t2 = 0;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 0
+        TrialInfo.t2 = 0
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 19392) then -- Thunderstick
-        TrialInfo.t1 = 941;
-        TrialInfo.t2 = 891;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 941
+        TrialInfo.t2 = 891
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     -- elsif
     --
     else -- Not a valid Item, return zeros for all.
-        TrialInfo.t1 = 0;
-        TrialInfo.t2 = 0;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 0
+        TrialInfo.t2 = 0
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     end
-end;
+end
 
 
 -----------------------------------
@@ -109,135 +109,135 @@ end;
 -----------------------------------
 
 function getEmoteTrialInfo(ItemID)
-    local TrialInfo = {};
+    local TrialInfo = {}
     if (ItemID == 11988) then -- Fighter's Torque
-        TrialInfo.t1 = 4424;
-        TrialInfo.t2 = 0;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 4424
+        TrialInfo.t2 = 0
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 11989) then -- Temple Torque
-        TrialInfo.t1 = 4425;
-        TrialInfo.t2 = 0;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 4425
+        TrialInfo.t2 = 0
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 11990) then -- Healer's Torque
-        TrialInfo.t1 = 4426;
-        TrialInfo.t2 = 0;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 4426
+        TrialInfo.t2 = 0
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 11991) then -- Wizard's Torque
-        TrialInfo.t1 = 4427;
-        TrialInfo.t2 = 0;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 4427
+        TrialInfo.t2 = 0
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 11992) then -- Warlock's Torque
-        TrialInfo.t1 = 4428;
-        TrialInfo.t2 = 0;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 4428
+        TrialInfo.t2 = 0
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 11993) then -- Rogue's Torque
-        TrialInfo.t1 = 4429;
-        TrialInfo.t2 = 0;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 4429
+        TrialInfo.t2 = 0
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 11994) then -- Gallant Torque
-        TrialInfo.t1 = 4430;
-        TrialInfo.t2 = 0;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 4430
+        TrialInfo.t2 = 0
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 11995) then -- Chaos Torque
-        TrialInfo.t1 = 4431;
-        TrialInfo.t2 = 0;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 4431
+        TrialInfo.t2 = 0
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 11996) then -- Beast Torque
-        TrialInfo.t1 = 4432;
-        TrialInfo.t2 = 0;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 4432
+        TrialInfo.t2 = 0
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 11997) then -- Choral Torque
-        TrialInfo.t1 = 4433;
-        TrialInfo.t2 = 0;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 4433
+        TrialInfo.t2 = 0
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 11998) then -- Hunter's Torque
-        TrialInfo.t1 = 4434;
-        TrialInfo.t2 = 0;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 4434
+        TrialInfo.t2 = 0
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 11999) then -- Myochin Shusa
-        TrialInfo.t1 = 4435;
-        TrialInfo.t2 = 0;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 4435
+        TrialInfo.t2 = 0
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 12000) then -- Ninja Shusa
-        TrialInfo.t1 = 4436;
-        TrialInfo.t2 = 0;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 4436
+        TrialInfo.t2 = 0
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 12001) then -- Drachen Torque
-        TrialInfo.t1 = 4437;
-        TrialInfo.t2 = 0;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 4437
+        TrialInfo.t2 = 0
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 12002) then -- Evoker's Torque
-        TrialInfo.t1 = 4438;
-        TrialInfo.t2 = 0;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 4438
+        TrialInfo.t2 = 0
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 12003) then -- Magus Torque
-        TrialInfo.t1 = 4439;
-        TrialInfo.t2 = 0;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 4439
+        TrialInfo.t2 = 0
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 12004) then -- Corsair's Torque
-        TrialInfo.t1 = 4440;
-        TrialInfo.t2 = 0;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 4440
+        TrialInfo.t2 = 0
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 12005) then -- Puppetry Torque
-        TrialInfo.t1 = 4441;
-        TrialInfo.t2 = 0;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 4441
+        TrialInfo.t2 = 0
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 12006) then -- Dancer's Torque
-        TrialInfo.t1 = 4442;
-        TrialInfo.t2 = 0;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 4442
+        TrialInfo.t2 = 0
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     elseif (ItemID == 12007) then -- Scholar's Torque
-        TrialInfo.t1 = 4443;
-        TrialInfo.t2 = 0;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 4443
+        TrialInfo.t2 = 0
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     else -- Not a valid Item, return zeros for all.
-        TrialInfo.t1 = 0;
-        TrialInfo.t2 = 0;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 0
+        TrialInfo.t2 = 0
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     end
-end;
+end
 
 
 -----------------------------------
@@ -245,21 +245,21 @@ end;
 -----------------------------------
 
 function getRelicTrialInfo(ItemID)
-    local TrialInfo = {};
+    local TrialInfo = {}
     if (ItemID == 19327) then --
-        TrialInfo.t1 = 0;
-        TrialInfo.t2 = 0;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 0
+        TrialInfo.t2 = 0
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     else -- Not a valid Item, return zeros for all.
-        TrialInfo.t1 = 0;
-        TrialInfo.t2 = 0;
-        TrialInfo.t3 = 0;
-        TrialInfo.t4 = 0;
-        return TrialInfo;
+        TrialInfo.t1 = 0
+        TrialInfo.t2 = 0
+        TrialInfo.t3 = 0
+        TrialInfo.t4 = 0
+        return TrialInfo
     end
-end;
+end
 
 -----------------------------------
 -- magianOrangeEventUpdate
@@ -269,44 +269,44 @@ function magianOrangeEventUpdate(player,ItemID,csid,option)
     -- DO NOT try to convert into "elseif" !
     -- Probably need to table all this too, for now I'm just mapping it out.
     if (csid == 10124 and option == 4456449) then
-        local ReqItemAugFlag = 2; -- 2 = ON, anything else = OFF.
-        local ReqItemAug1 = 1;
-        local ReqItemAug2 = 1;
-        local ReqItem = 19332;
-        local TrialID = 9;
-        player:updateEvent(ReqItemAugFlag, ReqItemAug1, ReqItemAug2, ReqItem, 0, 0, TrialID);
+        local ReqItemAugFlag = 2 -- 2 = ON, anything else = OFF.
+        local ReqItemAug1 = 1
+        local ReqItemAug2 = 1
+        local ReqItem = 19332
+        local TrialID = 9
+        player:updateEvent(ReqItemAugFlag, ReqItemAug1, ReqItemAug2, ReqItem, 0, 0, TrialID)
     end
     if (csid == 10124 and option == 4456450) then
-        local TotalObjectives = 11;
-        player:updateEvent(TotalObjectives);
+        local TotalObjectives = 11
+        player:updateEvent(TotalObjectives)
     end
     if (csid == 10124 and option == 4456451) then
-        local RewardAugFlag = 2; -- 2 = ON, anything else = OFF.
-        local RewardAug1 = 1;
-        local RewardAug2 = 1;
-        local RewardItem = 19328;
-        player:updateEvent(RewardAugFlag, RewardAug1, RewardAug2, RewardItem);
+        local RewardAugFlag = 2 -- 2 = ON, anything else = OFF.
+        local RewardAug1 = 1
+        local RewardAug2 = 1
+        local RewardItem = 19328
+        player:updateEvent(RewardAugFlag, RewardAug1, RewardAug2, RewardItem)
     end
     if (csid == 10124 and option == 4456452) then
-        local ResultTrial1 = 69;
-        local ResultTrial2 = 0;
-        local ResultTrial3 = 0;
-        local ResultTrial4 = 0;
-        local PrevTrial = 0;
-        player:updateEvent(ResultTrial1, ResultTrial2, ResultTrial3, ResultTrial4, PrevTrial);
+        local ResultTrial1 = 69
+        local ResultTrial2 = 0
+        local ResultTrial3 = 0
+        local ResultTrial4 = 0
+        local PrevTrial = 0
+        player:updateEvent(ResultTrial1, ResultTrial2, ResultTrial3, ResultTrial4, PrevTrial)
     end
-end;
+end
 
 -----------------------------------
 -- magianGreenEventUpdate
 -----------------------------------
 
 function magianGreenEventUpdate(player,ItemID,csid,option)
-end;
+end
 
 -----------------------------------
 -- magianBlueEventUpdate
 -----------------------------------
 
 function magianBlueEventUpdate(player,ItemID,csid,option)
-end;
+end

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -1,13 +1,13 @@
-require("scripts/globals/magicburst");
-require("scripts/globals/settings");
-require("scripts/globals/weather");
-require("scripts/globals/status");
-require("scripts/globals/utils");
-require("scripts/globals/msg");
+require("scripts/globals/magicburst")
+require("scripts/globals/settings")
+require("scripts/globals/weather")
+require("scripts/globals/status")
+require("scripts/globals/utils")
+require("scripts/globals/msg")
 ------------------------------------
 
-tpz = tpz or {};
-tpz.magic = tpz.magic or {};
+tpz = tpz or {}
+tpz.magic = tpz.magic or {}
 
 ------------------------------------
 -- Elements
@@ -26,7 +26,7 @@ tpz.magic.element =
     LIGHT     = 7,
     DARK      = 8,
 }
-tpz.magic.ele = tpz.magic.element;
+tpz.magic.ele = tpz.magic.element
 
 ------------------------------------
 -- Spell Groups
@@ -74,25 +74,25 @@ tpz.magic.spellFlag =
 -- Tables by element
 ------------------------------------
 
-tpz.magic.dayStrong           = {tpz.day.FIRESDAY,              tpz.day.EARTHSDAY,              tpz.day.WATERSDAY,               tpz.day.WINDSDAY,              tpz.day.ICEDAY,               tpz.day.LIGHTNINGDAY,            tpz.day.LIGHTSDAY,           tpz.day.DARKSDAY};
-tpz.magic.singleWeatherStrong = {tpz.weather.HOT_SPELL,         tpz.weather.DUST_STORM,         tpz.weather.RAIN,                tpz.weather.WIND,              tpz.weather.SNOW,             tpz.weather.THUNDER,             tpz.weather.AURORAS,         tpz.weather.GLOOM};
-tpz.magic.doubleWeatherStrong = {tpz.weather.HEAT_WAVE,         tpz.weather.SAND_STORM,         tpz.weather.SQUALL,              tpz.weather.GALES,             tpz.weather.BLIZZARDS,        tpz.weather.THUNDERSTORMS,       tpz.weather.STELLAR_GLARE,   tpz.weather.DARKNESS};
-local elementalObiStrong      = {tpz.mod.FORCE_FIRE_DWBONUS,    tpz.mod.FORCE_EARTH_DWBONUS,    tpz.mod.FORCE_WATER_DWBONUS,     tpz.mod.FORCE_WIND_DWBONUS,    tpz.mod.FORCE_ICE_DWBONUS,    tpz.mod.FORCE_LIGHTNING_DWBONUS, tpz.mod.FORCE_LIGHT_DWBONUS, tpz.mod.FORCE_DARK_DWBONUS};
-local spellAcc                = {tpz.mod.FIREACC,               tpz.mod.EARTHACC,               tpz.mod.WATERACC,                tpz.mod.WINDACC,               tpz.mod.ICEACC,               tpz.mod.THUNDERACC,              tpz.mod.LIGHTACC,            tpz.mod.DARKACC};
-local strongAffinityDmg       = {tpz.mod.FIRE_AFFINITY_DMG,     tpz.mod.EARTH_AFFINITY_DMG,     tpz.mod.WATER_AFFINITY_DMG,      tpz.mod.WIND_AFFINITY_DMG,     tpz.mod.ICE_AFFINITY_DMG,     tpz.mod.THUNDER_AFFINITY_DMG,    tpz.mod.LIGHT_AFFINITY_DMG,  tpz.mod.DARK_AFFINITY_DMG};
-local strongAffinityAcc       = {tpz.mod.FIRE_AFFINITY_ACC,     tpz.mod.EARTH_AFFINITY_ACC,     tpz.mod.WATER_AFFINITY_ACC,      tpz.mod.WIND_AFFINITY_ACC,     tpz.mod.ICE_AFFINITY_ACC,     tpz.mod.THUNDER_AFFINITY_ACC,    tpz.mod.LIGHT_AFFINITY_ACC,  tpz.mod.DARK_AFFINITY_ACC};
-tpz.magic.resistMod           = {tpz.mod.FIRERES,               tpz.mod.EARTHRES,               tpz.mod.WATERRES,                tpz.mod.WINDRES,               tpz.mod.ICERES,               tpz.mod.THUNDERRES,              tpz.mod.LIGHTRES,            tpz.mod.DARKRES};
-tpz.magic.defenseMod          = {tpz.mod.FIREDEF,               tpz.mod.EARTHDEF,               tpz.mod.WATERDEF,                tpz.mod.WINDDEF,               tpz.mod.ICEDEF,               tpz.mod.THUNDERDEF,              tpz.mod.LIGHTDEF,            tpz.mod.DARKDEF};
-tpz.magic.absorbMod           = {tpz.mod.FIRE_ABSORB,           tpz.mod.EARTH_ABSORB,           tpz.mod.WATER_ABSORB,            tpz.mod.WIND_ABSORB,           tpz.mod.ICE_ABSORB,           tpz.mod.LTNG_ABSORB,             tpz.mod.LIGHT_ABSORB,        tpz.mod.DARK_ABSORB};
-local nullMod                 = {tpz.mod.FIRE_NULL,             tpz.mod.EARTH_NULL,             tpz.mod.WATER_NULL,              tpz.mod.WIND_NULL,             tpz.mod.ICE_NULL,             tpz.mod.LTNG_NULL,               tpz.mod.LIGHT_NULL,          tpz.mod.DARK_NULL};
-local blmMerit                = {tpz.merit.FIRE_MAGIC_POTENCY,  tpz.merit.EARTH_MAGIC_POTENCY,  tpz.merit.WATER_MAGIC_POTENCY,   tpz.merit.WIND_MAGIC_POTENCY,  tpz.merit.ICE_MAGIC_POTENCY,  tpz.merit.LIGHTNING_MAGIC_POTENCY};
-local rdmMerit                = {tpz.merit.FIRE_MAGIC_ACCURACY, tpz.merit.EARTH_MAGIC_ACCURACY, tpz.merit.WATER_MAGIC_ACCURACY,  tpz.merit.WIND_MAGIC_ACCURACY, tpz.merit.ICE_MAGIC_ACCURACY, tpz.merit.LIGHTNING_MAGIC_ACCURACY};
-tpz.magic.barSpell            = {tpz.effect.BARFIRE,            tpz.effect.BARSTONE,            tpz.effect.BARWATER,             tpz.effect.BARAERO,            tpz.effect.BARBLIZZARD,       tpz.effect.BARTHUNDER};
+tpz.magic.dayStrong           = {tpz.day.FIRESDAY,              tpz.day.EARTHSDAY,              tpz.day.WATERSDAY,               tpz.day.WINDSDAY,              tpz.day.ICEDAY,               tpz.day.LIGHTNINGDAY,            tpz.day.LIGHTSDAY,           tpz.day.DARKSDAY}
+tpz.magic.singleWeatherStrong = {tpz.weather.HOT_SPELL,         tpz.weather.DUST_STORM,         tpz.weather.RAIN,                tpz.weather.WIND,              tpz.weather.SNOW,             tpz.weather.THUNDER,             tpz.weather.AURORAS,         tpz.weather.GLOOM}
+tpz.magic.doubleWeatherStrong = {tpz.weather.HEAT_WAVE,         tpz.weather.SAND_STORM,         tpz.weather.SQUALL,              tpz.weather.GALES,             tpz.weather.BLIZZARDS,        tpz.weather.THUNDERSTORMS,       tpz.weather.STELLAR_GLARE,   tpz.weather.DARKNESS}
+local elementalObiStrong      = {tpz.mod.FORCE_FIRE_DWBONUS,    tpz.mod.FORCE_EARTH_DWBONUS,    tpz.mod.FORCE_WATER_DWBONUS,     tpz.mod.FORCE_WIND_DWBONUS,    tpz.mod.FORCE_ICE_DWBONUS,    tpz.mod.FORCE_LIGHTNING_DWBONUS, tpz.mod.FORCE_LIGHT_DWBONUS, tpz.mod.FORCE_DARK_DWBONUS}
+local spellAcc                = {tpz.mod.FIREACC,               tpz.mod.EARTHACC,               tpz.mod.WATERACC,                tpz.mod.WINDACC,               tpz.mod.ICEACC,               tpz.mod.THUNDERACC,              tpz.mod.LIGHTACC,            tpz.mod.DARKACC}
+local strongAffinityDmg       = {tpz.mod.FIRE_AFFINITY_DMG,     tpz.mod.EARTH_AFFINITY_DMG,     tpz.mod.WATER_AFFINITY_DMG,      tpz.mod.WIND_AFFINITY_DMG,     tpz.mod.ICE_AFFINITY_DMG,     tpz.mod.THUNDER_AFFINITY_DMG,    tpz.mod.LIGHT_AFFINITY_DMG,  tpz.mod.DARK_AFFINITY_DMG}
+local strongAffinityAcc       = {tpz.mod.FIRE_AFFINITY_ACC,     tpz.mod.EARTH_AFFINITY_ACC,     tpz.mod.WATER_AFFINITY_ACC,      tpz.mod.WIND_AFFINITY_ACC,     tpz.mod.ICE_AFFINITY_ACC,     tpz.mod.THUNDER_AFFINITY_ACC,    tpz.mod.LIGHT_AFFINITY_ACC,  tpz.mod.DARK_AFFINITY_ACC}
+tpz.magic.resistMod           = {tpz.mod.FIRERES,               tpz.mod.EARTHRES,               tpz.mod.WATERRES,                tpz.mod.WINDRES,               tpz.mod.ICERES,               tpz.mod.THUNDERRES,              tpz.mod.LIGHTRES,            tpz.mod.DARKRES}
+tpz.magic.defenseMod          = {tpz.mod.FIREDEF,               tpz.mod.EARTHDEF,               tpz.mod.WATERDEF,                tpz.mod.WINDDEF,               tpz.mod.ICEDEF,               tpz.mod.THUNDERDEF,              tpz.mod.LIGHTDEF,            tpz.mod.DARKDEF}
+tpz.magic.absorbMod           = {tpz.mod.FIRE_ABSORB,           tpz.mod.EARTH_ABSORB,           tpz.mod.WATER_ABSORB,            tpz.mod.WIND_ABSORB,           tpz.mod.ICE_ABSORB,           tpz.mod.LTNG_ABSORB,             tpz.mod.LIGHT_ABSORB,        tpz.mod.DARK_ABSORB}
+local nullMod                 = {tpz.mod.FIRE_NULL,             tpz.mod.EARTH_NULL,             tpz.mod.WATER_NULL,              tpz.mod.WIND_NULL,             tpz.mod.ICE_NULL,             tpz.mod.LTNG_NULL,               tpz.mod.LIGHT_NULL,          tpz.mod.DARK_NULL}
+local blmMerit                = {tpz.merit.FIRE_MAGIC_POTENCY,  tpz.merit.EARTH_MAGIC_POTENCY,  tpz.merit.WATER_MAGIC_POTENCY,   tpz.merit.WIND_MAGIC_POTENCY,  tpz.merit.ICE_MAGIC_POTENCY,  tpz.merit.LIGHTNING_MAGIC_POTENCY}
+local rdmMerit                = {tpz.merit.FIRE_MAGIC_ACCURACY, tpz.merit.EARTH_MAGIC_ACCURACY, tpz.merit.WATER_MAGIC_ACCURACY,  tpz.merit.WIND_MAGIC_ACCURACY, tpz.merit.ICE_MAGIC_ACCURACY, tpz.merit.LIGHTNING_MAGIC_ACCURACY}
+tpz.magic.barSpell            = {tpz.effect.BARFIRE,            tpz.effect.BARSTONE,            tpz.effect.BARWATER,             tpz.effect.BARAERO,            tpz.effect.BARBLIZZARD,       tpz.effect.BARTHUNDER}
 
-tpz.magic.dayWeak             = {tpz.day.WATERSDAY,             tpz.day.WINDSDAY,               tpz.day.LIGHTNINGDAY,            tpz.day.ICEDAY,                tpz.day.FIRESDAY,             tpz.day.EARTHSDAY,               tpz.day.DARKSDAY,            tpz.day.LIGHTSDAY};
-tpz.magic.singleWeatherWeak   = {tpz.weather.RAIN,              tpz.weather.WIND,               tpz.weather.THUNDER,             tpz.weather.SNOW,              tpz.weather.HOT_SPELL,        tpz.weather.DUST_STORM,          tpz.weather.GLOOM,           tpz.weather.AURORAS};
-tpz.magic.doubleWeatherWeak   = {tpz.weather.SQUALL,            tpz.weather.GALES,              tpz.weather.THUNDERSTORMS,       tpz.weather.BLIZZARDS,         tpz.weather.HEAT_WAVE,        tpz.weather.SAND_STORM,          tpz.weather.DARKNESS,        tpz.weather.STELLAR_GLARE};
-local elementalObiWeak        = {tpz.mod.FORCE_WATER_DWBONUS,   tpz.mod.FORCE_WIND_DWBONUS,     tpz.mod.FORCE_LIGHTNING_DWBONUS, tpz.mod.FORCE_ICE_DWBONUS,     tpz.mod.FORCE_FIRE_DWBONUS,   tpz.mod.FORCE_EARTH_DWBONUS,     tpz.mod.FORCE_DARK_DWBONUS,  tpz.mod.FORCE_LIGHT_DWBONUS};
+tpz.magic.dayWeak             = {tpz.day.WATERSDAY,             tpz.day.WINDSDAY,               tpz.day.LIGHTNINGDAY,            tpz.day.ICEDAY,                tpz.day.FIRESDAY,             tpz.day.EARTHSDAY,               tpz.day.DARKSDAY,            tpz.day.LIGHTSDAY}
+tpz.magic.singleWeatherWeak   = {tpz.weather.RAIN,              tpz.weather.WIND,               tpz.weather.THUNDER,             tpz.weather.SNOW,              tpz.weather.HOT_SPELL,        tpz.weather.DUST_STORM,          tpz.weather.GLOOM,           tpz.weather.AURORAS}
+tpz.magic.doubleWeatherWeak   = {tpz.weather.SQUALL,            tpz.weather.GALES,              tpz.weather.THUNDERSTORMS,       tpz.weather.BLIZZARDS,         tpz.weather.HEAT_WAVE,        tpz.weather.SAND_STORM,          tpz.weather.DARKNESS,        tpz.weather.STELLAR_GLARE}
+local elementalObiWeak        = {tpz.mod.FORCE_WATER_DWBONUS,   tpz.mod.FORCE_WIND_DWBONUS,     tpz.mod.FORCE_LIGHTNING_DWBONUS, tpz.mod.FORCE_ICE_DWBONUS,     tpz.mod.FORCE_FIRE_DWBONUS,   tpz.mod.FORCE_EARTH_DWBONUS,     tpz.mod.FORCE_DARK_DWBONUS,  tpz.mod.FORCE_LIGHT_DWBONUS}
 
 -- USED FOR DAMAGING MAGICAL SPELLS (Stages 1 and 2 in Calculating Magic Damage on wiki)
 --Calculates magic damage using the standard magic damage calc.
@@ -106,38 +106,38 @@ local elementalObiWeak        = {tpz.mod.FORCE_WATER_DWBONUS,   tpz.mod.FORCE_WI
 --
 -- Output:
 -- The total damage, before resistance and before equipment (so no HQ staff bonus worked out here).
-local SOFT_CAP = 60; --guesstimated
-local HARD_CAP = 120; --guesstimated
+local SOFT_CAP = 60 --guesstimated
+local HARD_CAP = 120 --guesstimated
 
 function calculateMagicDamage(caster, target, spell, params)
 
-    local dINT = caster:getStat(params.attribute) - target:getStat(params.attribute);
-    local dmg = params.dmg;
+    local dINT = caster:getStat(params.attribute) - target:getStat(params.attribute)
+    local dmg = params.dmg
 
     if (dINT <= 0) then --if dINT penalises, it's always M=1
-        dmg = dmg + dINT;
+        dmg = dmg + dINT
         if (dmg <= 0) then --dINT penalty cannot result in negative damage (target absorption)
-            return 0;
+            return 0
         end
     elseif (dINT > 0 and dINT <= SOFT_CAP) then --The standard calc, most spells hit this
-        dmg = dmg + (dINT * params.multiplier);
+        dmg = dmg + (dINT * params.multiplier)
     elseif (dINT > 0 and dINT > SOFT_CAP and dINT < HARD_CAP) then --After SOFT_CAP, INT is only half effective
-        dmg = dmg + SOFT_CAP * params.multiplier + ((dINT - SOFT_CAP) * params.multiplier) / 2;
+        dmg = dmg + SOFT_CAP * params.multiplier + ((dINT - SOFT_CAP) * params.multiplier) / 2
     elseif (dINT > 0 and dINT > SOFT_CAP and dINT >= HARD_CAP) then --After HARD_CAP, INT has no tpz.effect.
-        dmg = dmg + HARD_CAP * params.multiplier;
+        dmg = dmg + HARD_CAP * params.multiplier
     end
 
 
     if (params.skillType == tpz.skill.DIVINE_MAGIC and target:isUndead()) then
         -- 150% bonus damage
-        dmg = dmg * 1.5;
+        dmg = dmg * 1.5
     end
 
-    -- printf("dmg: %d dINT: %d\n", dmg, dINT);
+    -- printf("dmg: %d dINT: %d\n", dmg, dINT)
 
-    return dmg;
+    return dmg
 
-end;
+end
 
 function doBoostGain(caster, target, spell, effect)
     local duration = calculateDuration(300, spell:getSkillType(), spell:getSpellGroup(), caster, target)
@@ -153,7 +153,7 @@ function doBoostGain(caster, target, spell, effect)
         potency = 5
     end
 
-    --printf("BOOST-GAIN: POTENCY = %d", potency);
+    --printf("BOOST-GAIN: POTENCY = %d", potency)
 
     --Only one Boost Effect can be active at once, so if the player has any we have to cancel & overwrite
     local effectOverwrite =
@@ -168,9 +168,9 @@ function doBoostGain(caster, target, spell, effect)
     }
 
     for i, effect in ipairs(effectOverwrite) do
-            --printf("BOOST-GAIN: CHECKING FOR EFFECT %d...",effect);
+            --printf("BOOST-GAIN: CHECKING FOR EFFECT %d...",effect)
             if caster:hasStatusEffect(effect) then
-                --printf("BOOST-GAIN: HAS EFFECT %d, DELETING...",effect);
+                --printf("BOOST-GAIN: HAS EFFECT %d, DELETING...",effect)
                 caster:delStatusEffect(effect)
             end
     end
@@ -211,25 +211,25 @@ end
 --   Source: http://members.shaw.ca/pizza_steve/cure/Cure_Calculator.html
 ---------------------------------
 function getCurePower(caster,isBlueMagic)
-    local MND = caster:getStat(tpz.mod.MND);
-    local VIT = caster:getStat(tpz.mod.VIT);
-    local skill = caster:getSkillLevel(tpz.skill.HEALING_MAGIC);
-    local power = math.floor(MND/2) + math.floor(VIT/4) + skill;
-    return power;
-end;
+    local MND = caster:getStat(tpz.mod.MND)
+    local VIT = caster:getStat(tpz.mod.VIT)
+    local skill = caster:getSkillLevel(tpz.skill.HEALING_MAGIC)
+    local power = math.floor(MND/2) + math.floor(VIT/4) + skill
+    return power
+end
 function getCurePowerOld(caster)
-    local MND = caster:getStat(tpz.mod.MND);
-    local VIT = caster:getStat(tpz.mod.VIT);
-    local skill = caster:getSkillLevel(tpz.skill.HEALING_MAGIC); -- it's healing magic skill for the BLU cures as well
-    local power = ((3 * MND) + VIT + (3 * math.floor(skill/5)));
-    return power;
-end;
+    local MND = caster:getStat(tpz.mod.MND)
+    local VIT = caster:getStat(tpz.mod.VIT)
+    local skill = caster:getSkillLevel(tpz.skill.HEALING_MAGIC) -- it's healing magic skill for the BLU cures as well
+    local power = ((3 * MND) + VIT + (3 * math.floor(skill/5)))
+    return power
+end
 function getBaseCure(power,divisor,constant,basepower)
-    return ((power - basepower) / divisor) + constant;
-end;
+    return ((power - basepower) / divisor) + constant
+end
 function getBaseCureOld(power,divisor,constant)
-    return (power / 2) / divisor + constant;
-end;
+    return (power / 2) / divisor + constant
+end
 
 function getCureFinal(caster, spell, basecure, minCure, isBlueMagic)
     if basecure < minCure then
@@ -240,74 +240,74 @@ function getCureFinal(caster, spell, basecure, minCure, isBlueMagic)
     local curePotII = math.min(caster:getMod(tpz.mod.CURE_POTENCY_II), 30) / 100 -- caps at 30%
     local potency = 1 + curePot + curePotII
 
-    local dSeal = 1;
+    local dSeal = 1
     if (caster:hasStatusEffect(tpz.effect.DIVINE_SEAL)) then
-        dSeal = 2;
+        dSeal = 2
     end
 
-    local rapture = 1;
+    local rapture = 1
     if (isBlueMagic == false) then --rapture doesn't affect BLU cures as they're not white magic
         if (caster:hasStatusEffect(tpz.effect.RAPTURE)) then
-            rapture = 1.5 + caster:getMod(tpz.mod.RAPTURE_AMOUNT)/100;
-            caster:delStatusEffectSilent(tpz.effect.RAPTURE);
+            rapture = 1.5 + caster:getMod(tpz.mod.RAPTURE_AMOUNT)/100
+            caster:delStatusEffectSilent(tpz.effect.RAPTURE)
         end
     end
 
-    local dayWeatherBonus = 1;
-    local ele = spell:getElement();
+    local dayWeatherBonus = 1
+    local ele = spell:getElement()
 
-    local castersWeather = caster:getWeather();
+    local castersWeather = caster:getWeather()
 
     if (castersWeather == tpz.magic.singleWeatherStrong[ele]) then
         if (caster:getMod(tpz.mod.IRIDESCENCE) >= 1) then
             if (math.random() < 0.33 or caster:getMod(elementalObiStrong[ele]) >= 1) then
-                dayWeatherBonus = dayWeatherBonus + 0.10;
+                dayWeatherBonus = dayWeatherBonus + 0.10
             end
         end
         if (math.random() < 0.33 or caster:getMod(elementalObiStrong[ele]) >= 1) then
-            dayWeatherBonus = dayWeatherBonus + 0.10;
+            dayWeatherBonus = dayWeatherBonus + 0.10
         end
     elseif (castersWeather == tpz.magic.singleWeatherWeak[ele]) then
         if (math.random() < 0.33 or caster:getMod(elementalObiStrong[ele]) >= 1) then
-            dayWeatherBonus = dayWeatherBonus - 0.10;
+            dayWeatherBonus = dayWeatherBonus - 0.10
         end
     elseif (castersWeather == tpz.magic.doubleWeatherStrong[ele]) then
         if (caster:getMod(tpz.mod.IRIDESCENCE) >= 1) then
             if (math.random() < 0.33 or caster:getMod(elementalObiStrong[ele]) >= 1) then
-                dayWeatherBonus = dayWeatherBonus + 0.10;
+                dayWeatherBonus = dayWeatherBonus + 0.10
             end
         end
         if (math.random() < 0.33 or caster:getMod(elementalObiStrong[ele]) >= 1) then
-            dayWeatherBonus = dayWeatherBonus + 0.25;
+            dayWeatherBonus = dayWeatherBonus + 0.25
         end
     elseif (castersWeather == tpz.magic.doubleWeatherWeak[ele]) then
         if (math.random() < 0.33 or caster:getMod(elementalObiStrong[ele]) >= 1) then
-            dayWeatherBonus = dayWeatherBonus - 0.25;
+            dayWeatherBonus = dayWeatherBonus - 0.25
         end
     end
 
-    local dayElement = VanadielDayElement();
+    local dayElement = VanadielDayElement()
     if (dayElement == tpz.magic.dayStrong[ele]) then
         if (math.random() < 0.33 or caster:getMod(elementalObiStrong[ele]) >= 1) then
-            dayWeatherBonus = dayWeatherBonus + 0.10;
+            dayWeatherBonus = dayWeatherBonus + 0.10
         end
     elseif (dayElement == tpz.magic.dayWeak[ele]) then
         if (math.random() < 0.33 or caster:getMod(elementalObiStrong[ele]) >= 1) then
-            dayWeatherBonus = dayWeatherBonus - 0.10;
+            dayWeatherBonus = dayWeatherBonus - 0.10
         end
     end
 
     if (dayWeatherBonus > 1.4) then
-        dayWeatherBonus = 1.4;
+        dayWeatherBonus = 1.4
     end
 
-    local final = math.floor(math.floor(math.floor(math.floor(basecure) * potency) * dayWeatherBonus) * rapture) * dSeal;
-    return final;
-end;
+    local final = math.floor(math.floor(math.floor(math.floor(basecure) * potency) * dayWeatherBonus) * rapture) * dSeal
+    return final
+end
 
 function getCureAsNukeFinal(caster,spell,power,divisor,constant,basepower)
-    return getCureFinal(caster,spell,power,divisor,constant,basepower);
-end;
+    return getCureFinal(caster,spell,power,divisor,constant,basepower)
+end
 
 -----------------------------------
 -- Returns the staff bonus for the caster and spell.
@@ -318,19 +318,19 @@ end;
 
 function AffinityBonusDmg(caster,ele)
 
-    local affinity = caster:getMod(strongAffinityDmg[ele]);
-    local bonus = 1.00 + affinity * 0.05; -- 5% per level of affinity
-    -- print(bonus);
-    return bonus;
-end;
+    local affinity = caster:getMod(strongAffinityDmg[ele])
+    local bonus = 1.00 + affinity * 0.05 -- 5% per level of affinity
+    -- print(bonus)
+    return bonus
+end
 
 function AffinityBonusAcc(caster,ele)
 
-    local affinity = caster:getMod(strongAffinityAcc[ele]);
-    local bonus = 0 + affinity * 10; -- 10 acc per level of affinity
-    -- print(bonus);
-    return bonus;
-end;
+    local affinity = caster:getMod(strongAffinityAcc[ele])
+    local bonus = 0 + affinity * 10 -- 10 acc per level of affinity
+    -- print(bonus)
+    return bonus
+end
 
 -- USED FOR DAMAGING MAGICAL SPELLS. Stage 3 of Calculating Magic Damage on wiki
 -- Reduces damage ifit resists.
@@ -339,108 +339,108 @@ end;
 -- The factor to multiply down damage (1/2 1/4 1/8 1/16) - In this format so this func can be used for enfeebs on duration.
 
 function applyResistance(caster, target, spell, params)
-    return applyResistanceEffect(caster, target, spell, params);
-end;
+    return applyResistanceEffect(caster, target, spell, params)
+end
 
 -- USED FOR Status Effect Enfeebs (blind, slow, para, etc.)
 -- Output:
 -- The factor to multiply down duration (1/2 1/4 1/8 1/16)
 --[[
-local params = {};
-params.attribute = $2;
-params.skillType = $3;
-params.bonus = $4;
-params.effect = $5;
+local params = {}
+params.attribute = $2
+params.skillType = $3
+params.bonus = $4
+params.effect = $5
 ]]
 function applyResistanceEffect(caster, target, spell, params)
-    local diff = params.diff or (caster:getStat(params.attribute) - target:getStat(params.attribute));
-    local skill = params.skillType;
-    local bonus = params.bonus;
-    local effect = params.effect;
+    local diff = params.diff or (caster:getStat(params.attribute) - target:getStat(params.attribute))
+    local skill = params.skillType
+    local bonus = params.bonus
+    local effect = params.effect
 
     -- If Stymie is active, as long as the mob is not immune then the effect is not resisted
     if (effect ~= nil) then -- Dispel's script doesn't have an "effect" to send here, nor should it.
         if (skill == tpz.skill.ENFEEBLING_MAGIC and caster:hasStatusEffect(tpz.effect.STYMIE) and target:canGainStatusEffect(effect)) then
-            caster:delStatusEffect(tpz.effect.STYMIE);
-            return 1;
+            caster:delStatusEffect(tpz.effect.STYMIE)
+            return 1
         end
     end
 
     if (skill == tpz.skill.SINGING and caster:hasStatusEffect(tpz.effect.TROUBADOUR)) then
         if (math.random(0,99) < caster:getMerit(tpz.merit.TROUBADOUR)-25) then
-            return 1.0;
+            return 1.0
         end
     end
 
-    local element = spell:getElement();
-    local percentBonus = 0;
-    local magicaccbonus = getSpellBonusAcc(caster, target, spell, params);
+    local element = spell:getElement()
+    local percentBonus = 0
+    local magicaccbonus = getSpellBonusAcc(caster, target, spell, params)
 
     if (diff > 10) then
-        magicaccbonus = magicaccbonus + 10 + (diff - 10)/2;
+        magicaccbonus = magicaccbonus + 10 + (diff - 10)/2
     else
-        magicaccbonus = magicaccbonus + diff;
+        magicaccbonus = magicaccbonus + diff
     end
 
     if (bonus ~= nil) then
-        magicaccbonus = magicaccbonus + bonus;
+        magicaccbonus = magicaccbonus + bonus
     end
 
     if (effect ~= nil) then
-        percentBonus = percentBonus - getEffectResistance(target, effect);
+        percentBonus = percentBonus - getEffectResistance(target, effect)
     end
 
-    local p = getMagicHitRate(caster, target, skill, element, percentBonus, magicaccbonus);
+    local p = getMagicHitRate(caster, target, skill, element, percentBonus, magicaccbonus)
 
-    return getMagicResist(p);
-end;
+    return getMagicResist(p)
+end
 
 -- Applies resistance for things that may not be spells - ie. Quick Draw
 function applyResistanceAbility(player,target,element,skill,bonus)
-    local p = getMagicHitRate(player, target, skill, element, 0, bonus);
+    local p = getMagicHitRate(player, target, skill, element, 0, bonus)
 
-    return getMagicResist(p);
-end;
+    return getMagicResist(p)
+end
 
 -- Applies resistance for additional effects
 function applyResistanceAddEffect(player,target,element,bonus)
 
-    local p = getMagicHitRate(player, target, 0, element, 0, bonus);
+    local p = getMagicHitRate(player, target, 0, element, 0, bonus)
 
-    return getMagicResist(p);
-end;
+    return getMagicResist(p)
+end
 
 function getMagicHitRate(caster, target, skillType, element, percentBonus, bonusAcc)
     -- resist everything if magic shield is active
     if (target:hasStatusEffect(tpz.effect.MAGIC_SHIELD, 0)) then
-        return 0;
+        return 0
     end
 
-    local magiceva = 0;
+    local magiceva = 0
 
     if (bonusAcc == nil) then
-        bonusAcc = 0;
+        bonusAcc = 0
     end
 
-    local magicacc = caster:getMod(tpz.mod.MACC) + caster:getILvlMacc();
+    local magicacc = caster:getMod(tpz.mod.MACC) + caster:getILvlMacc()
 
     -- Get the base acc (just skill + skill mod (79 + skillID = ModID) + magic acc mod)
     if (skillType ~= 0) then
-        magicacc = magicacc + caster:getSkillLevel(skillType);
+        magicacc = magicacc + caster:getSkillLevel(skillType)
     else
         -- for mob skills / additional effects which don't have a skill
-        magicacc = magicacc + utils.getSkillLvl(1, caster:getMainLvl());
+        magicacc = magicacc + utils.getSkillLvl(1, caster:getMainLvl())
     end
 
-    local resMod = 0; -- Some spells may possibly be non elemental, but have status effects.
+    local resMod = 0 -- Some spells may possibly be non elemental, but have status effects.
     if (element ~= tpz.magic.ele.NONE) then
-        resMod = target:getMod(tpz.magic.resistMod[element]);
+        resMod = target:getMod(tpz.magic.resistMod[element])
 
         -- Add acc for elemental affinity accuracy and element specific accuracy
-        local affinityBonus = AffinityBonusAcc(caster, element);
-        local elementBonus = caster:getMod(spellAcc[element]);
-        -- print(elementBonus);
-        bonusAcc = bonusAcc + affinityBonus + elementBonus;
+        local affinityBonus = AffinityBonusAcc(caster, element)
+        local elementBonus = caster:getMod(spellAcc[element])
+        -- print(elementBonus)
+        bonusAcc = bonusAcc + affinityBonus + elementBonus
     end
 
     magicacc = magicacc + caster:getMerit(tpz.merit.MAGIC_ACCURACY)
@@ -448,130 +448,130 @@ function getMagicHitRate(caster, target, skillType, element, percentBonus, bonus
     magicacc = magicacc + caster:getMerit(tpz.merit.NIN_MAGIC_ACCURACY)
 
     -- Base magic evasion (base magic evasion plus resistances(players), plus elemental defense(mobs)
-    local magiceva = target:getMod(tpz.mod.MEVA) + resMod;
+    local magiceva = target:getMod(tpz.mod.MEVA) + resMod
 
-    magicacc = magicacc + bonusAcc;
+    magicacc = magicacc + bonusAcc
 
     -- Add macc% from food
-    local maccFood = magicacc * (caster:getMod(tpz.mod.FOOD_MACCP)/100);
-    magicacc = magicacc + utils.clamp(maccFood, 0, caster:getMod(tpz.mod.FOOD_MACC_CAP));
+    local maccFood = magicacc * (caster:getMod(tpz.mod.FOOD_MACCP)/100)
+    magicacc = magicacc + utils.clamp(maccFood, 0, caster:getMod(tpz.mod.FOOD_MACC_CAP))
 
-    return calculateMagicHitRate(magicacc, magiceva, percentBonus, caster:getMainLvl(), target:getMainLvl());
+    return calculateMagicHitRate(magicacc, magiceva, percentBonus, caster:getMainLvl(), target:getMainLvl())
 end
 
 function calculateMagicHitRate(magicacc, magiceva, percentBonus, casterLvl, targetLvl)
-    local p = 0;
+    local p = 0
     --add a scaling bonus or penalty based on difference of targets level from caster
-    local levelDiff = utils.clamp(casterLvl - targetLvl, -5, 5);
+    local levelDiff = utils.clamp(casterLvl - targetLvl, -5, 5)
 
-    p = 70 - 0.5 * (magiceva - magicacc) + levelDiff * 3 + percentBonus;
+    p = 70 - 0.5 * (magiceva - magicacc) + levelDiff * 3 + percentBonus
 
-    return utils.clamp(p, 5, 95);
+    return utils.clamp(p, 5, 95)
 end
 
 -- Returns resistance value from given magic hit rate (p)
 function getMagicResist(magicHitRate)
 
-    local p = magicHitRate / 100;
-    local resist = 1;
+    local p = magicHitRate / 100
+    local resist = 1
 
     -- Resistance thresholds based on p.  A higher p leads to lower resist rates, and a lower p leads to higher resist rates.
-    local half = (1 - p);
-    local quart = ((1 - p)^2);
-    local eighth = ((1 - p)^3);
-    local sixteenth = ((1 - p)^4);
-    -- print("HALF: "..half);
-    -- print("QUART: "..quart);
-    -- print("EIGHTH: "..eighth);
-    -- print("SIXTEENTH: "..sixteenth);
+    local half = (1 - p)
+    local quart = ((1 - p)^2)
+    local eighth = ((1 - p)^3)
+    local sixteenth = ((1 - p)^4)
+    -- print("HALF: "..half)
+    -- print("QUART: "..quart)
+    -- print("EIGHTH: "..eighth)
+    -- print("SIXTEENTH: "..sixteenth)
 
-    local resvar = math.random();
+    local resvar = math.random()
 
     -- Determine final resist based on which thresholds have been crossed.
     if (resvar <= sixteenth) then
-        resist = 0.0625;
-        --printf("Spell resisted to 1/16!!!  Threshold = %u",sixteenth);
+        resist = 0.0625
+        --printf("Spell resisted to 1/16!!!  Threshold = %u",sixteenth)
     elseif (resvar <= eighth) then
-        resist = 0.125;
-        --printf("Spell resisted to 1/8!  Threshold = %u",eighth);
+        resist = 0.125
+        --printf("Spell resisted to 1/8!  Threshold = %u",eighth)
     elseif (resvar <= quart) then
-        resist = 0.25;
-        --printf("Spell resisted to 1/4.  Threshold = %u",quart);
+        resist = 0.25
+        --printf("Spell resisted to 1/4.  Threshold = %u",quart)
     elseif (resvar <= half) then
-        resist = 0.5;
-        --printf("Spell resisted to 1/2.  Threshold = %u",half);
+        resist = 0.5
+        --printf("Spell resisted to 1/2.  Threshold = %u",half)
     else
-        resist = 1.0;
-        --printf("1.0");
+        resist = 1.0
+        --printf("1.0")
     end
 
-    return resist;
+    return resist
 end
 
 -- Returns the amount of resistance the
 -- target has to the given effect (stun, sleep, etc..)
 function getEffectResistance(target, effect)
-    local effectres = 0;
+    local effectres = 0
     if (effect == tpz.effect.SLEEP_I or effect == tpz.effect.SLEEP_II) then
-        effectres = tpz.mod.SLEEPRES;
+        effectres = tpz.mod.SLEEPRES
     elseif (effect == tpz.effect.LULLABY) then
-        effectres = tpz.mod.LULLABYRES;
+        effectres = tpz.mod.LULLABYRES
     elseif (effect == tpz.effect.POISON) then
-        effectres = tpz.mod.POISONRES;
+        effectres = tpz.mod.POISONRES
     elseif (effect == tpz.effect.PARALYSIS) then
-        effectres = tpz.mod.PARALYZERES;
+        effectres = tpz.mod.PARALYZERES
     elseif (effect == tpz.effect.BLINDNESS) then
         effectres = tpz.mod.BLINDRES
     elseif (effect == tpz.effect.SILENCE) then
-        effectres = tpz.mod.SILENCERES;
+        effectres = tpz.mod.SILENCERES
     elseif (effect == tpz.effect.PLAGUE or effect == tpz.effect.DISEASE) then
-        effectres = tpz.mod.VIRUSRES;
+        effectres = tpz.mod.VIRUSRES
     elseif (effect == tpz.effect.PETRIFICATION) then
-        effectres = tpz.mod.PETRIFYRES;
+        effectres = tpz.mod.PETRIFYRES
     elseif (effect == tpz.effect.BIND) then
-        effectres = tpz.mod.BINDRES;
+        effectres = tpz.mod.BINDRES
     elseif (effect == tpz.effect.CURSE_I or effect == tpz.effect.CURSE_II or effect == tpz.effect.BANE) then
-        effectres = tpz.mod.CURSERES;
+        effectres = tpz.mod.CURSERES
     elseif (effect == tpz.effect.WEIGHT) then
-        effectres = tpz.mod.GRAVITYRES;
+        effectres = tpz.mod.GRAVITYRES
     elseif (effect == tpz.effect.SLOW or effect == tpz.effect.ELEGY) then
-        effectres = tpz.mod.SLOWRES;
+        effectres = tpz.mod.SLOWRES
     elseif (effect == tpz.effect.STUN) then
-        effectres = tpz.mod.STUNRES;
+        effectres = tpz.mod.STUNRES
     elseif (effect == tpz.effect.CHARM) then
-        effectres = tpz.mod.CHARMRES;
+        effectres = tpz.mod.CHARMRES
     elseif (effect == tpz.effect.AMNESIA) then
-        effectres = tpz.mod.AMNESIARES;
+        effectres = tpz.mod.AMNESIARES
     end
 
     if (effectres ~= 0) then
-        return target:getMod(effectres);
+        return target:getMod(effectres)
     end
 
-    return 0;
-end;
+    return 0
+end
 
 -- Returns the bonus magic accuracy for any spell
 function getSpellBonusAcc(caster, target, spell, params)
-    local magicAccBonus = 0;
-    local castersWeather = caster:getWeather();
-    local skill = spell:getSkillType();
-    local spellGroup = spell:getSpellGroup();
-    local element = spell:getElement();
+    local magicAccBonus = 0
+    local castersWeather = caster:getWeather()
+    local skill = spell:getSkillType()
+    local spellGroup = spell:getSpellGroup()
+    local element = spell:getElement()
 
     if caster:hasStatusEffect(tpz.effect.ALTRUISM) and spellGroup == tpz.magic.spellGroup.WHITE then
-        magicAccBonus = magicAccBonus + caster:getStatusEffect(tpz.effect.ALTRUISM):getPower();
+        magicAccBonus = magicAccBonus + caster:getStatusEffect(tpz.effect.ALTRUISM):getPower()
     end
 
     if caster:hasStatusEffect(tpz.effect.FOCALIZATION) and spellGroup == tpz.magic.spellGroup.BLACK then
-        magicAccBonus = magicAccBonus + caster:getStatusEffect(tpz.effect.FOCALIZATION):getPower();
+        magicAccBonus = magicAccBonus + caster:getStatusEffect(tpz.effect.FOCALIZATION):getPower()
     end
 
-    local skillchainTier, skillchainCount = FormMagicBurst(element, target);
+    local skillchainTier, skillchainCount = FormMagicBurst(element, target)
 
     --add acc for skillchains
     if (skillchainTier > 0) then
-        magicAccBonus = magicAccBonus + 25;
+        magicAccBonus = magicAccBonus + 25
     end
 
     --Add acc for klimaform
@@ -588,25 +588,25 @@ function getSpellBonusAcc(caster, target, spell, params)
 
     --Add acc for dark seal
     if (skill == tpz.skill.DARK_MAGIC and caster:hasStatusEffect(tpz.effect.DARK_SEAL)) then
-        magicAccBonus = magicAccBonus + 256;
+        magicAccBonus = magicAccBonus + 256
     end
 
     --add acc for RDM group 1 merits
     if (element > 0 and element <= 6) then
-        magicAccBonus = magicAccBonus + caster:getMerit(rdmMerit[element]);
+        magicAccBonus = magicAccBonus + caster:getMerit(rdmMerit[element])
     end
 
     -- BLU mag acc merits - nuke acc is handled in bluemagic.lua
     if (skill == tpz.skill.BLUE_MAGIC) then
-        magicAccBonus = magicAccBonus + caster:getMerit(tpz.merit.MAGICAL_ACCURACY);
+        magicAccBonus = magicAccBonus + caster:getMerit(tpz.merit.MAGICAL_ACCURACY)
     end
 
-    return magicAccBonus;
-end;
+    return magicAccBonus
+end
 
 function handleAfflatusMisery(caster, spell, dmg)
     if (caster:hasStatusEffect(tpz.effect.AFFLATUS_MISERY)) then
-        local misery = caster:getMod(tpz.mod.AFFLATUS_MISERY);
+        local misery = caster:getMod(tpz.mod.AFFLATUS_MISERY)
         -- According to BGWiki Caps at 300 magic damage.
         local miseryMax = 300
 
@@ -614,21 +614,21 @@ function handleAfflatusMisery(caster, spell, dmg)
 
         -- BGwiki puts the boost capping at 200% bonus at 1/4th max HP.
         if (misery > miseryMax) then
-            misery = miseryMax;
-        end;
+            misery = miseryMax
+        end
 
         -- Damage is 2x at boost cap.
-        local boost = 1 + (misery / miseryMax);
+        local boost = 1 + (misery / miseryMax)
 
-        dmg = math.floor(dmg * boost);
+        dmg = math.floor(dmg * boost)
 
-        -- printf("AFFLATUS MISERY: Damage boosted by %f to %d", boost, dmg);
+        -- printf("AFFLATUS MISERY: Damage boosted by %f to %d", boost, dmg)
 
         --Afflatus Mod is Used Up...
         caster:setMod(tpz.mod.AFFLATUS_MISERY, 0)
     end
-    return dmg;
-end;
+    return dmg
+end
 
  function finalMagicAdjustments(caster,target,spell,dmg)
     --Handles target's HP adjustment and returns UNSIGNED dmg (absorb message is set in this function)
@@ -699,54 +699,54 @@ end;
 function finalMagicNonSpellAdjustments(caster,target,ele,dmg)
     --Handles target's HP adjustment and returns SIGNED dmg (negative values on absorb)
 
-    dmg = target:magicDmgTaken(dmg);
+    dmg = target:magicDmgTaken(dmg)
 
     if (dmg > 0) then
-        dmg = dmg - target:getMod(tpz.mod.PHALANX);
-        dmg = utils.clamp(dmg, 0, 99999);
+        dmg = dmg - target:getMod(tpz.mod.PHALANX)
+        dmg = utils.clamp(dmg, 0, 99999)
     end
 
     --handling stoneskin
-    dmg = utils.stoneskin(target, dmg);
+    dmg = utils.stoneskin(target, dmg)
 
-    dmg = utils.clamp(dmg, -99999, 99999);
+    dmg = utils.clamp(dmg, -99999, 99999)
 
     if (dmg < 0) then
-        dmg = -(target:addHP(-dmg));
+        dmg = -(target:addHP(-dmg))
     else
-        target:takeDamage(dmg, caster, tpz.attackType.MAGICAL, tpz.damageType.ELEMENTAL + ele);
+        target:takeDamage(dmg, caster, tpz.attackType.MAGICAL, tpz.damageType.ELEMENTAL + ele)
     end
     --Not updating enmity from damage, as this is primarily used for additional effects (which don't generate emnity)
     -- in the case that updating enmity is needed, do it manually after calling this
-    --target:updateEnmityFromDamage(caster,dmg);
+    --target:updateEnmityFromDamage(caster,dmg)
 
-    return dmg;
-end;
+    return dmg
+end
 
 function adjustForTarget(target,dmg,ele)
     if (dmg > 0 and math.random(0,99) < target:getMod(tpz.magic.absorbMod[ele])) then
-        return -dmg;
+        return -dmg
     end
     if (math.random(0,99) < target:getMod(nullMod[ele])) then
-        return 0;
+        return 0
     end
     --Moved non element specific absorb and null mod checks to core
     --TODO: update all lua calls to magicDmgTaken with appropriate element and remove this function
-    return dmg;
-end;
+    return dmg
+end
 
 function calculateMagicBurst(caster, spell, target, params)
 
-    local burst = 1.0;
-    local skillchainburst = 1.0;
-    local modburst = 1.0;
+    local burst = 1.0
+    local skillchainburst = 1.0
+    local modburst = 1.0
 
     if (spell:getSpellGroup() == 3 and not caster:hasStatusEffect(tpz.effect.BURST_AFFINITY)) then
-        return burst;
+        return burst
     end
 
     -- Obtain first multiplier from gear, atma and job traits
-    modburst = modburst + (caster:getMod(tpz.mod.MAG_BURST_BONUS) / 100) + params.AMIIburstBonus;
+    modburst = modburst + (caster:getMod(tpz.mod.MAG_BURST_BONUS) / 100) + params.AMIIburstBonus
 
     if caster:isBehind(target) and caster:hasStatusEffect(tpz.effect.INNIN) then
         modburst = modburst + (caster:getMerit(tpz.merit.INNIN_EFFECT)/100)
@@ -754,256 +754,256 @@ function calculateMagicBurst(caster, spell, target, params)
 
     -- Cap bonuses from first multiplier at 40% or 1.4
     if (modburst > 1.4) then
-        modburst = 1.4;
+        modburst = 1.4
     end
 
     -- Obtain second multiplier from skillchain
     -- Starts at 35% damage bonus, increases by 10% for every additional weaponskill in the chain
-    local skillchainTier, skillchainCount = FormMagicBurst(spell:getElement(), target);
+    local skillchainTier, skillchainCount = FormMagicBurst(spell:getElement(), target)
 
     if (skillchainTier > 0) then
         if (skillchainCount == 1) then -- two weaponskills
-            skillchainburst = 1.35;
+            skillchainburst = 1.35
         elseif (skillchainCount == 2) then -- three weaponskills
-            skillchainburst = 1.45;
+            skillchainburst = 1.45
         elseif (skillchainCount == 3) then -- four weaponskills
-             skillchainburst = 1.55;
+             skillchainburst = 1.55
         elseif (skillchainCount == 4) then -- five weaponskills
-            skillchainburst = 1.65;
+            skillchainburst = 1.65
         elseif (skillchainCount == 5) then -- six weaponskills
-            skillchainburst = 1.75;
+            skillchainburst = 1.75
         else
             -- Something strange is going on if this occurs.
-            skillchainburst = 1.0;
+            skillchainburst = 1.0
         end
     end
 
     -- Multiply
     if (skillchainburst > 1) then
-        burst = burst * modburst * skillchainburst;
+        burst = burst * modburst * skillchainburst
     end
 
-    return burst;
-end;
+    return burst
+end
 
 function addBonuses(caster, spell, target, dmg, params)
-    params = params or {};
+    params = params or {}
 
-    local ele = spell:getElement();
+    local ele = spell:getElement()
 
-    local affinityBonus = AffinityBonusDmg(caster, ele);
-    dmg = math.floor(dmg * affinityBonus);
+    local affinityBonus = AffinityBonusDmg(caster, ele)
+    dmg = math.floor(dmg * affinityBonus)
 
     params.bonusmab = params.bonusmab or 0
     params.AMIIburstBonus = params.AMIIburstBonus or 0
 
-    local magicDefense = getElementalDamageReduction(target, ele);
-    dmg = math.floor(dmg * magicDefense);
+    local magicDefense = getElementalDamageReduction(target, ele)
+    dmg = math.floor(dmg * magicDefense)
 
-    local dayWeatherBonus = 1.00;
-    local weather = caster:getWeather();
+    local dayWeatherBonus = 1.00
+    local weather = caster:getWeather()
 
     if (weather == tpz.magic.singleWeatherStrong[ele]) then
         if (caster:getMod(tpz.mod.IRIDESCENCE) >= 1) then
             if (math.random() < 0.33 or caster:getMod(elementalObiStrong[ele]) >= 1 or isHelixSpell(spell)) then
-                dayWeatherBonus = dayWeatherBonus + 0.10;
+                dayWeatherBonus = dayWeatherBonus + 0.10
             end
         end
         if (math.random() < 0.33 or caster:getMod(elementalObiStrong[ele]) >= 1 or isHelixSpell(spell)) then
-            dayWeatherBonus = dayWeatherBonus + 0.10;
+            dayWeatherBonus = dayWeatherBonus + 0.10
         end
     elseif (caster:getWeather() == tpz.magic.singleWeatherWeak[ele]) then
         if (math.random() < 0.33 or caster:getMod(elementalObiWeak[ele]) >= 1 or isHelixSpell(spell)) then
-            dayWeatherBonus = dayWeatherBonus - 0.10;
+            dayWeatherBonus = dayWeatherBonus - 0.10
         end
     elseif (weather == tpz.magic.doubleWeatherStrong[ele]) then
         if (caster:getMod(tpz.mod.IRIDESCENCE) >= 1) then
             if (math.random() < 0.33 or caster:getMod(elementalObiStrong[ele]) >= 1 or isHelixSpell(spell)) then
-                dayWeatherBonus = dayWeatherBonus + 0.10;
+                dayWeatherBonus = dayWeatherBonus + 0.10
             end
         end
         if (math.random() < 0.33 or caster:getMod(elementalObiStrong[ele]) >= 1 or isHelixSpell(spell)) then
-            dayWeatherBonus = dayWeatherBonus + 0.25;
+            dayWeatherBonus = dayWeatherBonus + 0.25
         end
     elseif (weather == tpz.magic.doubleWeatherWeak[ele]) then
         if (math.random() < 0.33 or caster:getMod(elementalObiWeak[ele]) >= 1 or isHelixSpell(spell)) then
-            dayWeatherBonus = dayWeatherBonus - 0.25;
+            dayWeatherBonus = dayWeatherBonus - 0.25
         end
     end
 
-    local dayElement = VanadielDayElement();
+    local dayElement = VanadielDayElement()
     if (dayElement == tpz.magic.dayStrong[ele]) then
-        dayWeatherBonus = dayWeatherBonus + caster:getMod(tpz.mod.DAY_NUKE_BONUS)/100; -- sorc. tonban(+1)/zodiac ring
+        dayWeatherBonus = dayWeatherBonus + caster:getMod(tpz.mod.DAY_NUKE_BONUS)/100 -- sorc. tonban(+1)/zodiac ring
         if (math.random() < 0.33 or caster:getMod(elementalObiStrong[ele]) >= 1 or isHelixSpell(spell)) then
-            dayWeatherBonus = dayWeatherBonus + 0.10;
+            dayWeatherBonus = dayWeatherBonus + 0.10
         end
     elseif (dayElement == tpz.magic.dayWeak[ele]) then
         if (math.random() < 0.33 or caster:getMod(elementalObiWeak[ele]) >= 1 or isHelixSpell(spell)) then
-            dayWeatherBonus = dayWeatherBonus - 0.10;
+            dayWeatherBonus = dayWeatherBonus - 0.10
         end
     end
 
     if dayWeatherBonus > 1.4 then
-        dayWeatherBonus = 1.4;
+        dayWeatherBonus = 1.4
     end
 
-    dmg = math.floor(dmg * dayWeatherBonus);
+    dmg = math.floor(dmg * dayWeatherBonus)
 
-    local burst = calculateMagicBurst(caster, spell, target, params);
+    local burst = calculateMagicBurst(caster, spell, target, params)
 
     if (burst > 1.0) then
-        spell:setMsg(spell:getMagicBurstMessage()); -- "Magic Burst!"
+        spell:setMsg(spell:getMagicBurstMessage()) -- "Magic Burst!"
     end
 
-    dmg = math.floor(dmg * burst);
-    local mabbonus = 0;
-    local spellId = spell:getID();
+    dmg = math.floor(dmg * burst)
+    local mabbonus = 0
+    local spellId = spell:getID()
 
     if (spellId >= 245 and spellId <= 248) then -- Drain/Aspir (II)
-        mabbonus = 1 + caster:getMod(tpz.mod.ENH_DRAIN_ASPIR)/100;
+        mabbonus = 1 + caster:getMod(tpz.mod.ENH_DRAIN_ASPIR)/100
         if spellId == 247 or spellId == 248 then
             mabbonus = mabbonus + caster:getMerit(tpz.merit.ASPIR_ABSORPTION_AMOUNT)/100
         end
     else
-        local mab = caster:getMod(tpz.mod.MATT) + params.bonusmab;
+        local mab = caster:getMod(tpz.mod.MATT) + params.bonusmab
 
         if spell:getSkillType() == tpz.skill.NINJUTSU then
             mab = mab + caster:getMerit(tpz.merit.NIN_MAGIC_BONUS)
         end
 
-        local mab_crit = caster:getMod(tpz.mod.MAGIC_CRITHITRATE);
+        local mab_crit = caster:getMod(tpz.mod.MAGIC_CRITHITRATE)
         if ( math.random(1,100) < mab_crit ) then
-           mab = mab + ( 10 + caster:getMod(tpz.mod.MAGIC_CRIT_DMG_INCREASE ) );
+           mab = mab + ( 10 + caster:getMod(tpz.mod.MAGIC_CRIT_DMG_INCREASE ) )
         end
 
-        local mdefBarBonus = 0;
+        local mdefBarBonus = 0
         if (ele > 0 and ele <= 6) then
-            mab = mab + caster:getMerit(blmMerit[ele]);
+            mab = mab + caster:getMerit(blmMerit[ele])
             if (target:hasStatusEffect(tpz.magic.barSpell[ele])) then -- bar- spell magic defense bonus
-                mdefBarBonus = target:getStatusEffect(tpz.magic.barSpell[ele]):getSubPower();
+                mdefBarBonus = target:getStatusEffect(tpz.magic.barSpell[ele]):getSubPower()
             end
         end
-        mabbonus = (100 + mab) / (100 + target:getMod(tpz.mod.MDEF) + mdefBarBonus);
+        mabbonus = (100 + mab) / (100 + target:getMod(tpz.mod.MDEF) + mdefBarBonus)
     end
 
     if (mabbonus < 0) then
-        mabbonus = 0;
+        mabbonus = 0
     end
 
-    dmg = math.floor(dmg * mabbonus);
+    dmg = math.floor(dmg * mabbonus)
 
     if (caster:hasStatusEffect(tpz.effect.EBULLIENCE)) then
-        dmg = dmg * (1.2 + caster:getMod(tpz.mod.EBULLIENCE_AMOUNT)/100);
-        caster:delStatusEffectSilent(tpz.effect.EBULLIENCE);
+        dmg = dmg * (1.2 + caster:getMod(tpz.mod.EBULLIENCE_AMOUNT)/100)
+        caster:delStatusEffectSilent(tpz.effect.EBULLIENCE)
     end
 
-    dmg = math.floor(dmg);
+    dmg = math.floor(dmg)
 
-    -- print(affinityBonus);
-    -- print(speciesReduction);
-    -- print(dayWeatherBonus);
-    -- print(burst);
-    -- print(mab);
-    -- print(magicDmgMod);
+    -- print(affinityBonus)
+    -- print(speciesReduction)
+    -- print(dayWeatherBonus)
+    -- print(burst)
+    -- print(mab)
+    -- print(magicDmgMod)
 
-    return dmg;
-end;
+    return dmg
+end
 
 function addBonusesAbility(caster, ele, target, dmg, params)
 
-    local affinityBonus = AffinityBonusDmg(caster, ele);
-    dmg = math.floor(dmg * affinityBonus);
+    local affinityBonus = AffinityBonusDmg(caster, ele)
+    dmg = math.floor(dmg * affinityBonus)
 
-    local magicDefense = getElementalDamageReduction(target, ele);
-    dmg = math.floor(dmg * magicDefense);
+    local magicDefense = getElementalDamageReduction(target, ele)
+    dmg = math.floor(dmg * magicDefense)
 
-    local dayWeatherBonus = 1.00;
-    local weather = caster:getWeather();
+    local dayWeatherBonus = 1.00
+    local weather = caster:getWeather()
 
     if (weather == tpz.magic.singleWeatherStrong[ele]) then
         if (caster:getMod(tpz.mod.IRIDESCENCE) >= 1) then
             if (math.random() < 0.33 or caster:getMod(elementalObiStrong[ele]) >= 1) then
-                dayWeatherBonus = dayWeatherBonus + 0.10;
+                dayWeatherBonus = dayWeatherBonus + 0.10
             end
         end
         if (math.random() < 0.33 or caster:getMod(elementalObiStrong[ele]) >= 1) then
-            dayWeatherBonus = dayWeatherBonus + 0.10;
+            dayWeatherBonus = dayWeatherBonus + 0.10
         end
     elseif (caster:getWeather() == tpz.magic.singleWeatherWeak[ele]) then
         if (math.random() < 0.33 or caster:getMod(elementalObiWeak[ele]) >= 1) then
-            dayWeatherBonus = dayWeatherBonus - 0.10;
+            dayWeatherBonus = dayWeatherBonus - 0.10
         end
     elseif (weather == tpz.magic.doubleWeatherStrong[ele]) then
         if (caster:getMod(tpz.mod.IRIDESCENCE) >= 1) then
             if (math.random() < 0.33 or caster:getMod(elementalObiStrong[ele]) >= 1) then
-                dayWeatherBonus = dayWeatherBonus + 0.10;
+                dayWeatherBonus = dayWeatherBonus + 0.10
             end
         end
         if (math.random() < 0.33 or caster:getMod(elementalObiStrong[ele]) >= 1) then
-            dayWeatherBonus = dayWeatherBonus + 0.25;
+            dayWeatherBonus = dayWeatherBonus + 0.25
         end
     elseif (weather == tpz.magic.doubleWeatherWeak[ele]) then
         if (math.random() < 0.33 or caster:getMod(elementalObiWeak[ele]) >= 1) then
-            dayWeatherBonus = dayWeatherBonus - 0.25;
+            dayWeatherBonus = dayWeatherBonus - 0.25
         end
     end
 
-    local dayElement = VanadielDayElement();
+    local dayElement = VanadielDayElement()
     if (dayElement == tpz.magic.dayStrong[ele]) then
-        dayWeatherBonus = dayWeatherBonus + caster:getMod(tpz.mod.DAY_NUKE_BONUS)/100; -- sorc. tonban(+1)/zodiac ring
+        dayWeatherBonus = dayWeatherBonus + caster:getMod(tpz.mod.DAY_NUKE_BONUS)/100 -- sorc. tonban(+1)/zodiac ring
         if (math.random() < 0.33 or caster:getMod(elementalObiStrong[ele]) >= 1) then
-            dayWeatherBonus = dayWeatherBonus + 0.10;
+            dayWeatherBonus = dayWeatherBonus + 0.10
         end
     elseif (dayElement == tpz.magic.dayWeak[ele]) then
         if (math.random() < 0.33 or caster:getMod(elementalObiWeak[ele]) >= 1) then
-            dayWeatherBonus = dayWeatherBonus - 0.10;
+            dayWeatherBonus = dayWeatherBonus - 0.10
         end
     end
 
     if dayWeatherBonus > 1.4 then
-        dayWeatherBonus = 1.4;
+        dayWeatherBonus = 1.4
     end
 
-    dmg = math.floor(dmg * dayWeatherBonus);
+    dmg = math.floor(dmg * dayWeatherBonus)
 
-    local mab = 1;
-    local mdefBarBonus = 0;
+    local mab = 1
+    local mdefBarBonus = 0
     if (ele > 0 and ele <= 6 and target:hasStatusEffect(tpz.magic.barSpell[ele])) then -- bar- spell magic defense bonus
-        mdefBarBonus = target:getStatusEffect(tpz.magic.barSpell[ele]):getSubPower();
+        mdefBarBonus = target:getStatusEffect(tpz.magic.barSpell[ele]):getSubPower()
     end
 
     if (params ~= nil and params.bonusmab ~= nil and params.includemab == true) then
-        mab = (100 + caster:getMod(tpz.mod.MATT) + params.bonusmab) / (100 + target:getMod(tpz.mod.MDEF) + mdefBarBonus);
+        mab = (100 + caster:getMod(tpz.mod.MATT) + params.bonusmab) / (100 + target:getMod(tpz.mod.MDEF) + mdefBarBonus)
     elseif (params == nil or (params ~= nil and params.includemab == true)) then
-        mab = (100 + caster:getMod(tpz.mod.MATT)) / (100 + target:getMod(tpz.mod.MDEF) + mdefBarBonus);
+        mab = (100 + caster:getMod(tpz.mod.MATT)) / (100 + target:getMod(tpz.mod.MDEF) + mdefBarBonus)
     end
 
     if (mab < 0) then
-        mab = 0;
+        mab = 0
     end
 
-    dmg = math.floor(dmg * mab);
+    dmg = math.floor(dmg * mab)
 
-    -- print(affinityBonus);
-    -- print(speciesReduction);
-    -- print(dayWeatherBonus);
-    -- print(burst);
-    -- print(mab);
-    -- print(magicDmgMod);
+    -- print(affinityBonus)
+    -- print(speciesReduction)
+    -- print(dayWeatherBonus)
+    -- print(burst)
+    -- print(mab)
+    -- print(magicDmgMod)
 
-    return dmg;
-end;
+    return dmg
+end
 
 -- get elemental damage reduction
 function getElementalDamageReduction(target, element)
-    local defense = 1;
+    local defense = 1
     if (element > 0) then
-        defense = 1 - (target:getMod(tpz.magic.defenseMod[element]) / 256);
+        defense = 1 - (target:getMod(tpz.magic.defenseMod[element]) / 256)
 
-        return utils.clamp(defense, 0.0, 2.0);
+        return utils.clamp(defense, 0.0, 2.0)
     end
 
-    return defense;
+    return defense
 end
 
 ---------------------------------------------
@@ -1011,170 +1011,170 @@ end
 ---------------------------------------------
 
 function getElementalDebuffDOT(INT)
-    local DOT = 0;
+    local DOT = 0
     if (INT<= 39) then
-        DOT = 1;
+        DOT = 1
     elseif (INT <= 69) then
-        DOT = 2;
+        DOT = 2
     elseif (INT <= 99) then
-        DOT = 3;
+        DOT = 3
     elseif (INT <= 149) then
-        DOT = 4;
+        DOT = 4
     else
-        DOT = 5;
+        DOT = 5
     end
-    return DOT;
-end;
+    return DOT
+end
 
 function getElementalDebuffStatDownFromDOT(dot)
-    local stat_down = 0;
+    local stat_down = 0
     if (dot == 1) then
-        stat_down = 5;
+        stat_down = 5
     elseif (dot == 2) then
-        stat_down = 7;
+        stat_down = 7
     elseif (dot == 3) then
-        stat_down = 9;
+        stat_down = 9
     elseif (dot == 4) then
-        stat_down = 11;
+        stat_down = 11
     else
-        stat_down = 13;
+        stat_down = 13
     end
-    return stat_down;
-end;
+    return stat_down
+end
 
 function getHelixDuration(caster)
     --Dark Arts will further increase Helix duration, but testing is ongoing.
 
-    local casterLevel = caster:getMainLvl();
-    local duration = 30; --fallthrough
+    local casterLevel = caster:getMainLvl()
+    local duration = 30 --fallthrough
     if (casterLevel <= 39) then
-        duration = 30;
+        duration = 30
     elseif (casterLevel <= 59) then
-        duration = 60;
+        duration = 60
     elseif (casterLevel <= 99) then
-        duration = 90;
+        duration = 90
     end
-    return duration;
-end;
+    return duration
+end
 
 function isHelixSpell(spell)
     --Dark Arts will further increase Helix duration, but testing is ongoing.
 
-    local id = spell:getID();
+    local id = spell:getID()
     if id >= 278 and id <= 285 then
-        return true;
+        return true
     end
-    return false;
-end;
+    return false
+end
 
 function handleThrenody(caster, target, spell, basePower, baseDuration, modifier)
     -- Process resitances
-    local staff = AffinityBonusAcc(caster, spell:getElement());
-    -- print("staff=" .. staff);
-    local dCHR = (caster:getStat(tpz.mod.CHR) - target:getStat(tpz.mod.CHR));
-    -- print("dCHR=" .. dCHR);
-    local params = {};
-    params.attribute = tpz.mod.CHR;
-    params.skillType = tpz.skill.SINGING;
-    params.bonus = staff;
+    local staff = AffinityBonusAcc(caster, spell:getElement())
+    -- print("staff=" .. staff)
+    local dCHR = (caster:getStat(tpz.mod.CHR) - target:getStat(tpz.mod.CHR))
+    -- print("dCHR=" .. dCHR)
+    local params = {}
+    params.attribute = tpz.mod.CHR
+    params.skillType = tpz.skill.SINGING
+    params.bonus = staff
 
-    local resm = applyResistance(caster, target, spell, params);
-    -- print("rsem=" .. resm);
+    local resm = applyResistance(caster, target, spell, params)
+    -- print("rsem=" .. resm)
 
     if (resm < 0.5) then
-        -- print("resm resist");
-        spell:setMsg(tpz.msg.basic.MAGIC_RESIST);
-        return tpz.effect.THRENODY;
+        -- print("resm resist")
+        spell:setMsg(tpz.msg.basic.MAGIC_RESIST)
+        return tpz.effect.THRENODY
     end
 
     -- Remove previous Threnody
-    target:delStatusEffect(tpz.effect.THRENODY);
+    target:delStatusEffect(tpz.effect.THRENODY)
 
-    local iBoost = caster:getMod(tpz.mod.THRENODY_EFFECT) + caster:getMod(tpz.mod.ALL_SONGS_EFFECT);
-    local power = basePower + iBoost*5;
-    local duration = baseDuration * ((iBoost * 0.1) + (caster:getMod(tpz.mod.SONG_DURATION_BONUS)/100) + 1);
+    local iBoost = caster:getMod(tpz.mod.THRENODY_EFFECT) + caster:getMod(tpz.mod.ALL_SONGS_EFFECT)
+    local power = basePower + iBoost*5
+    local duration = baseDuration * ((iBoost * 0.1) + (caster:getMod(tpz.mod.SONG_DURATION_BONUS)/100) + 1)
 
     if (caster:hasStatusEffect(tpz.effect.SOUL_VOICE)) then
-        power = power * 2;
+        power = power * 2
     elseif (caster:hasStatusEffect(tpz.effect.MARCATO)) then
-        power = power * 1.5;
+        power = power * 1.5
     end
 
     if (caster:hasStatusEffect(tpz.effect.TROUBADOUR)) then
-        duration = duration * 2;
+        duration = duration * 2
     end
 
     -- Set spell message and apply status effect
-    target:addStatusEffect(tpz.effect.THRENODY, -power, 0, duration, 0, modifier, 0);
+    target:addStatusEffect(tpz.effect.THRENODY, -power, 0, duration, 0, modifier, 0)
 
-    return tpz.effect.THRENODY;
-end;
+    return tpz.effect.THRENODY
+end
 
 function handleNinjutsuDebuff(caster, target, spell, basePower, baseDuration, modifier)
     -- Add new
-    target:addStatusEffectEx(tpz.effect.NINJUTSU_ELE_DEBUFF, 0, basePower, 0, baseDuration, 0, modifier, 0);
-    return tpz.effect.NINJUTSU_ELE_DEBUFF;
-end;
+    target:addStatusEffectEx(tpz.effect.NINJUTSU_ELE_DEBUFF, 0, basePower, 0, baseDuration, 0, modifier, 0)
+    return tpz.effect.NINJUTSU_ELE_DEBUFF
+end
 
 -- Returns true if you can overwrite the effect
 -- Example: canOverwrite(target, tpz.effect.SLOW, 25)
 function canOverwrite(target, effect, power, mod)
-    mod = mod or 1;
+    mod = mod or 1
 
-    local statusEffect = target:getStatusEffect(effect);
+    local statusEffect = target:getStatusEffect(effect)
 
     -- effect not found so overwrite
     if (statusEffect == nil) then
-        return true;
+        return true
     end
 
     -- overwrite if its weaker
     if (statusEffect:getPower()*mod > power) then
-        return false;
+        return false
     end
 
-    return true;
+    return true
 end
 
 function doElementalNuke(caster, spell, target, spellParams)
-    local DMG = 0;
-    local dINT = caster:getStat(tpz.mod.INT) - target:getStat(tpz.mod.INT);
-    local V = 0;
-    local M = 0;
+    local DMG = 0
+    local dINT = caster:getStat(tpz.mod.INT) - target:getStat(tpz.mod.INT)
+    local V = 0
+    local M = 0
 
     if USE_OLD_MAGIC_DAMAGE and spellParams.V ~= nil and spellParams.M ~= nil then
-        V = spellParams.V; -- Base value
-        M = spellParams.M; -- Tier multiplier
-        local I = spellParams.I; -- Inflection point
-        local cap = I * 2 + V; -- Base damage soft cap
+        V = spellParams.V -- Base value
+        M = spellParams.M -- Tier multiplier
+        local I = spellParams.I -- Inflection point
+        local cap = I * 2 + V -- Base damage soft cap
 
         if dINT < 0 then
             -- If dINT is a negative value the tier multiplier is always 1
-            DMG = V + dINT;
+            DMG = V + dINT
 
             -- Check/ set lower limit of 0 damage for negative dINT
             if DMG < 1 then
-                return 0;
+                return 0
             end
 
         elseif dINT < I then
              -- If dINT > 0 but below inflection point I
-            DMG = V + dINT * M;
+            DMG = V + dINT * M
 
         else
              -- Above inflection point I additional dINT is only half as effective
-            DMG = V + I + ((dINT - I) * (M / 2));
+            DMG = V + I + ((dINT - I) * (M / 2))
         end
 
         -- Check/ set damage soft cap
         if DMG > cap then
-            DMG = cap;
+            DMG = cap
         end
 
     else
-        local hasMultipleTargetReduction = spellParams.hasMultipleTargetReduction; --still unused!!!
-        local resistBonus = spellParams.resistBonus;
-        local mDMG = caster:getMod(tpz.mod.MAGIC_DAMAGE);
+        local hasMultipleTargetReduction = spellParams.hasMultipleTargetReduction --still unused!!!
+        local resistBonus = spellParams.resistBonus
+        local mDMG = caster:getMod(tpz.mod.MAGIC_DAMAGE)
 
         --[[
                 Calculate base damage:
@@ -1184,142 +1184,142 @@ function doElementalNuke(caster, spell, target, spellParams)
         ]]
 
         if (dINT <= 49) then
-            V = spellParams.V0;
-            M = spellParams.M0;
-            DMG = math.floor(DMG + mDMG + V + (dINT * M));
+            V = spellParams.V0
+            M = spellParams.M0
+            DMG = math.floor(DMG + mDMG + V + (dINT * M))
 
             if (DMG <= 0) then
-                return 0;
+                return 0
             end
 
         elseif (dINT >= 50 and dINT <= 99) then
-            V = spellParams.V50;
-            M = spellParams.M50;
-            DMG = math.floor(DMG + mDMG + V + ((dINT - 50) * M));
+            V = spellParams.V50
+            M = spellParams.M50
+            DMG = math.floor(DMG + mDMG + V + ((dINT - 50) * M))
 
         elseif (dINT >= 100 and dINT <= 199) then
-            V = spellParams.V100;
-            M = spellParams.M100;
-            DMG = math.floor(DMG + mDMG + V + ((dINT - 100) * M));
+            V = spellParams.V100
+            M = spellParams.M100
+            DMG = math.floor(DMG + mDMG + V + ((dINT - 100) * M))
 
         elseif (dINT > 199) then
-            V = spellParams.V200;
-            M = spellParams.M200;
-            DMG = math.floor(DMG + mDMG + V + ((dINT - 200) * M));
+            V = spellParams.V200
+            M = spellParams.M200
+            DMG = math.floor(DMG + mDMG + V + ((dINT - 200) * M))
         end
     end
 
     --get resist multiplier (1x if no resist)
-    local params = {};
-    params.attribute = tpz.mod.INT;
-    params.skillType = tpz.skill.ELEMENTAL_MAGIC;
-    params.resistBonus = resistBonus;
+    local params = {}
+    params.attribute = tpz.mod.INT
+    params.skillType = tpz.skill.ELEMENTAL_MAGIC
+    params.resistBonus = resistBonus
 
-    local resist = applyResistance(caster, target, spell, params);
+    local resist = applyResistance(caster, target, spell, params)
 
     --get the resisted damage
-    DMG = DMG * resist;
+    DMG = DMG * resist
 
     --add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
-    DMG = addBonuses(caster, spell, target, DMG, spellParams);
+    DMG = addBonuses(caster, spell, target, DMG, spellParams)
 
     --add in target adjustment
-    local ele = spell:getElement();
-    DMG = adjustForTarget(target, DMG, ele);
+    local ele = spell:getElement()
+    DMG = adjustForTarget(target, DMG, ele)
 
     --add in final adjustments
-    DMG = finalMagicAdjustments(caster, target, spell, DMG);
+    DMG = finalMagicAdjustments(caster, target, spell, DMG)
 
-    return DMG;
+    return DMG
 end
 
 function doDivineNuke(caster, target, spell, params)
-    params.skillType = tpz.skill.DIVINE_MAGIC;
-    params.attribute = tpz.mod.MND;
+    params.skillType = tpz.skill.DIVINE_MAGIC
+    params.attribute = tpz.mod.MND
 
-    return doNuke(caster, target, spell, params);
+    return doNuke(caster, target, spell, params)
 end
 
 function doNinjutsuNuke(caster, target, spell, params)
-    local mabBonus = params.mabBonus;
+    local mabBonus = params.mabBonus
 
-    mabBonus = mabBonus or 0;
+    mabBonus = mabBonus or 0
 
-    mabBonus = mabBonus + caster:getMod(tpz.mod.NIN_NUKE_BONUS); -- "enhances ninjutsu damage" bonus
+    mabBonus = mabBonus + caster:getMod(tpz.mod.NIN_NUKE_BONUS) -- "enhances ninjutsu damage" bonus
     if (caster:hasStatusEffect(tpz.effect.INNIN) and caster:isBehind(target, 23)) then -- Innin mag atk bonus from behind, guesstimating angle at 23 degrees
-        mabBonus = mabBonus + caster:getStatusEffect(tpz.effect.INNIN):getPower();
+        mabBonus = mabBonus + caster:getStatusEffect(tpz.effect.INNIN):getPower()
     end
-    params.skillType = tpz.skill.NINJUTSU;
-    params.attribute = tpz.mod.INT;
-    params.mabBonus = mabBonus;
+    params.skillType = tpz.skill.NINJUTSU
+    params.attribute = tpz.mod.INT
+    params.mabBonus = mabBonus
 
-    return doNuke(caster, target, spell, params);
+    return doNuke(caster, target, spell, params)
 end
 
 function doNuke(caster, target, spell, params)
     --calculate raw damage
-    local dmg = calculateMagicDamage(caster, target, spell, params);
+    local dmg = calculateMagicDamage(caster, target, spell, params)
     --get resist multiplier (1x if no resist)
-    local resist = applyResistance(caster, target, spell, params);
+    local resist = applyResistance(caster, target, spell, params)
     --get the resisted damage
-    dmg = dmg*resist;
+    dmg = dmg*resist
     if (skill == tpz.skill.NINJUTSU) then
         if (caster:getMainJob() == tpz.job.NIN) then -- NIN main gets a bonus to their ninjutsu nukes
-            local ninSkillBonus = 100;
+            local ninSkillBonus = 100
             if (spell:getID() % 3 == 2) then -- ichi nuke spell ids are 320, 323, 326, 329, 332, and 335
-                ninSkillBonus = 100 + math.floor((caster:getSkillLevel(tpz.skill.NINJUTSU) - 50)/2); -- getSkillLevel includes bonuses from merits and modifiers (ie. gear)
+                ninSkillBonus = 100 + math.floor((caster:getSkillLevel(tpz.skill.NINJUTSU) - 50)/2) -- getSkillLevel includes bonuses from merits and modifiers (ie. gear)
             elseif (spell:getID() % 3 == 0) then -- ni nuke spell ids are 1 more than their corresponding ichi spell
-                ninSkillBonus = 100 + math.floor((caster:getSkillLevel(tpz.skill.NINJUTSU) - 125)/2);
+                ninSkillBonus = 100 + math.floor((caster:getSkillLevel(tpz.skill.NINJUTSU) - 125)/2)
             else -- san nuke spell, also has ids 1 more than their corresponding ni spell
-                ninSkillBonus = 100 + math.floor((caster:getSkillLevel(tpz.skill.NINJUTSU) - 275)/2);
+                ninSkillBonus = 100 + math.floor((caster:getSkillLevel(tpz.skill.NINJUTSU) - 275)/2)
             end
-            ninSkillBonus = utils.clamp(ninSkillBonus, 100, 200); -- bonus caps at +100%, and does not go negative
-            dmg = dmg * ninSkillBonus/100;
+            ninSkillBonus = utils.clamp(ninSkillBonus, 100, 200) -- bonus caps at +100%, and does not go negative
+            dmg = dmg * ninSkillBonus/100
         end
         -- boost with Futae
         if (caster:hasStatusEffect(tpz.effect.FUTAE)) then
-            dmg = math.floor(dmg * 1.50);
-            caster:delStatusEffect(tpz.effect.FUTAE);
+            dmg = math.floor(dmg * 1.50)
+            caster:delStatusEffect(tpz.effect.FUTAE)
         end
     end
 
     --add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
-    dmg = addBonuses(caster, spell, target, dmg, params);
+    dmg = addBonuses(caster, spell, target, dmg, params)
     --add in target adjustment
-    dmg = adjustForTarget(target,dmg,spell:getElement());
+    dmg = adjustForTarget(target,dmg,spell:getElement())
     --add in final adjustments
-    dmg = finalMagicAdjustments(caster,target,spell,dmg);
-    return dmg;
+    dmg = finalMagicAdjustments(caster,target,spell,dmg)
+    return dmg
 end
 
 function doDivineBanishNuke(caster, target, spell, params)
-    params.skillType = tpz.skill.DIVINE_MAGIC;
-    params.attribute = tpz.mod.MND;
+    params.skillType = tpz.skill.DIVINE_MAGIC
+    params.attribute = tpz.mod.MND
 
     --calculate raw damage
-    local dmg = calculateMagicDamage(caster, target, spell, params);
+    local dmg = calculateMagicDamage(caster, target, spell, params)
     --get resist multiplier (1x if no resist)
-    local resist = applyResistance(caster, target, spell, params);
+    local resist = applyResistance(caster, target, spell, params)
     --get the resisted damage
-    dmg = dmg*resist;
+    dmg = dmg*resist
 
     --add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
-    dmg = addBonuses(caster, spell, target, dmg, params);
+    dmg = addBonuses(caster, spell, target, dmg, params)
     --add in target adjustment
-    dmg = adjustForTarget(target,dmg,spell:getElement());
+    dmg = adjustForTarget(target,dmg,spell:getElement())
     --handling afflatus misery
-    dmg = handleAfflatusMisery(caster, spell, dmg);
+    dmg = handleAfflatusMisery(caster, spell, dmg)
     --add in final adjustments
-    dmg = finalMagicAdjustments(caster,target,spell,dmg);
-    return dmg;
+    dmg = finalMagicAdjustments(caster,target,spell,dmg)
+    return dmg
 end
 
 function calculateDurationForLvl(duration, spellLvl, targetLvl)
     if (targetLvl < spellLvl) then
-        return duration * targetLvl / spellLvl;
+        return duration * targetLvl / spellLvl
     end
 
-    return duration;
+    return duration
 end
 
 function calculateDuration(duration, magicSkill, spellGroup, caster, target, useComposure)
@@ -1374,39 +1374,39 @@ end
 function outputMagicHitRateInfo()
     for casterLvl = 1, 75 do
 
-        printf("");
-        printf("-------- CasterLvl: %d", casterLvl);
+        printf("")
+        printf("-------- CasterLvl: %d", casterLvl)
 
         for lvlMod = -5, 20 do
 
-            local targetLvl = casterLvl + lvlMod;
+            local targetLvl = casterLvl + lvlMod
 
             if (targetLvl >= 0) then
                 -- assume BLM spell, A+
-                local magicAcc = utils.getSkillLvl(6, casterLvl);
+                local magicAcc = utils.getSkillLvl(6, casterLvl)
                 -- assume default monster magic eva, D
-                local magicEvaRank = 3;
-                local rate = 0;
+                local magicEvaRank = 3
+                local rate = 0
 
-                local magicEva = utils.getMobSkillLvl(magicEvaRank, targetLvl);
+                local magicEva = utils.getMobSkillLvl(magicEvaRank, targetLvl)
 
-                local dINT = (lvlMod + 1) * -1;
+                local dINT = (lvlMod + 1) * -1
 
                 if (dINT > 10) then
-                    magicAcc = magicAcc + 10 + (dINT - 10)/2;
+                    magicAcc = magicAcc + 10 + (dINT - 10)/2
                 else
-                    magicAcc = magicAcc + dINT;
+                    magicAcc = magicAcc + dINT
                 end
 
-                local magicHitRate = calculateMagicHitRate(magicAcc, magicEva, 0, casterLvl, targetLvl);
+                local magicHitRate = calculateMagicHitRate(magicAcc, magicEva, 0, casterLvl, targetLvl)
 
-                printf("Lvl: %d vs %d, %d%%, MA: %d, ME: %d", casterLvl, targetLvl, magicHitRate, magicAcc, magicEva);
+                printf("Lvl: %d vs %d, %d%%, MA: %d, ME: %d", casterLvl, targetLvl, magicHitRate, magicAcc, magicEva)
             end
 
         end
     end
-end;
+end
 
--- outputMagicHitRateInfo();
+-- outputMagicHitRateInfo()
 
-tpz.mag = tpz.magic;
+tpz.mag = tpz.magic

--- a/scripts/globals/magic_maps.lua
+++ b/scripts/globals/magic_maps.lua
@@ -4,7 +4,7 @@
 --    SE updated the map NPCs to sell maps from the normal areas, RoZ, and CoP areas (Update was in Nov 5, 2013)
 ---------------------------------------------
 
-require("scripts/globals/keyitems");
+require("scripts/globals/keyitems")
 
 local Maps = {tpz.ki.MAP_OF_THE_SAN_DORIA_AREA, tpz.ki.MAP_OF_THE_BASTOK_AREA, tpz.ki.MAP_OF_THE_WINDURST_AREA, tpz.ki.MAP_OF_THE_JEUNO_AREA, tpz.ki.MAP_OF_ORDELLES_CAVES, tpz.ki.MAP_OF_GHELSBA, tpz.ki.MAP_OF_DAVOI, tpz.ki.MAP_OF_CARPENTERS_LANDING, tpz.ki.MAP_OF_THE_ZERUHN_MINES,
     tpz.ki.MAP_OF_THE_PALBOROUGH_MINES, tpz.ki.MAP_OF_BEADEAUX, tpz.ki.MAP_OF_GIDDEUS, tpz.ki.MAP_OF_CASTLE_OZTROJA, tpz.ki.MAP_OF_THE_MAZE_OF_SHAKHRAMI, tpz.ki.MAP_OF_THE_LITELOR_REGION, tpz.ki.MAP_OF_BIBIKI_BAY, tpz.ki.MAP_OF_QUFIM_ISLAND, tpz.ki.MAP_OF_THE_ELDIEME_NECROPOLIS,
@@ -14,7 +14,7 @@ local Maps = {tpz.ki.MAP_OF_THE_SAN_DORIA_AREA, tpz.ki.MAP_OF_THE_BASTOK_AREA, t
     tpz.ki.MAP_OF_IFRITS_CAULDRON, tpz.ki.MAP_OF_THE_QUICKSAND_CAVES, tpz.ki.MAP_OF_THE_SEA_SERPENT_GROTTO, tpz.ki.MAP_OF_THE_VOLLBOW_REGION, tpz.ki.MAP_OF_THE_LABYRINTH_OF_ONZOZO, tpz.ki.MAP_OF_THE_ULEGUERAND_RANGE, tpz.ki.MAP_OF_THE_ATTOHWA_CHASM, tpz.ki.MAP_OF_PSOXJA,
     tpz.ki.MAP_OF_OLDTON_MOVALPOLOS, tpz.ki.MAP_OF_NEWTON_MOVALPOLOS, tpz.ki.MAP_OF_TAVNAZIA, tpz.ki.MAP_OF_THE_AQUEDUCTS, tpz.ki.MAP_OF_THE_SACRARIUM, tpz.ki.MAP_OF_CAPE_RIVERNE, tpz.ki.MAP_OF_ALTAIEU, tpz.ki.MAP_OF_HUXZOI, tpz.ki.MAP_OF_RUHMET, tpz.ki.MAP_OF_AL_ZAHBI, tpz.ki.MAP_OF_NASHMAU,
     tpz.ki.MAP_OF_WAJAOM_WOODLANDS, tpz.ki.MAP_OF_CAEDARVA_MIRE, tpz.ki.MAP_OF_MOUNT_ZHAYOLM, tpz.ki.MAP_OF_AYDEEWA_SUBTERRANE, tpz.ki.MAP_OF_MAMOOK, tpz.ki.MAP_OF_HALVUNG, tpz.ki.MAP_OF_ARRAPAGO_REEF, tpz.ki.MAP_OF_ALZADAAL_RUINS, tpz.ki.MAP_OF_BHAFLAU_THICKETS,
-    tpz.ki.MAP_OF_VUNKERL_INLET, tpz.ki.MAP_OF_GRAUBERG, tpz.ki.MAP_OF_FORT_KARUGONARUGO};
+    tpz.ki.MAP_OF_VUNKERL_INLET, tpz.ki.MAP_OF_GRAUBERG, tpz.ki.MAP_OF_FORT_KARUGONARUGO}
 
 local Uoption = {    --User option selected.
     1,            --SanDoria Area
@@ -89,7 +89,7 @@ local Uoption = {    --User option selected.
     4521985,    --Vunkerl Inlet
     4587521,    --Grauberg
     4653057        --Fort Karugo-Narugo
-    };
+    }
 
 --Groups maps by price, based off the user option.
 local p2 = { --Maps that are price at 200 gil
@@ -97,7 +97,7 @@ local p2 = { --Maps that are price at 200 gil
     Uoption[2],        --Bastok Area
     Uoption[3],        --Windurst Area
     Uoption[9]        --Zeruhn Mines
-    };
+    }
 local p6 = { --Maps that are price at 600 gil
     Uoption[4],        --Jeuno Area
     Uoption[5],        --Ordelles Caves
@@ -111,7 +111,7 @@ local p6 = { --Maps that are price at 600 gil
     Uoption[24],    --Horutoto Ruins
     Uoption[27],    --Gusgen Mines
     Uoption[59]        --Al Zahbi
-    };
+    }
 local p3 = {    --Maps that are price at 3000 gil
     Uoption[7],        --Davoi
     Uoption[8],        --Carpenters Landing
@@ -166,105 +166,105 @@ local p3 = {    --Maps that are price at 3000 gil
     Uoption[67],    --Arrapago Reef
     Uoption[68],    --Alzadall Ruins
     Uoption[69]        --Bhaflau Thickets
-    };
+    }
 local p30 = { --Maps that are price at 30,000 gil
     Uoption[70],    --Vunkerl Inlet
     Uoption[71],    --Grauberg
     Uoption[72]        --Fort Karugo-Narugo
-    };
+    }
     
 function CheckMaps(player, npc, csid)
-    local i = 0;
-    local mapVar1 = 0;
-    local mapVar2 = 0;
-    local mapVar3 = 0;
+    local i = 0
+    local mapVar1 = 0
+    local mapVar2 = 0
+    local mapVar3 = 0
 
     while i <= 31 do
         if player:hasKeyItem(Maps[i+1]) then
-            mapVar1 = bit.bor(mapVar1, bit.lshift(1,i));
+            mapVar1 = bit.bor(mapVar1, bit.lshift(1,i))
         end
-        i = i + 1;
+        i = i + 1
     end
     
     while i <= 63 do
         if player:hasKeyItem(Maps[i+1]) then
-            mapVar2 = bit.bor(mapVar2, bit.lshift(1,i));
+            mapVar2 = bit.bor(mapVar2, bit.lshift(1,i))
         end
-        i = i + 1;
+        i = i + 1
     end
     
     while i <= 71 do
         if player:hasKeyItem(Maps[i+1]) then
-            mapVar3 = bit.bor(mapVar3, bit.lshift(1,i));
+            mapVar3 = bit.bor(mapVar3, bit.lshift(1,i))
         end
-        i = i + 1;
+        i = i + 1
     end
     
-    player:startEvent(csid, mapVar1, mapVar2, mapVar3);
-end;
+    player:startEvent(csid, mapVar1, mapVar2, mapVar3)
+end
 
 function CheckMapsUpdate (player, option, NOT_HAVE_ENOUGH_GIL, KEYITEM_OBTAINED)
-    local price = 0;
-    local MadePurchase = false;
-    local KI = 0;
-    local i = 0;
-    local mapVar1 = 0;
-    local mapVar2 = 0;
-    local mapVar3 = 0;
+    local price = 0
+    local MadePurchase = false
+    local KI = 0
+    local i = 0
+    local mapVar1 = 0
+    local mapVar2 = 0
+    local mapVar3 = 0
 
     while i <= 71 do
         if (option == Uoption[i+1]) then
-            local x = 1;
+            local x = 1
             while x <= 53 do
                 if (x <= 4 and option == p2[x]) then
-                    price = 200;
+                    price = 200
                 elseif (x <= 12 and option == p6[x]) then
-                    price = 600;
+                    price = 600
                 elseif (x <= 53 and option == p3[x]) then
-                    price = 3000;
+                    price = 3000
                 elseif (x <= 3 and option == p30[x]) then
-                    price = 30000;
+                    price = 30000
                 end
-                x=x+1;
+                x=x+1
             end
-            MadePurchase = true;
-            KI = Maps[i+1];
+            MadePurchase = true
+            KI = Maps[i+1]
         end
-        i = i + 1;
+        i = i + 1
     end
 
     if (price > player:getGil()) then
-        player:messageSpecial(NOT_HAVE_ENOUGH_GIL);
-        MadePurchase = false;
-        price = 0;
+        player:messageSpecial(NOT_HAVE_ENOUGH_GIL)
+        MadePurchase = false
+        price = 0
     elseif (price > 0 and MadePurchase == true) then
-        player:delGil(price);
-        MadePurchase = false;
-        player:addKeyItem(KI);
-        player:messageSpecial(KEYITEM_OBTAINED, KI);
+        player:delGil(price)
+        MadePurchase = false
+        player:addKeyItem(KI)
+        player:messageSpecial(KEYITEM_OBTAINED, KI)
     end
     
-    i=0;
+    i=0
     while i <= 31 do
         if player:hasKeyItem(Maps[i+1]) then
-            mapVar1 = bit.bor(mapVar1, bit.lshift(1,i));
+            mapVar1 = bit.bor(mapVar1, bit.lshift(1,i))
         end
-        i = i + 1;
+        i = i + 1
     end
     
     while i <= 63 do
         if player:hasKeyItem(Maps[i+1]) then
-            mapVar2 = bit.bor(mapVar2, bit.lshift(1,i));
+            mapVar2 = bit.bor(mapVar2, bit.lshift(1,i))
         end
-        i = i + 1;
+        i = i + 1
     end
     
     while i <= 71 do
         if player:hasKeyItem(Maps[i+1]) then
-            mapVar3 = bit.bor(mapVar3, bit.lshift(1,i));
+            mapVar3 = bit.bor(mapVar3, bit.lshift(1,i))
         end
-        i = i + 1;
+        i = i + 1
     end
     
-    player:updateEvent(mapVar1, mapVar2, mapVar3);
-end;
+    player:updateEvent(mapVar1, mapVar2, mapVar3)
+end

--- a/scripts/globals/magicburst.lua
+++ b/scripts/globals/magicburst.lua
@@ -40,41 +40,41 @@ local matches = -- [element id][resonance id]
 
 -- Returns a boolean if the spell's element matches the resonace given
 function doesSpellElementMatchResonance(ele, resonance)
-    isMatch = matches[ele + 1][resonance:getPower() + 1];
-    return (isMatch ~= nil and isMatch > 0);
+    isMatch = matches[ele + 1][resonance:getPower() + 1]
+    return (isMatch ~= nil and isMatch > 0)
 end
 
 -- Returns the burst level for a spell / target combination
 function FormMagicBurst(ele, target)
-    local resonance = target:getStatusEffect(tpz.effect.SKILLCHAIN);
+    local resonance = target:getStatusEffect(tpz.effect.SKILLCHAIN)
     if (resonance ~= nil and resonance:getTier() > 0) then -- Resonance exists, ignore it if its tier 0
         if (doesSpellElementMatchResonance(ele, resonance) == true) then
-            return resonance:getTier(), resonance:getSubPower();
+            return resonance:getTier(), resonance:getSubPower()
         end
     end -- if resonance
     
-    return 0, 0;
+    return 0, 0
 end
 
 function MobFormMagicBurst(element, target)
-    local resonance = target:getStatusEffect(tpz.effect.SKILLCHAIN);
+    local resonance = target:getStatusEffect(tpz.effect.SKILLCHAIN)
 
     if (resonance ~= nil and resonance:getTier() > 0) then -- Resonance exists, ignore it if its tier 0
         if (doesMobSpellElementMatchResonance(element, resonance) == true) then
-            return resonance:getTier(), resonance:getSubPower();
+            return resonance:getTier(), resonance:getSubPower()
         end
     end -- if resonance
     
-    return 0, 0;
+    return 0, 0
 end
 
 function doesMobSpellElementMatchResonance(element, resonance)
-    isMatch = matches[element + 1][resonance:getPower() + 1];
-    return (isMatch ~= nil and isMatch > 0);
+    isMatch = matches[element + 1][resonance:getPower() + 1]
+    return (isMatch ~= nil and isMatch > 0)
 end
 
 -- Returns a boolean if the element matches the skillchain property given
 function doesElementMatchWeaponskill(ele, SCProp)
-    isMatch = matches[ele + 1][SCProp + 1];
-    return (isMatch ~= nil and isMatch > 0);
+    isMatch = matches[ele + 1][SCProp + 1]
+    return (isMatch ~= nil and isMatch > 0)
 end

--- a/scripts/globals/missions.lua
+++ b/scripts/globals/missions.lua
@@ -649,58 +649,58 @@ tpz.mission.id =
 --  Assault (7)
 -----------------------------------
 
-LEUJAOAM_CLEANSING                = 1; -- ± --
-ORICHALCUM_SURVEY                 = 2;
-ESCORT_PROFESSOR_CHANOIX          = 3;
-SHANARHA_GRASS_CONSERVATION       = 4;
-COUNTING_SHEEP                    = 5;
-SUPPLIES_RECOVERY                 = 6;
-AZURE_EXPERIMENTS                 = 7;
-IMPERIAL_CODE                     = 8;
-RED_VERSUS_BLUE                   = 9;
-BLOODY_RONDO                      = 10;
-IMPERIAL_AGENT_RESCUE             = 11;
-PREEMPTIVE_STRIKE                 = 12; -- ± --
-SAGELORD_ELIMINATION              = 13;
-BREAKING_MORALE                   = 14;
-THE_DOUBLE_AGENT                  = 15;
-IMPERIAL_TREASURE_RETRIEVAL       = 16;
-BLITZKRIEG                        = 17;
-MARIDS_IN_THE_MIST                = 18;
-AZURE_AILMENTS                    = 19;
-THE_SUSANOO_SHUFFLE               = 20;
-EXCAVATION_DUTY                   = 21; --+
-LEBROS_SUPPLIES                   = 22;
-TROLL_FUGITIVES                   = 23; --+
-EVADE_AND_ESCAPE                  = 24;
-SIEGEMASTER_ASSASSINATION         = 25;
-APKALLU_BREEDING                  = 26;
-WAMOURA_FARM_RAID                 = 27;
-EGG_CONSERVATION                  = 28;
-OPERATION__BLACK_PEARL            = 29;
-BETTER_THAN_ONE                   = 30;
-SEAGULL_GROUNDED                  = 31;
-REQUIEM                           = 32; -- ± --
-SAVING_PRIVATE_RYAAF              = 33;
-SHOOTING_DOWN_THE_BARON           = 34;
-BUILDING_BRIDGES                  = 35;
-STOP_THE_BLOODSHED                = 36;
-DEFUSE_THE_THREAT                 = 37;
-OPERATION__SNAKE_EYES             = 38;
-WAKE_THE_PUPPET                   = 39;
-THE_PRICE_IS_RIGHT                = 40;
-GOLDEN_SALVAGE                    = 41; -- ± --
-LAMIA_NO_13                       = 42;
-EXTERMINATION                     = 43; -- ± --
-DEMOLITION_DUTY                   = 44;
-SEARAT_SALVATION                  = 45;
-APKALLU_SEIZURE                   = 46;
-LOST_AND_FOUND                    = 47;
-DESERTER                          = 48;
-DESPERATELY_SEEKING_CEPHALOPODS   = 49;
-BELLEROPHON_S_BLISS               = 50;
-NYZUL_ISLE_INVESTIGATION          = 51;
-NYZUL_ISLE_UNCHARTED_AREA_SURVEY  = 52;
+LEUJAOAM_CLEANSING                = 1 -- ± --
+ORICHALCUM_SURVEY                 = 2
+ESCORT_PROFESSOR_CHANOIX          = 3
+SHANARHA_GRASS_CONSERVATION       = 4
+COUNTING_SHEEP                    = 5
+SUPPLIES_RECOVERY                 = 6
+AZURE_EXPERIMENTS                 = 7
+IMPERIAL_CODE                     = 8
+RED_VERSUS_BLUE                   = 9
+BLOODY_RONDO                      = 10
+IMPERIAL_AGENT_RESCUE             = 11
+PREEMPTIVE_STRIKE                 = 12 -- ± --
+SAGELORD_ELIMINATION              = 13
+BREAKING_MORALE                   = 14
+THE_DOUBLE_AGENT                  = 15
+IMPERIAL_TREASURE_RETRIEVAL       = 16
+BLITZKRIEG                        = 17
+MARIDS_IN_THE_MIST                = 18
+AZURE_AILMENTS                    = 19
+THE_SUSANOO_SHUFFLE               = 20
+EXCAVATION_DUTY                   = 21 --+
+LEBROS_SUPPLIES                   = 22
+TROLL_FUGITIVES                   = 23 --+
+EVADE_AND_ESCAPE                  = 24
+SIEGEMASTER_ASSASSINATION         = 25
+APKALLU_BREEDING                  = 26
+WAMOURA_FARM_RAID                 = 27
+EGG_CONSERVATION                  = 28
+OPERATION__BLACK_PEARL            = 29
+BETTER_THAN_ONE                   = 30
+SEAGULL_GROUNDED                  = 31
+REQUIEM                           = 32 -- ± --
+SAVING_PRIVATE_RYAAF              = 33
+SHOOTING_DOWN_THE_BARON           = 34
+BUILDING_BRIDGES                  = 35
+STOP_THE_BLOODSHED                = 36
+DEFUSE_THE_THREAT                 = 37
+OPERATION__SNAKE_EYES             = 38
+WAKE_THE_PUPPET                   = 39
+THE_PRICE_IS_RIGHT                = 40
+GOLDEN_SALVAGE                    = 41 -- ± --
+LAMIA_NO_13                       = 42
+EXTERMINATION                     = 43 -- ± --
+DEMOLITION_DUTY                   = 44
+SEARAT_SALVATION                  = 45
+APKALLU_SEIZURE                   = 46
+LOST_AND_FOUND                    = 47
+DESERTER                          = 48
+DESPERATELY_SEEKING_CEPHALOPODS   = 49
+BELLEROPHON_S_BLISS               = 50
+NYZUL_ISLE_INVESTIGATION          = 51
+NYZUL_ISLE_UNCHARTED_AREA_SURVEY  = 52
 
 -----------------------------------
 --  Campaign (8)
@@ -708,238 +708,238 @@ NYZUL_ISLE_UNCHARTED_AREA_SURVEY  = 52;
 -- None yet!
 
 function rankPointMath(rank)
-    return 0.372*rank^2 - 1.62*rank + 6.2;
+    return 0.372*rank^2 - 1.62*rank + 6.2
 end
 
 function getMissionRankPoints(player, missionID)
-    if     (missionID ==  3) then crystals = 9;
-    elseif (missionID ==  4) then crystals = 17;
-    elseif (missionID ==  5) then crystals = 42;
-    elseif (missionID == 10) then crystals = 12;                    -- 1 stack needed to unlock
-    elseif (missionID == 11) then crystals = 30;                    -- 2.5 stacks needed to unlock (2 stacks of crystals + 3.1 rank points corresponding to half a stack)
-    elseif (missionID == 12) then crystals = 48;                    -- 4 stacks to unlock (3.5 stacks + 3.1 rank points corresponding to half a stack)
-    elseif (missionID == 13) then crystals = 36;                    -- 3 stacks to unlock
+    if     (missionID ==  3) then crystals = 9
+    elseif (missionID ==  4) then crystals = 17
+    elseif (missionID ==  5) then crystals = 42
+    elseif (missionID == 10) then crystals = 12                    -- 1 stack needed to unlock
+    elseif (missionID == 11) then crystals = 30                    -- 2.5 stacks needed to unlock (2 stacks of crystals + 3.1 rank points corresponding to half a stack)
+    elseif (missionID == 12) then crystals = 48                    -- 4 stacks to unlock (3.5 stacks + 3.1 rank points corresponding to half a stack)
+    elseif (missionID == 13) then crystals = 36                    -- 3 stacks to unlock
     -- 5.1 starts directly after Magicite, no crystals needed
-    elseif (missionID == 15) then crystals = 44;                    -- Mission unlocks at 50% rank bar ~= 44 crystals using the present formula.
-    elseif (missionID == 16) then crystals = 36;                    -- 3 stacks to unlock
-    elseif (missionID == 17) then crystals = 93;                    -- 3 additional stacks to unlock + 3 original stacks + 21 from mission 6.1
-    elseif (missionID == 18) then crystals = 45;                    -- 45 needed, from http://wiki.ffxiclopedia.org/wiki/The_Final_Image
-    elseif (missionID == 19) then crystals = 119;                    -- 4 additional stacks needed, plus mission reward of 26
-    elseif (missionID == 20) then crystals = 57;                    -- 4 3/4 stacks needed
-    elseif (missionID == 21) then crystals = 148;                    -- 5 additional stacks needed, plus mission reward of 31,
-    elseif (missionID == 22) then crystals = 96;                    -- 8 stacks needed (higher value chosen so final rank bar requirement is closer to 90%)
-    elseif (missionID == 23) then crystals = 228;                    -- Additional 8 stacks needed, plus mission reward of 36 (87% rank bar)
-    end;
+    elseif (missionID == 15) then crystals = 44                    -- Mission unlocks at 50% rank bar ~= 44 crystals using the present formula.
+    elseif (missionID == 16) then crystals = 36                    -- 3 stacks to unlock
+    elseif (missionID == 17) then crystals = 93                    -- 3 additional stacks to unlock + 3 original stacks + 21 from mission 6.1
+    elseif (missionID == 18) then crystals = 45                    -- 45 needed, from http://wiki.ffxiclopedia.org/wiki/The_Final_Image
+    elseif (missionID == 19) then crystals = 119                    -- 4 additional stacks needed, plus mission reward of 26
+    elseif (missionID == 20) then crystals = 57                    -- 4 3/4 stacks needed
+    elseif (missionID == 21) then crystals = 148                    -- 5 additional stacks needed, plus mission reward of 31,
+    elseif (missionID == 22) then crystals = 96                    -- 8 stacks needed (higher value chosen so final rank bar requirement is closer to 90%)
+    elseif (missionID == 23) then crystals = 228                    -- Additional 8 stacks needed, plus mission reward of 36 (87% rank bar)
+    end
 
-    points_needed = 1024 * (crystals-.25) / (3*rankPointMath(player:getRank()));
+    points_needed = 1024 * (crystals-.25) / (3*rankPointMath(player:getRank()))
 
     if (player:getRankPoints() >= points_needed) then
-        return 1;
+        return 1
     else
-        return 0;
+        return 0
     end
-end;
+end
 
 function getMissionMask(player)
     rank = player:getRank()
-    nation = player:getNation();  -- 0 = San d'Oria ; 1 = Bastok ; 2 = Windurst
-    mission_status =  player:getCurrentMission(nation);
+    nation = player:getNation()  -- 0 = San d'Oria  1 = Bastok  2 = Windurst
+    mission_status =  player:getCurrentMission(nation)
 
-    first_mission = 0;
-    repeat_mission = 0;
+    first_mission = 0
+    repeat_mission = 0
 
     if (nation == tpz.nation.WINDURST) then
         if (rank >= 1) then
             if (player:hasCompletedMission(WINDURST,tpz.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT) == false) then
                 -- 1-1 NOTE: This mission will not be listed in the Mission List for Windurst
-                --first_mission = first_mission + 1;
+                --first_mission = first_mission + 1
             end
             if (player:hasCompletedMission(WINDURST,tpz.mission.id.windurst.THE_HEART_OF_THE_MATTER) == false) then
                 -- 1-2 NOTE: This mission will not be listed in the Mission List for Windurst
-                --first_mission = first_mission + 2;
+                --first_mission = first_mission + 2
             end
             if (player:hasCompletedMission(WINDURST,tpz.mission.id.windurst.THE_PRICE_OF_PEACE) == false) then
                 -- 1-3 NOTE: This mission will not be listed in the Mission List for Windurst
-                --first_mission = first_mission + 4;
+                --first_mission = first_mission + 4
             end
         end
         if (rank >= 2) then
             -- 2-1
             if (player:hasCompletedMission(WINDURST,tpz.mission.id.windurst.LOST_FOR_WORDS) == false and getMissionRankPoints(player,3) == 1) then
-                first_mission = first_mission + 8;
+                first_mission = first_mission + 8
             else
                 if (player:hasCompletedMission(WINDURST,tpz.mission.id.windurst.LOST_FOR_WORDS) and (rank > 2 or getMissionRankPoints(player,4) == 1)) then
                     -- 2-2 Repeatable
-                    repeat_mission = repeat_mission + 16;
+                    repeat_mission = repeat_mission + 16
                 end
                 if (player:hasCompletedMission(WINDURST,tpz.mission.id.windurst.THE_THREE_KINGDOMS) == false and getMissionRankPoints(player,5) == 1) then
                     -- 2-3
-                    first_mission = first_mission + 32;
+                    first_mission = first_mission + 32
                 end
             end
         end
         if (rank >= 3) then
             -- 3-1
             if (player:hasCompletedMission(WINDURST,tpz.mission.id.windurst.TO_EACH_HIS_OWN_RIGHT) == false and getMissionRankPoints(player,10) == 1) then
-                first_mission = first_mission + 1024;
+                first_mission = first_mission + 1024
             else
                 if (player:hasCompletedMission(WINDURST,tpz.mission.id.windurst.WRITTEN_IN_THE_STARS) == false and getMissionRankPoints(player,11) == 1) then
                     -- 3-2 Repeatable & Skippable
-                    repeat_mission = repeat_mission + 2048;
+                    repeat_mission = repeat_mission + 2048
                 elseif (rank > 3 or getMissionRankPoints(player,11) == 1) then
                     -- 3-2 Repeatable & Skippable
-                    repeat_mission = repeat_mission + 2048;
+                    repeat_mission = repeat_mission + 2048
                 end
                 if (player:hasCompletedMission(WINDURST,tpz.mission.id.windurst.A_NEW_JOURNEY) == false and getMissionRankPoints(player,12) == 1) then
                     -- 3-3
-                    first_mission = first_mission + 4096;
+                    first_mission = first_mission + 4096
                 end
             end
         end
         if (rank == 4) then
             -- The mission is triggered by the Ambassador in Jeuno
-            -- first_mission = first_mission + 8192;
+            -- first_mission = first_mission + 8192
         end
         if (rank == 5) then
             if (player:hasCompletedMission(WINDURST,tpz.mission.id.windurst.THE_FINAL_SEAL) == false and getMissionRankPoints(player,0) == 1 and mission_status == 0) then
-                first_mission = first_mission + 16384;
+                first_mission = first_mission + 16384
             end
             if (player:hasCompletedMission(WINDURST,tpz.mission.id.windurst.THE_FINAL_SEAL) and player:hasCompletedMission(WINDURST,tpz.mission.id.windurst.THE_SHADOW_AWAITS) == false and getMissionRankPoints(player,15) == 1) then
                 -- 5-2
-                first_mission = first_mission + 32768;
+                first_mission = first_mission + 32768
             end
         end
         if (rank == 6) then
             if (player:hasCompletedMission(WINDURST,tpz.mission.id.windurst.FULL_MOON_FOUNTAIN) == false and getMissionRankPoints(player,16) == 1) then
                 -- 6-1
-                first_mission = first_mission + 65536;
+                first_mission = first_mission + 65536
             elseif (player:hasCompletedMission(WINDURST,tpz.mission.id.windurst.SAINTLY_INVITATION) == false and getMissionRankPoints(player,17) == 1) then
                 -- 6-2
-                first_mission = first_mission + 131072;
+                first_mission = first_mission + 131072
             end
         end
         if (rank == 7) then
             if (player:hasCompletedMission(WINDURST,tpz.mission.id.windurst.THE_SIXTH_MINISTRY) == false and getMissionRankPoints(player,18) == 1) then
                 -- 7-1
-                first_mission = first_mission + 262144;
+                first_mission = first_mission + 262144
             elseif (player:hasCompletedMission(WINDURST,tpz.mission.id.windurst.AWAKENING_OF_THE_GODS) == false and getMissionRankPoints(player,19) == 1) then
                 -- 7-2
-                first_mission = first_mission + 524288;
+                first_mission = first_mission + 524288
             end
         end
         if (rank == 8) then
             if (player:hasCompletedMission(WINDURST,tpz.mission.id.windurst.VAIN) == false and getMissionRankPoints(player,20) == 1) then
                 -- 8-1
-                first_mission = first_mission + 1048576;
+                first_mission = first_mission + 1048576
             elseif (player:hasCompletedMission(WINDURST,tpz.mission.id.windurst.THE_JESTER_WHO_D_BE_KING) == false and getMissionRankPoints(player,21) == 1) then
                 -- 8-2
-                first_mission = first_mission + 2097152;
+                first_mission = first_mission + 2097152
             end
         end
         if (rank == 9) then
             if (player:hasCompletedMission(WINDURST,tpz.mission.id.windurst.DOLL_OF_THE_DEAD) == false and getMissionRankPoints(player,22) == 1) then
                 -- 9-1
-                first_mission = first_mission + 4194304;
+                first_mission = first_mission + 4194304
             elseif (player:hasCompletedMission(WINDURST,tpz.mission.id.windurst.MOON_READING) == false and getMissionRankPoints(player,23) == 1) then
                 -- 9-2
-                first_mission = first_mission + 8388608;
+                first_mission = first_mission + 8388608
             end
         end
     elseif (nation == tpz.nation.SANDORIA) then
         if (rank >= 1) then
             if (player:hasCompletedMission(SANDORIA,tpz.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS) == false) then -- The first mission is repeatable in San d'Oria
                 -- 1-1
-                repeat_mission = repeat_mission + 1;
+                repeat_mission = repeat_mission + 1
             elseif (player:hasCompletedMission(SANDORIA,tpz.mission.id.sandoria.BAT_HUNT) == false) then
                 -- 1-2 If we completed 1-1, we can start and repeat this mission
-                repeat_mission = repeat_mission + 2 + 1;
+                repeat_mission = repeat_mission + 2 + 1
             elseif (player:hasCompletedMission(SANDORIA,tpz.mission.id.sandoria.SAVE_THE_CHILDREN) == false) then
                 -- 1-3 If we completed 1-2, we can start and repeat this mission
-                repeat_mission = repeat_mission + 4 + 2 + 1;
+                repeat_mission = repeat_mission + 4 + 2 + 1
             else
-                repeat_mission = repeat_mission + 4 + 2 + 1;
+                repeat_mission = repeat_mission + 4 + 2 + 1
             end
         end
         if (rank >= 2) then
             -- 2-1
             if (player:hasCompletedMission(SANDORIA,tpz.mission.id.sandoria.THE_RESCUE_DRILL) == false and getMissionRankPoints(player,3) == 1) then
-                first_mission = first_mission + 8;
+                first_mission = first_mission + 8
             else
                 if (rank > 2 or getMissionRankPoints(player,4) == 1) then
                     -- 2-2 Repeatable & Skippable
-                    repeat_mission = repeat_mission + 16;
+                    repeat_mission = repeat_mission + 16
                 end
                 if (player:hasCompletedMission(SANDORIA,tpz.mission.id.sandoria.JOURNEY_ABROAD) == false and getMissionRankPoints(player,5) == 1) then
                     -- 2-3
-                    first_mission = first_mission + 32;
+                    first_mission = first_mission + 32
                 end
             end
         end
         if (rank >= 3) then
             if (rank > 3 or getMissionRankPoints(player,10) == 1) then
                 -- 3-1
-                repeat_mission = repeat_mission + 1024;
+                repeat_mission = repeat_mission + 1024
             end
             if (player:hasCompletedMission(SANDORIA,tpz.mission.id.sandoria.INFILTRATE_DAVOI) == true and getMissionRankPoints(player,11) == 1) then
                 -- 3-2 Repeatable & Skippable
-                repeat_mission = repeat_mission + 2048;
+                repeat_mission = repeat_mission + 2048
             end
             if (player:hasCompletedMission(SANDORIA,tpz.mission.id.sandoria.APPOINTMENT_TO_JEUNO) == false and getMissionRankPoints(player,12) == 1) then
                 -- 3-3
-                first_mission = first_mission + 4096;
+                first_mission = first_mission + 4096
             end
         end
         if (rank == 4) then
             -- The mission is triggered by the Ambassador in Jeuno
-            -- first_mission = first_mission + 8192;
+            -- first_mission = first_mission + 8192
         end
         if (rank == 5) then
             if (player:hasCompletedMission(SANDORIA,tpz.mission.id.sandoria.THE_RUINS_OF_FEI_YIN) == false and player:hasKeyItem(tpz.ki.MESSAGE_TO_JEUNO_SANDORIA) == false) then
-                first_mission = first_mission + 16384;
+                first_mission = first_mission + 16384
             end
             if (player:hasCompletedMission(SANDORIA,tpz.mission.id.sandoria.THE_SHADOW_LORD) == false and player:hasCompletedMission(SANDORIA,tpz.mission.id.sandoria.THE_RUINS_OF_FEI_YIN) and getMissionRankPoints(player,15) == 1) then
                 -- 5-2
-                first_mission = first_mission + 32768;
+                first_mission = first_mission + 32768
             end
         end
         if (rank == 6) then
             if (player:hasCompletedMission(SANDORIA,tpz.mission.id.sandoria.LEAUTE_S_LAST_WISHES) == false and getMissionRankPoints(player,16) == 1) then
                 -- 6-1
-                first_mission = first_mission + 65536;
+                first_mission = first_mission + 65536
             elseif (player:hasCompletedMission(SANDORIA,tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST) == false and getMissionRankPoints(player,17) == 1) then
                 -- 6-2
-                first_mission = first_mission + 131072;
+                first_mission = first_mission + 131072
             end
         end
         if (rank == 7) then
             if (player:hasCompletedMission(SANDORIA,tpz.mission.id.sandoria.PRESTIGE_OF_THE_PAPSQUE) == false and getMissionRankPoints(player,18) == 1) then
                 -- 7-1
-                first_mission = first_mission + 262144;
+                first_mission = first_mission + 262144
             elseif (player:hasCompletedMission(SANDORIA,tpz.mission.id.sandoria.THE_SECRET_WEAPON) == false and getMissionRankPoints(player,19) == 1) then
                 -- 7-2
-                first_mission = first_mission + 524288;
+                first_mission = first_mission + 524288
             end
         end
         if (rank == 8) then
             if (player:hasCompletedMission(SANDORIA,tpz.mission.id.sandoria.COMING_OF_AGE) == false and getMissionRankPoints(player,20) == 1) then
                 -- 8-1
-                first_mission = first_mission + 1048576;
+                first_mission = first_mission + 1048576
             elseif (player:hasCompletedMission(SANDORIA,tpz.mission.id.sandoria.LIGHTBRINGER) == false and getMissionRankPoints(player,21) == 1 and player:getCharVar("Mission8-1Completed") == 1) then
                 -- 8-2
-                first_mission = first_mission + 2097152;
+                first_mission = first_mission + 2097152
             end
         end
         if (rank == 9) then
             if (player:hasCompletedMission(SANDORIA,tpz.mission.id.sandoria.BREAKING_BARRIERS) == false and getMissionRankPoints(player,22) == 1) then
                 -- 9-1
-                first_mission = first_mission + 4194304;
+                first_mission = first_mission + 4194304
             elseif (player:hasCompletedMission(SANDORIA,tpz.mission.id.sandoria.BREAKING_BARRIERS) == false and getMissionRankPoints(player,22) == 1 and player:getCharVar("Cutscenes_8-2") == 2) then
                 -- 9-2
-                first_mission = first_mission + 8388608;
+                first_mission = first_mission + 8388608
 
     elseif (player:hasCompletedMission(SANDORIA,tpz.mission.id.sandoria.THE_HEIR_TO_THE_LIGHT) == false and getMissionRankPoints(player,23) == 1) then
                 -- 9-2
-                first_mission = first_mission + 8388608;
+                first_mission = first_mission + 8388608
 
             end
         end
@@ -947,218 +947,218 @@ function getMissionMask(player)
         if (rank >= 1) then
             if (player:hasCompletedMission(BASTOK,tpz.mission.id.bastok.THE_ZERUHN_REPORT) == false) then
                 -- 1-1 NOTE: This mission will not be listed in the Mission List for Bastok
-                --first_mission = first_mission + 1;
+                --first_mission = first_mission + 1
             end
             if (player:hasCompletedMission(BASTOK,tpz.mission.id.bastok.GEOLOGICAL_SURVEY) == false) then
                 -- 1-2 NOTE: This mission will not be listed in the Mission List for Bastok
-                first_mission = first_mission + 2;
+                first_mission = first_mission + 2
             end
             if (player:hasCompletedMission(BASTOK,tpz.mission.id.bastok.GEOLOGICAL_SURVEY) == true) then
                 -- 1-3
-                repeat_mission = repeat_mission + 4;
+                repeat_mission = repeat_mission + 4
             end
         end
         if (rank >= 2) then
             -- 2-1
             if (player:hasCompletedMission(BASTOK,tpz.mission.id.bastok.THE_CRYSTAL_LINE) == false and getMissionRankPoints(player,3) == 1) then
-                first_mission = first_mission + 8;
+                first_mission = first_mission + 8
             else
                 if (rank > 2 or getMissionRankPoints(player,4) == 1) then
                     -- 2-2 Repeatable
-                    repeat_mission = repeat_mission + 16;
+                    repeat_mission = repeat_mission + 16
                 end
                 if (player:hasCompletedMission(BASTOK,tpz.mission.id.bastok.THE_EMISSARY) == false and getMissionRankPoints(player,5) == 1) then
                     -- 2-3
-                    first_mission = first_mission + 32;
+                    first_mission = first_mission + 32
                 end
             end
         end
         if (rank >= 3) then
             -- 3-1
             if (player:hasCompletedMission(BASTOK,tpz.mission.id.bastok.THE_FOUR_MUSKETEERS) == false and getMissionRankPoints(player,10) == 1) then
-                first_mission = first_mission + 1024;
+                first_mission = first_mission + 1024
             else
                 if (rank > 3 or getMissionRankPoints(player,11) == 1) then
                     -- 3-2 Repeatable & Skippable
-                    repeat_mission = repeat_mission + 2048;
+                    repeat_mission = repeat_mission + 2048
                 end
                 if (player:hasCompletedMission(BASTOK,tpz.mission.id.bastok.JEUNO) == false and getMissionRankPoints(player,12) == 1) then
                     -- 3-3
-                    first_mission = first_mission + 4096;
+                    first_mission = first_mission + 4096
                 end
             end
         end
         if (rank == 4) then
             -- The mission is triggered by the Ambassador in Jeuno
-            -- first_mission = first_mission + 8192;
+            -- first_mission = first_mission + 8192
         end
         if (rank == 5) then
             if (player:hasCompletedMission(BASTOK,tpz.mission.id.bastok.DARKNESS_RISING) == false and getMissionRankPoints(player,0) == 1 and mission_status == 0) then
-                first_mission = first_mission + 16384;
+                first_mission = first_mission + 16384
             end
             if (player:hasCompletedMission(BASTOK,tpz.mission.id.bastok.DARKNESS_RISING) and player:hasCompletedMission(BASTOK,tpz.mission.id.bastok.XARCABARD_LAND_OF_TRUTHS) == false and getMissionRankPoints(player,15) == 1) then
                 -- 5-2
-                first_mission = first_mission + 32768;
+                first_mission = first_mission + 32768
             end
         end
         if (rank == 6) then
             if (player:hasCompletedMission(BASTOK,tpz.mission.id.bastok.RETURN_OF_THE_TALEKEEPER) == false and getMissionRankPoints(player,16) == 1) then
                 -- 6-1
-                first_mission = first_mission + 65536;
+                first_mission = first_mission + 65536
             elseif (player:hasCompletedMission(BASTOK,tpz.mission.id.bastok.THE_PIRATE_S_COVE) == false and getMissionRankPoints(player,17) == 1) then
                 -- 6-2
-                first_mission = first_mission + 131072;
+                first_mission = first_mission + 131072
             end
         end
         if (rank == 7) then
             if (player:hasCompletedMission(BASTOK,tpz.mission.id.bastok.THE_FINAL_IMAGE) == false and getMissionRankPoints(player,18) == 1) then
                 -- 7-1
-                first_mission = first_mission + 262144;
+                first_mission = first_mission + 262144
             elseif (player:hasCompletedMission(BASTOK,tpz.mission.id.bastok.ON_MY_WAY) == false and getMissionRankPoints(player,19) == 1) then
                 -- 7-2
-                first_mission = first_mission + 524288;
+                first_mission = first_mission + 524288
             end
         end
         if (rank == 8) then
             if (player:hasCompletedMission(BASTOK,tpz.mission.id.bastok.THE_CHAINS_THAT_BIND_US) == false and getMissionRankPoints(player,20) == 1) then
                 -- 8-1
-                first_mission = first_mission + 1048576;
+                first_mission = first_mission + 1048576
             elseif (player:hasCompletedMission(BASTOK,tpz.mission.id.bastok.ENTER_THE_TALEKEEPER) == false and getMissionRankPoints(player,21) == 1) then
                 -- 8-2
-                first_mission = first_mission + 2097152;
+                first_mission = first_mission + 2097152
             end
         end
         if (rank == 9) then
             if (player:hasCompletedMission(BASTOK,tpz.mission.id.bastok.THE_SALT_OF_THE_EARTH) == false and getMissionRankPoints(player,22) == 1) then
                 -- 9-1
-                first_mission = first_mission + 4194304;
+                first_mission = first_mission + 4194304
             elseif (player:hasCompletedMission(BASTOK,tpz.mission.id.bastok.WHERE_TWO_PATHS_CONVERGE) == false and getMissionRankPoints(player,23) == 1) then
                 -- 9-2
-                first_mission = first_mission + 8388608;
+                first_mission = first_mission + 8388608
             end
         end
     end
 
     if (player:getCurrentMission(nation) == tpz.mission.id.sandoria.THE_RUINS_OF_FEI_YIN and player:getCharVar("MissionStatus") == 8) then
-        mission_mask = 2147483647 - 16384;
+        mission_mask = 2147483647 - 16384
     else
-        mission_mask = 2147483647 - repeat_mission - first_mission; -- 2^31 -1 - ..
+        mission_mask = 2147483647 - repeat_mission - first_mission -- 2^31 -1 - ..
     end
 
-    return mission_mask,repeat_mission;
-end;
+    return mission_mask,repeat_mission
+end
 
 function getMissionOffset(player,guard,pMission,MissionStatus)
 
-    offset = 0; cs = 0; params = {0,0,0,0,0,0,0,0};
-    nation = player:getNation();
+    offset = 0 cs = 0 params = {0,0,0,0,0,0,0,0}
+    nation = player:getNation()
 
     if (nation == tpz.nation.SANDORIA) then
 
-            if (guard == 1) then GuardCS = {1022,1021,1025,1004,1024,1005,1006,1028,1029,1012,1031};
-        elseif (guard == 2) then GuardCS = {2022,2021,2025,2004,2024,2005,2006,2028,2029,2012,2031};
+            if (guard == 1) then GuardCS = {1022,1021,1025,1004,1024,1005,1006,1028,1029,1012,1031}
+        elseif (guard == 2) then GuardCS = {2022,2021,2025,2004,2024,2005,2006,2028,2029,2012,2031}
         end
 
         switch (pMission) : caseof {
-            [0] = function (x) offset = 0; end, -- Mission 1-1
-            [1] = function (x) if (MissionStatus == 2) then cs = GuardCS[1]; else cs = GuardCS[2]; end end, -- Mission 1-2 (1) after check tombstone
-            [2] = function (x) if (MissionStatus == 0) then cs = GuardCS[3]; -- Mission 1-3 before Battlefield
-                           elseif (MissionStatus == 4 and player:hasCompletedMission(0,2) == false) then cs = GuardCS[4]; -- Mission 1-3 after Battlefield
-                           elseif (MissionStatus == 4) then cs = GuardCS[5]; else offset = 24; end end, -- Mission 1-3 after Battlefield (Finish Quest)
-            [3] = function (x) if (MissionStatus == 11) then cs = GuardCS[6]; else offset = 36; end end,
-            [4] = function (x) if (MissionStatus == 3 and player:hasCompletedMission(0,4)) then cs = GuardCS[7];
-                           elseif (MissionStatus == 3) then cs = GuardCS[8]; params = {0,0,0,44}; else offset = 44; end end,
-            [5] = function (x) if (MissionStatus == 0) then offset = 50; else offset = 51; end end,
-            [10] = function (x) if (MissionStatus == 0) then cs = GuardCS[9];
-                            elseif (MissionStatus == 4) then offset = 55;
-                            elseif (MissionStatus == 5) then offset = 60;
-                            elseif (MissionStatus == 10) then cs = GuardCS[10]; end end,
-            [11] = function (x) if (MissionStatus == 0) then offset = 68;
-                            elseif (MissionStatus == 2) then cs = GuardCS[11]; end end,
-            [12] = function (x) if (MissionStatus == 0) then offset = 74; end end,
-            [14] = function (x) if (MissionStatus == 0) then cs = 61; end end,
+            [0] = function (x) offset = 0 end, -- Mission 1-1
+            [1] = function (x) if (MissionStatus == 2) then cs = GuardCS[1] else cs = GuardCS[2] end end, -- Mission 1-2 (1) after check tombstone
+            [2] = function (x) if (MissionStatus == 0) then cs = GuardCS[3] -- Mission 1-3 before Battlefield
+                           elseif (MissionStatus == 4 and player:hasCompletedMission(0,2) == false) then cs = GuardCS[4] -- Mission 1-3 after Battlefield
+                           elseif (MissionStatus == 4) then cs = GuardCS[5] else offset = 24 end end, -- Mission 1-3 after Battlefield (Finish Quest)
+            [3] = function (x) if (MissionStatus == 11) then cs = GuardCS[6] else offset = 36 end end,
+            [4] = function (x) if (MissionStatus == 3 and player:hasCompletedMission(0,4)) then cs = GuardCS[7]
+                           elseif (MissionStatus == 3) then cs = GuardCS[8] params = {0,0,0,44} else offset = 44 end end,
+            [5] = function (x) if (MissionStatus == 0) then offset = 50 else offset = 51 end end,
+            [10] = function (x) if (MissionStatus == 0) then cs = GuardCS[9]
+                            elseif (MissionStatus == 4) then offset = 55
+                            elseif (MissionStatus == 5) then offset = 60
+                            elseif (MissionStatus == 10) then cs = GuardCS[10] end end,
+            [11] = function (x) if (MissionStatus == 0) then offset = 68
+                            elseif (MissionStatus == 2) then cs = GuardCS[11] end end,
+            [12] = function (x) if (MissionStatus == 0) then offset = 74 end end,
+            [14] = function (x) if (MissionStatus == 0) then cs = 61 end end,
         }
-        return cs, params, offset;
+        return cs, params, offset
 
     elseif (nation == tpz.nation.BASTOK) then
 
         switch (pMission) : caseof {
-            [0] = function (x) offset = 0; end,
-            [1] = function (x) offset = 3; end,
-            [2] = function (x) offset = 6; end,
-            [3] = function (x) offset = 19; end,
-            [4] = function (x) offset = 21; end,
-            [5] = function (x) offset = 23; end,
-            [10] = function (x) offset = 27; end,
-            [11] = function (x) offset = 30; end,
-            [12] = function (x) offset = 35; end,
-            [14] = function (x) cs = 1007; end,
-            [15] = function (x) offset = 39; end,
-            [16] = function (x) offset = 0; end,
-            [17] = function (x) offset = 3; end,
-            [18] = function (x) offset = 5; end,
-            [19] = function (x) offset = 7; end,
-            [20] = function (x) offset = 10; end,
-            [21] = function (x) offset = 12; end,
-            [22] = function (x) offset = 14; end,
-            [23] = function (x) offset = 19; end,
+            [0] = function (x) offset = 0 end,
+            [1] = function (x) offset = 3 end,
+            [2] = function (x) offset = 6 end,
+            [3] = function (x) offset = 19 end,
+            [4] = function (x) offset = 21 end,
+            [5] = function (x) offset = 23 end,
+            [10] = function (x) offset = 27 end,
+            [11] = function (x) offset = 30 end,
+            [12] = function (x) offset = 35 end,
+            [14] = function (x) cs = 1007 end,
+            [15] = function (x) offset = 39 end,
+            [16] = function (x) offset = 0 end,
+            [17] = function (x) offset = 3 end,
+            [18] = function (x) offset = 5 end,
+            [19] = function (x) offset = 7 end,
+            [20] = function (x) offset = 10 end,
+            [21] = function (x) offset = 12 end,
+            [22] = function (x) offset = 14 end,
+            [23] = function (x) offset = 19 end,
         }
-        return cs, params, offset;
+        return cs, params, offset
 
     elseif (nation == tpz.nation.WINDURST) then
 
-            if (guard == 1) then GuardCS = {127,136,150,154,160,473,177};
-        elseif (guard == 2) then GuardCS = {123,131,310,148,156,177,215};
-        elseif (guard == 3) then GuardCS = {89,105,110,114,120,133,138};
-        elseif (guard == 4) then GuardCS = {99,107,112,116,122,127,134};
+            if (guard == 1) then GuardCS = {127,136,150,154,160,473,177}
+        elseif (guard == 2) then GuardCS = {123,131,310,148,156,177,215}
+        elseif (guard == 3) then GuardCS = {89,105,110,114,120,133,138}
+        elseif (guard == 4) then GuardCS = {99,107,112,116,122,127,134}
         end
 
         switch (pMission) : caseof {
-            [0] = function (x) cs = GuardCS[1]; end,
-            [1] = function (x) cs = GuardCS[2]; end,
-            [2] = function (x) if (MissionStatus <= 2) then cs = GuardCS[3]; else cs = GuardCS[4]; end end,
-            [3] = function (x) cs = GuardCS[5]; end,
-            [4] = function (x) cs = GuardCS[6]; end,
-            [5] = function (x) cs = GuardCS[7]; end,
+            [0] = function (x) cs = GuardCS[1] end,
+            [1] = function (x) cs = GuardCS[2] end,
+            [2] = function (x) if (MissionStatus <= 2) then cs = GuardCS[3] else cs = GuardCS[4] end end,
+            [3] = function (x) cs = GuardCS[5] end,
+            [4] = function (x) cs = GuardCS[6] end,
+            [5] = function (x) cs = GuardCS[7] end,
         }
-        return cs, params, offset;
+        return cs, params, offset
     end
 
-end;
+end
 
 function finishMissionTimeline(player,guard,csid,option)
 
-    nation = player:getNation();
+    nation = player:getNation()
 
     -- To prevent the cs conflict, use the 1st and 2nd for guard and 3/4 for npc
     -- missionid, {Guard1CS,option}, {Guard2CS,option}, {NPC1 CS,option}, {NPC2 CS,option}, {{function,value},...},
-    --  1: player:addMission(nation,mission);
-    --  2: player:messageSpecial(YOU_ACCEPT_THE_MISSION);
-    --  3: player:setCharVar(variablename,value);
-    --  4: player:tradeComplete();
-    --  5: player:addRankPoints(number);
-    --  6: player:setRankPoints(0);
-    --  7: player:addPoint(player:getNation(),number); player:messageSpecial(YOUVE_EARNED_CONQUEST_POINTS);
-    --  8: player:addGil(GIL_RATE*number); player:messageSpecial(GIL_OBTAINED,GIL_RATE*number);
-    --  9: player:delKeyItem(number);
-    -- 10: player:addKeyItem(number); player:messageSpecial(KEYITEM_OBTAINED,number);
-    -- 11: player:setRank(number);
-    -- 12: player:completeMission(nation,mission);
-    -- 13: player:addTitle(number);
-    -- 14: player:setCharVar("MissionStatus",value);
+    --  1: player:addMission(nation,mission)
+    --  2: player:messageSpecial(YOU_ACCEPT_THE_MISSION)
+    --  3: player:setCharVar(variablename,value)
+    --  4: player:tradeComplete()
+    --  5: player:addRankPoints(number)
+    --  6: player:setRankPoints(0)
+    --  7: player:addPoint(player:getNation(),number) player:messageSpecial(YOUVE_EARNED_CONQUEST_POINTS)
+    --  8: player:addGil(GIL_RATE*number) player:messageSpecial(GIL_OBTAINED,GIL_RATE*number)
+    --  9: player:delKeyItem(number)
+    -- 10: player:addKeyItem(number) player:messageSpecial(KEYITEM_OBTAINED,number)
+    -- 11: player:setRank(number)
+    -- 12: player:completeMission(nation,mission)
+    -- 13: player:addTitle(number)
+    -- 14: player:setCharVar("MissionStatus",value)
 
     if (nation == tpz.nation.SANDORIA) then
         if ((csid == 1009 or csid == 2009) and option ~= 1073741824 and option ~= 31) then
             if (option > 100) then
-                badoption = {101,1,102,2,104,4,110,10,111,11};
+                badoption = {101,1,102,2,104,4,110,10,111,11}
                 for op = 1, #badoption, 2 do
                     if (option == badoption[op]) then
-                    timeline = {badoption[op+1],{1009,badoption[op]},{2009,badoption[op]},{0,0},{0,0},{{1},{2}}}; end
+                    timeline = {badoption[op+1],{1009,badoption[op]},{2009,badoption[op]},{0,0},{0,0},{{1},{2}}} end
                 end
             elseif (option == 14) then
-                timeline = {option,{1009,option},{2009,option},{0,0},{0,0},{{1},{2},{3,"MissionStatus",9}}};
+                timeline = {option,{1009,option},{2009,option},{0,0},{0,0},{{1},{2},{3,"MissionStatus",9}}}
             else
-                timeline = {option,{1009,option},{2009,option},{0,0},{0,0},{{1},{2}}};
+                timeline = {option,{1009,option},{2009,option},{0,0},{0,0},{{1},{2}}}
             end
         else
             timeline =
@@ -1195,11 +1195,11 @@ function finishMissionTimeline(player,guard,csid,option)
                 22,{0,0},      {0,0},     {76,0},{0,0},{{14,0},{9,481},{9,482},{9,483},{5,900},{12}}                    -- MISSION 9-1 (Finish (Door: Great Hall))
                 --[[0,{0,0},{0,0},{0,0},{0,0},{0},{0,0},{0,0},{0,0},{0,0},{0},
                 0,{0,0},{0,0},{0,0},{0,0},{0},{0,0},{0,0},{0,0},{0,0},{0}, ]]--
-            };
+            }
         end
     elseif (nation == tpz.nation.BASTOK) then
         if (csid == 1001 and option ~= 1073741824 and option ~= 31) then
-            timeline = {option,{1001,option},{0,0},{0,0},{0,0},{{1},{2}}};
+            timeline = {option,{1001,option},{0,0},{0,0},{0,0},{{1},{2}}}
         else
             timeline =
             {
@@ -1224,12 +1224,12 @@ function finishMissionTimeline(player,guard,csid,option)
                 19,{766,0},{0,0},{0,0},{0,0},{{14,0},{6},{11,8},{8,60000},{3,"OptionalCSforOMW",1},{12}},             -- MISSION 7-2 (Finish (Karst))
                 20,{768,0},{0,0},{0,0},{0,0},{{14,0},{5,1133},{12}},                                                 -- MISSION 8-1 (Finish (Iron Eater))
                 21,{176,0},{0,0},{0,0},{0,0},{{14,0},{6},{11,9},{9,293},{8,80000},{12}},                                     -- MISSION 8-2 (Finish (Bastok Mines))
-            };
+            }
         end
     elseif (nation == tpz.nation.WINDURST) then
-        guardlist = {114,111,78,93};
+        guardlist = {114,111,78,93}
         if (csid == guardlist[guard] and option ~= 1073741824 and option ~= 31) then
-            timeline = {option,{guardlist[guard],option},{guardlist[guard],option},{guardlist[guard],option},{guardlist[guard],option},{{1},{2}}};
+            timeline = {option,{guardlist[guard],option},{guardlist[guard],option},{guardlist[guard],option},{guardlist[guard],option},{{1},{2}}}
         else
             timeline =
             {
@@ -1261,33 +1261,33 @@ function finishMissionTimeline(player,guard,csid,option)
                 21,{0,0},      {0,0},     {609,0},{0,0},       {{14,0},{11,9},{8,80000},{6},{0,0},{12}},                    -- MISSION 8-2 (Finish (Apururu))
                 22,{0,0},     {0,0},     {61,0},{0,0},     {{14,0},{5,800},{13,293},{0},{0,0},{12}},                    -- MISSION 9-1 (Finish (Zone: Full Moon Fountain))
                 23,{0,0},      {0,0},     {407,0},{0,0},       {{13,294},{11,10},{8,100000},{6},{0,0},{12}}                    -- MISSION 9-2 (Finish (Vestal Chamber))
-            };
+            }
         end
     end
 
     for cs = 1, #timeline, 6 do
         if (csid == timeline[cs + guard][1] and option == timeline[cs + guard][2]) then
             for nb = 1, #timeline[cs + 5], 1 do
-                messList = timeline[cs + 5][nb];
+                messList = timeline[cs + 5][nb]
 
                 switch (messList[1]) : caseof {
-                    [1] = function (x) if (messList[2] ~= nil) then player:addMission(nation,messList[2]); else player:addMission(nation,timeline[cs]); end end,
-                    [2] = function (x) player:messageSpecial(zones[player:getZoneID()].text.YOU_ACCEPT_THE_MISSION); end,
-                    [3] = function (x) player:setCharVar(messList[2],messList[3]); end,
-                    [4] = function (x) player:tradeComplete(); end,
-                    [5] = function (x) if ((player:getRankPoints() + messList[2]) > 4000) then player:setRankPoints(4000); else player:addRankPoints(messList[2]); end end,
-                    [6] = function (x) player:setRankPoints(0); end,
-                    [7] = function (x) player:addCP(messList[2]); player:messageSpecial(zones[player:getZoneID()].text.YOUVE_EARNED_CONQUEST_POINTS); end,
-                    [8] = function (x) player:addGil(GIL_RATE*messList[2]); player:messageSpecial(zones[player:getZoneID()].text.GIL_OBTAINED,GIL_RATE*messList[2]); end,
-                    [9] = function (x) player:delKeyItem(messList[2]); end,
-                    [10] = function (x) player:addKeyItem(messList[2]); player:messageSpecial(zones[player:getZoneID()].text.KEYITEM_OBTAINED,messList[2]); end,
-                    [11] = function (x) player:setRank(messList[2]); end,
-                    [12] = function (x) player:completeMission(nation,timeline[cs]); end,
-                    [13] = function (x) player:addTitle(messList[2]); end,
-                    [14] = function (x) player:setCharVar("MissionStatus",messList[2]); end,
+                    [1] = function (x) if (messList[2] ~= nil) then player:addMission(nation,messList[2]) else player:addMission(nation,timeline[cs]) end end,
+                    [2] = function (x) player:messageSpecial(zones[player:getZoneID()].text.YOU_ACCEPT_THE_MISSION) end,
+                    [3] = function (x) player:setCharVar(messList[2],messList[3]) end,
+                    [4] = function (x) player:tradeComplete() end,
+                    [5] = function (x) if ((player:getRankPoints() + messList[2]) > 4000) then player:setRankPoints(4000) else player:addRankPoints(messList[2]) end end,
+                    [6] = function (x) player:setRankPoints(0) end,
+                    [7] = function (x) player:addCP(messList[2]) player:messageSpecial(zones[player:getZoneID()].text.YOUVE_EARNED_CONQUEST_POINTS) end,
+                    [8] = function (x) player:addGil(GIL_RATE*messList[2]) player:messageSpecial(zones[player:getZoneID()].text.GIL_OBTAINED,GIL_RATE*messList[2]) end,
+                    [9] = function (x) player:delKeyItem(messList[2]) end,
+                    [10] = function (x) player:addKeyItem(messList[2]) player:messageSpecial(zones[player:getZoneID()].text.KEYITEM_OBTAINED,messList[2]) end,
+                    [11] = function (x) player:setRank(messList[2]) end,
+                    [12] = function (x) player:completeMission(nation,timeline[cs]) end,
+                    [13] = function (x) player:addTitle(messList[2]) end,
+                    [14] = function (x) player:setCharVar("MissionStatus",messList[2]) end,
                 }
             end
         end
     end
 
-end;
+end

--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -254,7 +254,7 @@ local additionalEffects =
         msg = tpz.msg.basic.ADD_EFFECT_MP_DRAIN,
         mod = tpz.mod.INT,
         bonusAbilityParams = {bonusmab = 0, includemab = false},
-        code = function(mob, target, power) local mp = math.min(power, target:getMP()); target:delMP(mp); mob:addMP(mp) end,
+        code = function(mob, target, power) local mp = math.min(power, target:getMP()) target:delMP(mp) mob:addMP(mp) end,
     },
     [tpz.mob.ae.PARALYZE] =
     {
@@ -363,7 +363,7 @@ local additionalEffects =
         msg = tpz.msg.basic.ADD_EFFECT_TP_DRAIN,
         mod = tpz.mod.INT,
         bonusAbilityParams = {bonusmab = 0, includemab = false},
-        code = function(mob, target, power) local tp = math.min(power, target:getTP()); target:delTP(tp); mob:addTP(tp) end,
+        code = function(mob, target, power) local tp = math.min(power, target:getTP()) target:delTP(tp) mob:addTP(tp) end,
     },
 }
 

--- a/scripts/globals/moghouse.lua
+++ b/scripts/globals/moghouse.lua
@@ -3,7 +3,7 @@
 --
 
 require("scripts/globals/npc_util")
-require("scripts/globals/quests");
+require("scripts/globals/quests")
 require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/titles")
@@ -243,7 +243,7 @@ function addMogLockerExpiryTime(player, numBronze)
 
     local currentTs = getMogLockerExpiryTimestamp(player)
     if currentTs == nil then
-        -- print("Unable to add time: player hasn't unlocked mog locker.");
+        -- print("Unable to add time: player hasn't unlocked mog locker.")
         return false
     end
 

--- a/scripts/globals/monstertpmoves.lua
+++ b/scripts/globals/monstertpmoves.lua
@@ -1,8 +1,8 @@
 require("scripts/globals/magicburst")
-require("scripts/globals/status");
-require("scripts/globals/magic");
+require("scripts/globals/status")
+require("scripts/globals/magic")
 require("scripts/globals/utils")
-require("scripts/globals/msg");
+require("scripts/globals/msg")
 
 -- Foreword: A lot of this is good estimating since the FFXI playerbase has not found all of info for individual moves.
 --            What is known is that they roughly follow player Weaponskill calculations (pDIF, dMOD, ratio, etc) so this is what
@@ -10,42 +10,42 @@ require("scripts/globals/msg");
 
 -- mob types
 -- used in mob:isMobType()
-MOBTYPE_NORMAL            = 0x00;
-MOBTYPE_0X01             = 0x01;
-MOBTYPE_NOTORIOUS        = 0x02;
-MOBTYPE_FISHED            = 0x04;
-MOBTYPE_CALLED            = 0x08;
-MOBTYPE_BATTLEFIELD        = 0x10;
-MOBTYPE_EVENT            = 0x20;
+MOBTYPE_NORMAL            = 0x00
+MOBTYPE_0X01             = 0x01
+MOBTYPE_NOTORIOUS        = 0x02
+MOBTYPE_FISHED            = 0x04
+MOBTYPE_CALLED            = 0x08
+MOBTYPE_BATTLEFIELD        = 0x10
+MOBTYPE_EVENT            = 0x20
 
-MOBDRAIN_HP = 0;
-MOBDRAIN_MP = 1;
-MOBDRAIN_TP = 2;
+MOBDRAIN_HP = 0
+MOBDRAIN_MP = 1
+MOBDRAIN_TP = 2
 
 --shadowbehav (number of shadows to take off)
-MOBPARAM_IGNORE_SHADOWS = 0;
-MOBPARAM_1_SHADOW = 1;
-MOBPARAM_2_SHADOW = 2;
-MOBPARAM_3_SHADOW = 3;
-MOBPARAM_4_SHADOW = 4;
-MOBPARAM_WIPE_SHADOWS = 999;
+MOBPARAM_IGNORE_SHADOWS = 0
+MOBPARAM_1_SHADOW = 1
+MOBPARAM_2_SHADOW = 2
+MOBPARAM_3_SHADOW = 3
+MOBPARAM_4_SHADOW = 4
+MOBPARAM_WIPE_SHADOWS = 999
 
-TP_ACC_VARIES = 0;
-TP_ATK_VARIES = 1;
-TP_DMG_VARIES = 2;
-TP_CRIT_VARIES = 3;
-TP_NO_EFFECT = 0;
-TP_MACC_BONUS = 1;
-TP_MAB_BONUS = 2;
-TP_DMG_BONUS = 3;
-TP_RANGED = 4;
+TP_ACC_VARIES = 0
+TP_ATK_VARIES = 1
+TP_DMG_VARIES = 2
+TP_CRIT_VARIES = 3
+TP_NO_EFFECT = 0
+TP_MACC_BONUS = 1
+TP_MAB_BONUS = 2
+TP_DMG_BONUS = 3
+TP_RANGED = 4
 
-BOMB_TOSS_HPP = 1;
+BOMB_TOSS_HPP = 1
 
 function MobRangedMove(mob,target,skill,numberofhits,accmod,dmgmod, tpeffect)
     -- this will eventually contian ranged attack code
-    return MobPhysicalMove(mob,target,skill,numberofhits,accmod,dmgmod, TP_RANGED);
-end;
+    return MobPhysicalMove(mob,target,skill,numberofhits,accmod,dmgmod, TP_RANGED)
+end
 
 -- PHYSICAL MOVE FUNCTION
 -- Call this on every physical move!
@@ -62,159 +62,159 @@ end;
 -- if TP_DMG_VARIES -> three values are
 
 function MobPhysicalMove(mob,target,skill,numberofhits,accmod,dmgmod,tpeffect,mtp000,mtp150,mtp300,offcratiomod)
-    local returninfo = {};
+    local returninfo = {}
 
     --get dstr (bias to monsters, so no fSTR)
-    local dstr = mob:getStat(tpz.mod.STR) - target:getStat(tpz.mod.VIT);
+    local dstr = mob:getStat(tpz.mod.STR) - target:getStat(tpz.mod.VIT)
     if (dstr < -10) then
-        dstr = -10;
+        dstr = -10
     end
 
     if (dstr > 10) then
-        dstr = 10;
+        dstr = 10
     end
 
-    local lvluser = mob:getMainLvl();
-    local lvltarget = target:getMainLvl();
-    local acc = mob:getACC();
-    local eva = target:getEVA();
+    local lvluser = mob:getMainLvl()
+    local lvltarget = target:getMainLvl()
+    local acc = mob:getACC()
+    local eva = target:getEVA()
     if (target:hasStatusEffect(tpz.effect.YONIN) and mob:isFacing(target, 23)) then -- Yonin evasion boost if mob is facing target
-        eva = eva + target:getStatusEffect(tpz.effect.YONIN):getPower();
+        eva = eva + target:getStatusEffect(tpz.effect.YONIN):getPower()
     end
 
     --apply WSC
-    local base = mob:getWeaponDmg() + dstr; --todo: change to include WSC
+    local base = mob:getWeaponDmg() + dstr --todo: change to include WSC
     if (base < 1) then
-        base = 1;
+        base = 1
     end
 
     --work out and cap ratio
     if (offcratiomod == nil) then -- default to attack. Pretty much every physical mobskill will use this, Cannonball being the exception.
-        offcratiomod = mob:getStat(tpz.mod.ATT);
-        -- print ("Nothing passed, defaulting to attack");
-    end;
-    local ratio = offcratiomod/target:getStat(tpz.mod.DEF);
+        offcratiomod = mob:getStat(tpz.mod.ATT)
+        -- print ("Nothing passed, defaulting to attack")
+    end
+    local ratio = offcratiomod/target:getStat(tpz.mod.DEF)
 
-    local lvldiff = lvluser - lvltarget;
+    local lvldiff = lvluser - lvltarget
     if lvldiff < 0 then
-        lvldiff = 0;
-    end;
-
-    ratio = ratio + lvldiff * 0.05;
-    ratio = utils.clamp(ratio, 0, 4);
-
-    --work out hit rate for mobs (bias towards them)
-    local hitrate = (acc*accmod) - eva + (lvldiff*2) + 75;
-
-    -- printf("acc: %f, eva: %f, hitrate: %f", acc, eva, hitrate);
-    hitrate = utils.clamp(hitrate, 20, 95);
-
-    --work out the base damage for a single hit
-    local hitdamage = base + lvldiff;
-    if (hitdamage < 1) then
-        hitdamage = 1;
+        lvldiff = 0
     end
 
-    hitdamage = hitdamage * dmgmod;
+    ratio = ratio + lvldiff * 0.05
+    ratio = utils.clamp(ratio, 0, 4)
+
+    --work out hit rate for mobs (bias towards them)
+    local hitrate = (acc*accmod) - eva + (lvldiff*2) + 75
+
+    -- printf("acc: %f, eva: %f, hitrate: %f", acc, eva, hitrate)
+    hitrate = utils.clamp(hitrate, 20, 95)
+
+    --work out the base damage for a single hit
+    local hitdamage = base + lvldiff
+    if (hitdamage < 1) then
+        hitdamage = 1
+    end
+
+    hitdamage = hitdamage * dmgmod
 
     if (tpeffect == TP_DMG_VARIES) then
-        hitdamage = hitdamage * MobTPMod(skill:getTP() / 10);
+        hitdamage = hitdamage * MobTPMod(skill:getTP() / 10)
     end
 
     --work out min and max cRatio
-    local maxRatio = 1;
-    local minRatio = 0;
+    local maxRatio = 1
+    local minRatio = 0
 
     if (ratio < 0.5) then
-        maxRatio = ratio + 0.5;
+        maxRatio = ratio + 0.5
     elseif ((0.5 <= ratio) and (ratio <= 0.7)) then
-        maxRatio = 1;
+        maxRatio = 1
     elseif ((0.7 < ratio) and (ratio <= 1.2)) then
-        maxRatio = ratio + 0.3;
+        maxRatio = ratio + 0.3
     elseif ((1.2 < ratio) and (ratio <= 1.5)) then
-        maxRatio = (ratio * 0.25) + ratio;
+        maxRatio = (ratio * 0.25) + ratio
     elseif ((1.5 < ratio) and (ratio <= 2.625)) then
-        maxRatio = ratio + 0.375;
+        maxRatio = ratio + 0.375
     elseif ((2.625 < ratio) and (ratio <= 3.25)) then
-        maxRatio = 3;
+        maxRatio = 3
     else
-        maxRatio = ratio;
+        maxRatio = ratio
     end
 
 
     if (ratio < 0.38) then
-        minRatio =  0;
+        minRatio =  0
     elseif ((0.38 <= ratio) and (ratio <= 1.25)) then
-        minRatio = ratio * (1176 / 1024) - (448 / 1024);
+        minRatio = ratio * (1176 / 1024) - (448 / 1024)
     elseif ((1.25 < ratio) and (ratio <= 1.51)) then
-        minRatio = 1;
+        minRatio = 1
     elseif ((1.51 < ratio) and (ratio <= 2.44)) then
-        minRatio = ratio * (1176 / 1024) - (775 / 1024);
+        minRatio = ratio * (1176 / 1024) - (775 / 1024)
     else
-        minRatio = ratio - 0.375;
+        minRatio = ratio - 0.375
     end
 
     --apply ftp (assumes 1~3 scalar linear mod)
     if (tpeffect==TP_DMG_BONUS) then
-        hitdamage = hitdamage * fTP(skill:getTP(), mtp000, mtp150, mtp300);
+        hitdamage = hitdamage * fTP(skill:getTP(), mtp000, mtp150, mtp300)
     end
 
     --Applying pDIF
-    local pdif = 0;
+    local pdif = 0
 
     -- start the hits
-    local hitchance = math.random();
-    local finaldmg = 0;
-    local hitsdone = 1;
-    local hitslanded = 0;
+    local hitchance = math.random()
+    local finaldmg = 0
+    local hitsdone = 1
+    local hitslanded = 0
 
-    local chance = math.random();
+    local chance = math.random()
 
     -- first hit has a higher chance to land
-    local firstHitChance = hitrate * 1.5;
+    local firstHitChance = hitrate * 1.5
 
     if (tpeffect==TP_RANGED) then
-        firstHitChance = hitrate * 1.2;
+        firstHitChance = hitrate * 1.2
     end
 
-    firstHitChance = utils.clamp(firstHitChance, 35, 95);
+    firstHitChance = utils.clamp(firstHitChance, 35, 95)
 
     if ((chance*100) <= firstHitChance) then
         pdif = math.random((minRatio*1000),(maxRatio*1000)) --generate random PDIF
-        pdif = pdif/1000; --multiplier set.
-        finaldmg = finaldmg + hitdamage * pdif;
-        hitslanded = hitslanded + 1;
+        pdif = pdif/1000 --multiplier set.
+        finaldmg = finaldmg + hitdamage * pdif
+        hitslanded = hitslanded + 1
     end
     while (hitsdone < numberofhits) do
-        chance = math.random();
+        chance = math.random()
         if ((chance*100)<=hitrate) then --it hit
             pdif = math.random((minRatio*1000),(maxRatio*1000)) --generate random PDIF
-            pdif = pdif/1000; --multiplier set.
-            finaldmg = finaldmg + hitdamage * pdif;
-            hitslanded = hitslanded + 1;
+            pdif = pdif/1000 --multiplier set.
+            finaldmg = finaldmg + hitdamage * pdif
+            hitslanded = hitslanded + 1
         end
-        hitsdone = hitsdone + 1;
+        hitsdone = hitsdone + 1
     end
 
-    -- printf("final: %f, hits: %f, acc: %f", finaldmg, hitslanded, hitrate);
-    -- printf("ratio: %f, min: %f, max: %f, pdif, %f hitdmg: %f", ratio, minRatio, maxRatio, pdif, hitdamage);
+    -- printf("final: %f, hits: %f, acc: %f", finaldmg, hitslanded, hitrate)
+    -- printf("ratio: %f, min: %f, max: %f, pdif, %f hitdmg: %f", ratio, minRatio, maxRatio, pdif, hitdamage)
 
     -- if an attack landed it must do at least 1 damage
     if (hitslanded >= 1 and finaldmg < 1) then
-        finaldmg = 1;
+        finaldmg = 1
     end
 
     -- all hits missed
     if (hitslanded == 0 or finaldmg == 0) then
-        finaldmg = 0;
-        hitslanded = 0;
-        skill:setMsg(tpz.msg.basic.SKILL_MISS);
+        finaldmg = 0
+        hitslanded = 0
+        skill:setMsg(tpz.msg.basic.SKILL_MISS)
     end
 
-    returninfo.dmg = finaldmg;
-    returninfo.hitslanded = hitslanded;
+    returninfo.dmg = finaldmg
+    returninfo.hitslanded = hitslanded
 
-    return returninfo;
+    return returninfo
 
 end
 
@@ -240,50 +240,50 @@ end
 -- TP_DMG_BONUS and TP=200, tpvalue = 2, assume V=150  --> damage is now 150*(TP*2)/100 = 600
 
 function MobMagicalMove(mob,target,skill,damage,element,dmgmod,tpeffect,tpvalue)
-    returninfo = {};
+    returninfo = {}
     --get all the stuff we need
-    local resist = 1;
+    local resist = 1
 
-    local mdefBarBonus = 0;
+    local mdefBarBonus = 0
     if (element > 0 and element <= 6 and target:hasStatusEffect(tpz.magic.barSpell[element])) then -- bar- spell magic defense bonus
-        mdefBarBonus = target:getStatusEffect(tpz.magic.barSpell[element]):getSubPower();
+        mdefBarBonus = target:getStatusEffect(tpz.magic.barSpell[element]):getSubPower()
     end
     -- plus 100 forces it to be a number
-    mab = (100 + mob:getMod(tpz.mod.MATT)) / (100 + target:getMod(tpz.mod.MDEF) + mdefBarBonus);
+    mab = (100 + mob:getMod(tpz.mod.MATT)) / (100 + target:getMod(tpz.mod.MDEF) + mdefBarBonus)
 
     if (mab > 1.3) then
-        mab = 1.3;
+        mab = 1.3
     end
 
     if (mab < 0.7) then
-        mab = 0.7;
+        mab = 0.7
     end
 
     if (tpeffect==TP_DMG_BONUS) then
-        damage = damage * (((skill:getTP() / 10)*tpvalue)/100);
+        damage = damage * (((skill:getTP() / 10)*tpvalue)/100)
     end
 
-    -- printf("power: %f, bonus: %f", damage, mab);
+    -- printf("power: %f, bonus: %f", damage, mab)
     -- resistence is added last
-    finaldmg = damage * mab * dmgmod;
+    finaldmg = damage * mab * dmgmod
 
     -- get resistence
-    local avatarAccBonus = 0;
+    local avatarAccBonus = 0
     if (mob:isPet() and mob:getMaster() ~= nil) then
-        local master = mob:getMaster();
+        local master = mob:getMaster()
         if (master:getPetID() >= 0 and master:getPetID() <= 20) then -- check to ensure pet is avatar
-            avatarAccBonus = utils.clamp(master:getSkillLevel(tpz.skill.SUMMONING_MAGIC) - master:getMaxSkillLevel(mob:getMainLvl(), tpz.job.SMN, tpz.skill.SUMMONING_MAGIC), 0, 200);
+            avatarAccBonus = utils.clamp(master:getSkillLevel(tpz.skill.SUMMONING_MAGIC) - master:getMaxSkillLevel(mob:getMainLvl(), tpz.job.SMN, tpz.skill.SUMMONING_MAGIC), 0, 200)
         end
     end
-    resist = applyPlayerResistance(mob,nil,target,mob:getStat(tpz.mod.INT)-target:getStat(tpz.mod.INT),avatarAccBonus,element);
+    resist = applyPlayerResistance(mob,nil,target,mob:getStat(tpz.mod.INT)-target:getStat(tpz.mod.INT),avatarAccBonus,element)
 
-    local magicDefense = getElementalDamageReduction(target, element);
+    local magicDefense = getElementalDamageReduction(target, element)
 
-    finaldmg = finaldmg * resist * magicDefense;
+    finaldmg = finaldmg * resist * magicDefense
 
-    returninfo.dmg = finaldmg;
+    returninfo.dmg = finaldmg
 
-    return returninfo;
+    return returninfo
 
 end
 
@@ -292,125 +292,125 @@ end
 -- statmod = the stat to account for resist (INT,MND,etc) e.g. tpz.mod.INT
 -- This determines how much the monsters ability resists on the player.
 function applyPlayerResistance(mob,effect,target,diff,bonus,element)
-    local percentBonus = 0;
-    local magicaccbonus = 0;
+    local percentBonus = 0
+    local magicaccbonus = 0
 
     if (diff > 10) then
-        magicaccbonus = magicaccbonus + 10 + (diff - 10)/2;
+        magicaccbonus = magicaccbonus + 10 + (diff - 10)/2
     else
-        magicaccbonus = magicaccbonus + diff;
+        magicaccbonus = magicaccbonus + diff
     end
 
     if (bonus ~= nil) then
-        magicaccbonus = magicaccbonus + bonus;
+        magicaccbonus = magicaccbonus + bonus
     end
 
     if (effect ~= nil) then
-        percentBonus = percentBonus - getEffectResistance(target, effect);
+        percentBonus = percentBonus - getEffectResistance(target, effect)
     end
 
-    local p = getMagicHitRate(mob, target, 0, element, percentBonus, magicaccbonus);
+    local p = getMagicHitRate(mob, target, 0, element, percentBonus, magicaccbonus)
 
-    return getMagicResist(p);
-end;
+    return getMagicResist(p)
+end
 
 function mobAddBonuses(caster, spell, target, dmg, ele)
 
-    local magicDefense = getElementalDamageReduction(target, ele);
-    dmg = math.floor(dmg * magicDefense);
+    local magicDefense = getElementalDamageReduction(target, ele)
+    dmg = math.floor(dmg * magicDefense)
 
-    dayWeatherBonus = 1.00;
+    dayWeatherBonus = 1.00
 
     if caster:getWeather() == tpz.magic.singleWeatherStrong[ele] then
         if math.random() < 0.33 then
-            dayWeatherBonus = dayWeatherBonus + 0.10;
+            dayWeatherBonus = dayWeatherBonus + 0.10
         end
     elseif caster:getWeather() == tpz.magic.singleWeatherWeak[ele] then
         if math.random() < 0.33 then
-            dayWeatherBonus = dayWeatherBonus - 0.10;
+            dayWeatherBonus = dayWeatherBonus - 0.10
         end
     elseif caster:getWeather() == tpz.magic.doubleWeatherStrong[ele] then
         if math.random() < 0.33 then
-            dayWeatherBonus = dayWeatherBonus + 0.25;
+            dayWeatherBonus = dayWeatherBonus + 0.25
         end
     elseif caster:getWeather() == tpz.magic.doubleWeatherWeak[ele] then
         if math.random() < 0.33 then
-            dayWeatherBonus = dayWeatherBonus - 0.25;
+            dayWeatherBonus = dayWeatherBonus - 0.25
         end
     end
 
     if VanadielDayElement() == tpz.magic.dayStrong[ele] then
         if math.random() < 0.33 then
-            dayWeatherBonus = dayWeatherBonus + 0.10;
+            dayWeatherBonus = dayWeatherBonus + 0.10
         end
     elseif VanadielDayElement() == tpz.magic.dayWeak[ele] then
         if math.random() < 0.33 then
-            dayWeatherBonus = dayWeatherBonus - 0.10;
+            dayWeatherBonus = dayWeatherBonus - 0.10
         end
     end
 
     if dayWeatherBonus > 1.35 then
-        dayWeatherBonus = 1.35;
+        dayWeatherBonus = 1.35
     end
 
-    dmg = math.floor(dmg * dayWeatherBonus);
+    dmg = math.floor(dmg * dayWeatherBonus)
 
-    burst = calculateMobMagicBurst(caster, ele, target);
+    burst = calculateMobMagicBurst(caster, ele, target)
 
     -- not sure what to do for this yet
     -- if (burst > 1.0) then
-        -- spell:setMsg(spell:getMagicBurstMessage()); -- "Magic Burst!"
+        -- spell:setMsg(spell:getMagicBurstMessage()) -- "Magic Burst!"
     -- end
 
-    dmg = math.floor(dmg * burst);
+    dmg = math.floor(dmg * burst)
 
-    local mdefBarBonus = 0;
+    local mdefBarBonus = 0
     if (ele > 0 and ele <= 6 and target:hasStatusEffect(tpz.magic.barSpell[ele])) then -- bar- spell magic defense bonus
-        mdefBarBonus = target:getStatusEffect(tpz.magic.barSpell[ele]):getSubPower();
+        mdefBarBonus = target:getStatusEffect(tpz.magic.barSpell[ele]):getSubPower()
     end
-    mab = (100 + caster:getMod(tpz.mod.MATT)) / (100 + target:getMod(tpz.mod.MDEF) + mdefBarBonus) ;
+    mab = (100 + caster:getMod(tpz.mod.MATT)) / (100 + target:getMod(tpz.mod.MDEF) + mdefBarBonus) 
 
-    dmg = math.floor(dmg * mab);
+    dmg = math.floor(dmg * mab)
 
-    magicDmgMod = (256 + target:getMod(tpz.mod.DMGMAGIC)) / 256;
+    magicDmgMod = (256 + target:getMod(tpz.mod.DMGMAGIC)) / 256
 
-    dmg = math.floor(dmg * magicDmgMod);
+    dmg = math.floor(dmg * magicDmgMod)
 
-    -- print(affinityBonus);
-    -- print(speciesReduction);
-    -- print(dayWeatherBonus);
-    -- print(burst);
-    -- print(mab);
-    -- print(magicDmgMod);
+    -- print(affinityBonus)
+    -- print(speciesReduction)
+    -- print(dayWeatherBonus)
+    -- print(burst)
+    -- print(mab)
+    -- print(magicDmgMod)
 
-    return dmg;
+    return dmg
 end
 
 function calculateMobMagicBurst(caster, ele, target)
 
-    local burst = 1.0;
+    local burst = 1.0
 
-    local skillchainTier, skillchainCount = MobFormMagicBurst(ele, target);
+    local skillchainTier, skillchainCount = MobFormMagicBurst(ele, target)
 
     if (skillchainTier > 0) then
         if (skillchainCount == 1) then
-            burst = 1.3;
+            burst = 1.3
         elseif (skillchainCount == 2) then
-            burst = 1.35;
+            burst = 1.35
         elseif (skillchainCount == 3) then
-             burst = 1.40;
+             burst = 1.40
         elseif (skillchainCount == 4) then
-            burst = 1.45;
+            burst = 1.45
         elseif (skillchainCount == 5) then
-            burst = 1.50;
+            burst = 1.50
         else
             -- Something strange is going on if this occurs.
-            burst = 1.0;
+            burst = 1.0
         end
     end
 
-    return burst;
-end;
+    return burst
+end
 
 -- Calculates breath damage
 -- mob is a mob reference to get hp and lvl
@@ -419,80 +419,80 @@ end;
 -- Equation: (HP * percent) + (LVL / base)
 -- cap is optional, defines a maximum damage
 function MobBreathMove(mob, target, percent, base, element, cap)
-    local damage = (mob:getHP() * percent) + (mob:getMainLvl() / base);
+    local damage = (mob:getHP() * percent) + (mob:getMainLvl() / base)
 
     if (cap == nil) then
         -- cap max damage
-        cap = math.floor(mob:getHP()/5);
+        cap = math.floor(mob:getHP()/5)
     end
 
     -- Deal bonus damage vs mob ecosystem
-    local systemBonus = utils.getSystemStrengthBonus(mob, target);
-    damage = damage + (damage * (systemBonus * 0.25));
+    local systemBonus = utils.getSystemStrengthBonus(mob, target)
+    damage = damage + (damage * (systemBonus * 0.25))
 
     -- elemental resistence
     if (element ~= nil and element > 0) then
         -- no skill available, pass nil
-        local resist = applyPlayerResistance(mob,nil,target,mob:getStat(tpz.mod.INT)-target:getStat(tpz.mod.INT),0,element);
+        local resist = applyPlayerResistance(mob,nil,target,mob:getStat(tpz.mod.INT)-target:getStat(tpz.mod.INT),0,element)
 
         -- get elemental damage reduction
         local defense = getElementalDamageReduction(target, element)
 
-        damage = damage * resist * defense;
+        damage = damage * resist * defense
     end
 
-    damage = utils.clamp(damage, 1, cap);
+    damage = utils.clamp(damage, 1, cap)
 
-    return damage;
-end;
+    return damage
+end
 
 function MobFinalAdjustments(dmg,mob,skill,target,attackType,damageType,shadowbehav)
 
     -- physical attack missed, skip rest
     if (skill:hasMissMsg()) then
-        return 0;
+        return 0
     end
 
     --handle pd
     if ((target:hasStatusEffect(tpz.effect.PERFECT_DODGE) or target:hasStatusEffect(tpz.effect.TOO_HIGH) )
             and attackType==tpz.attackType.PHYSICAL) then
-        skill:setMsg(tpz.msg.basic.SKILL_MISS);
-        return 0;
+        skill:setMsg(tpz.msg.basic.SKILL_MISS)
+        return 0
     end
 
     -- set message to damage
     -- this is for AoE because its only set once
-    skill:setMsg(tpz.msg.basic.DAMAGE);
+    skill:setMsg(tpz.msg.basic.DAMAGE)
 
     --Handle shadows depending on shadow behaviour / attackType
     if (shadowbehav ~= MOBPARAM_WIPE_SHADOWS and shadowbehav ~= MOBPARAM_IGNORE_SHADOWS) then --remove 'shadowbehav' shadows.
 
         if (skill:isAoE() or skill:isConal()) then
-            shadowbehav = MobTakeAoEShadow(mob, target, shadowbehav);
+            shadowbehav = MobTakeAoEShadow(mob, target, shadowbehav)
         end
 
-        dmg = utils.takeShadows(target, dmg, shadowbehav);
+        dmg = utils.takeShadows(target, dmg, shadowbehav)
 
         -- dealt zero damage, so shadows took hit
         if (dmg == 0) then
-            skill:setMsg(tpz.msg.basic.SHADOW_ABSORB);
-            return shadowbehav;
+            skill:setMsg(tpz.msg.basic.SHADOW_ABSORB)
+            return shadowbehav
         end
 
     elseif (shadowbehav == MOBPARAM_WIPE_SHADOWS) then --take em all!
-        target:delStatusEffect(tpz.effect.COPY_IMAGE);
-        target:delStatusEffect(tpz.effect.BLINK);
-        target:delStatusEffect(tpz.effect.THIRD_EYE);
+        target:delStatusEffect(tpz.effect.COPY_IMAGE)
+        target:delStatusEffect(tpz.effect.BLINK)
+        target:delStatusEffect(tpz.effect.THIRD_EYE)
     end
 
     if (attackType == tpz.attackType.PHYSICAL and skill:isSingle() == false) then
-        target:delStatusEffect(tpz.effect.THIRD_EYE);
+        target:delStatusEffect(tpz.effect.THIRD_EYE)
     end
 
     --handle Third Eye using shadowbehav as a guide
     if (attackType == tpz.attackType.PHYSICAL and utils.thirdeye(target)) then
-        skill:setMsg(tpz.msg.basic.ANTICIPATE);
-        return 0;
+        skill:setMsg(tpz.msg.basic.ANTICIPATE)
+        return 0
     end
 
     -- Handle Automaton Analyzer which decreases damage from successive special attacks
@@ -512,57 +512,57 @@ function MobFinalAdjustments(dmg,mob,skill,target,attackType,damageType,shadowbe
 
     if (attackType == tpz.attackType.PHYSICAL) then
 
-        dmg = target:physicalDmgTaken(dmg, damageType);
+        dmg = target:physicalDmgTaken(dmg, damageType)
 
     elseif (attackType == tpz.attackType.MAGICAL) then
 
-        dmg = target:magicDmgTaken(dmg);
+        dmg = target:magicDmgTaken(dmg)
 
     elseif (attackType == tpz.attackType.BREATH) then
 
-        dmg = target:breathDmgTaken(dmg);
+        dmg = target:breathDmgTaken(dmg)
 
     elseif (attackType == tpz.attackType.RANGED) then
 
-        dmg = target:rangedDmgTaken(dmg);
+        dmg = target:rangedDmgTaken(dmg)
 
     end
 
     --handling phalanx
-    dmg = dmg - target:getMod(tpz.mod.PHALANX);
+    dmg = dmg - target:getMod(tpz.mod.PHALANX)
 
     if (dmg < 0) then
-        return 0;
+        return 0
     end
 
-    dmg = utils.stoneskin(target, dmg);
+    dmg = utils.stoneskin(target, dmg)
 
     if (dmg > 0) then
-        target:updateEnmityFromDamage(mob,dmg);
-        target:handleAfflatusMiseryDamage(dmg);
+        target:updateEnmityFromDamage(mob,dmg)
+        target:handleAfflatusMiseryDamage(dmg)
     end
 
-    return dmg;
-end;
+    return dmg
+end
 
 -- returns true if mob attack hit
 -- used to stop tp move status effects
 function MobPhysicalHit(skill)
     -- if message is not the default. Then there was a miss, shadow taken etc
-    return skill:hasMissMsg() == false;
-end;
+    return skill:hasMissMsg() == false
+end
 
 -- function MobHit()
--- end;
+-- end
 
 -- function MobAoEHit()
--- end;
+-- end
 
 -- function MobMagicHit()
--- end;
+-- end
 
 -- function MobMagicAoEHit()
--- end;
+-- end
 
 function MobDrainMove(mob, target, drainType, drain, attackType, damageType)
 
@@ -570,162 +570,162 @@ function MobDrainMove(mob, target, drainType, drain, attackType, damageType)
         if (drainType == MOBDRAIN_MP) then
             -- can't go over limited mp
             if (target:getMP() < drain) then
-                drain = target:getMP();
+                drain = target:getMP()
             end
 
-            target:delMP(drain);
-            mob:addMP(drain);
+            target:delMP(drain)
+            mob:addMP(drain)
 
-            return tpz.msg.basic.SKILL_DRAIN_MP;
+            return tpz.msg.basic.SKILL_DRAIN_MP
         elseif (drainType == MOBDRAIN_TP) then
             -- can't go over limited tp
             if (target:getTP() < drain) then
-                drain = target:getTP();
+                drain = target:getTP()
             end
 
-            target:delTP(drain);
-            mob:addTP(drain);
+            target:delTP(drain)
+            mob:addTP(drain)
 
-            return tpz.msg.basic.SKILL_DRAIN_TP;
+            return tpz.msg.basic.SKILL_DRAIN_TP
         elseif (drainType == MOBDRAIN_HP) then
             -- can't go over limited hp
             if (target:getHP() < drain) then
-                drain = target:getHP();
+                drain = target:getHP()
             end
 
-            target:takeDamage(drain, mob, attackType, damageType);
-            mob:addHP(drain);
+            target:takeDamage(drain, mob, attackType, damageType)
+            mob:addHP(drain)
 
-            return tpz.msg.basic.SKILL_DRAIN_HP;
+            return tpz.msg.basic.SKILL_DRAIN_HP
         end
     else
         -- it's undead so just deal damage
         -- can't go over limited hp
         if (target:getHP() < drain) then
-            drain = target:getHP();
+            drain = target:getHP()
         end
 
-        target:takeDamage(drain, mob, attackType, damageType);
-        return tpz.msg.basic.DAMAGE;
+        target:takeDamage(drain, mob, attackType, damageType)
+        return tpz.msg.basic.DAMAGE
     end
 
-    return tpz.msg.basic.SKILL_NO_EFFECT;
-end;
+    return tpz.msg.basic.SKILL_NO_EFFECT
+end
 
 function MobPhysicalDrainMove(mob, target, skill, drainType, drain)
     if (MobPhysicalHit(skill)) then
-        return MobDrainMove(mob, target, drainType, drain);
+        return MobDrainMove(mob, target, drainType, drain)
     end
 
-    return tpz.msg.basic.SKILL_MISS;
-end;
+    return tpz.msg.basic.SKILL_MISS
+end
 
 function MobDrainAttribute(mob, target, typeEffect, power, tick, duration)
-    local positive = nil;
+    local positive = nil
     if (typeEffect == tpz.effect.STR_DOWN) then
-        positive = tpz.effect.STR_BOOST;
+        positive = tpz.effect.STR_BOOST
     elseif (typeEffect == tpz.effect.DEX_DOWN) then
-        positive = tpz.effect.DEX_BOOST;
+        positive = tpz.effect.DEX_BOOST
     elseif (typeEffect == tpz.effect.AGI_DOWN) then
-        positive = tpz.effect.AGI_BOOST;
+        positive = tpz.effect.AGI_BOOST
     elseif (typeEffect == tpz.effect.VIT_DOWN) then
-        positive = tpz.effect.VIT_BOOST;
+        positive = tpz.effect.VIT_BOOST
     elseif (typeEffect == tpz.effect.MND_DOWN) then
-        positive = tpz.effect.MND_BOOST;
+        positive = tpz.effect.MND_BOOST
     elseif (typeEffect == tpz.effect.INT_DOWN) then
-        positive = tpz.effect.INT_BOOST;
+        positive = tpz.effect.INT_BOOST
     elseif (typeEffect == tpz.effect.CHR_DOWN) then
-        positive = tpz.effect.CHR_BOOST;
+        positive = tpz.effect.CHR_BOOST
     end
 
     if (positive ~= nil) then
-        local results = MobStatusEffectMove(mob, target, typeEffect, power, tick, duration);
+        local results = MobStatusEffectMove(mob, target, typeEffect, power, tick, duration)
 
         if (results == tpz.msg.basic.SKILL_ENFEEB_IS) then
-            mob:addStatusEffect(positive, power, tick, duration);
+            mob:addStatusEffect(positive, power, tick, duration)
 
-            return tpz.msg.basic.ATTR_DRAINED;
+            return tpz.msg.basic.ATTR_DRAINED
         end
 
-        return tpz.msg.basic.SKILL_MISS;
+        return tpz.msg.basic.SKILL_MISS
     end
 
-    return tpz.msg.basic.SKILL_NO_EFFECT;
-end;
+    return tpz.msg.basic.SKILL_NO_EFFECT
+end
 
 function MobDrainStatusEffectMove(mob, target)
     -- try to drain buff
-    local effect = mob:stealStatusEffect(target);
+    local effect = mob:stealStatusEffect(target)
 
     if (effect ~= 0) then
-        return tpz.msg.basic.EFFECT_DRAINED;
+        return tpz.msg.basic.EFFECT_DRAINED
     end
 
-    return tpz.msg.basic.SKILL_NO_EFFECT;
-end;
+    return tpz.msg.basic.SKILL_NO_EFFECT
+end
 
 -- Adds a status effect to a target
 function MobStatusEffectMove(mob, target, typeEffect, power, tick, duration)
 
     if (target:canGainStatusEffect(typeEffect, power)) then
-        local statmod = tpz.mod.INT;
-        local element = mob:getStatusEffectElement(typeEffect);
+        local statmod = tpz.mod.INT
+        local element = mob:getStatusEffectElement(typeEffect)
 
-        local resist = applyPlayerResistance(mob,typeEffect,target,mob:getStat(statmod)-target:getStat(statmod),0,element);
+        local resist = applyPlayerResistance(mob,typeEffect,target,mob:getStat(statmod)-target:getStat(statmod),0,element)
 
         if (resist >= 0.25) then
 
-            local totalDuration = utils.clamp(duration * resist, 1);
-            target:addStatusEffect(typeEffect, power, tick, totalDuration);
+            local totalDuration = utils.clamp(duration * resist, 1)
+            target:addStatusEffect(typeEffect, power, tick, totalDuration)
 
-            return tpz.msg.basic.SKILL_ENFEEB_IS;
+            return tpz.msg.basic.SKILL_ENFEEB_IS
         end
 
-        return tpz.msg.basic.SKILL_MISS; -- resist !
+        return tpz.msg.basic.SKILL_MISS -- resist !
     end
-    return tpz.msg.basic.SKILL_NO_EFFECT; -- no effect
-end;
+    return tpz.msg.basic.SKILL_NO_EFFECT -- no effect
+end
 
 -- similar to status effect move except, this will not land if the attack missed
 function MobPhysicalStatusEffectMove(mob, target, skill, typeEffect, power, tick, duration)
 
     if (MobPhysicalHit(skill)) then
-        return MobStatusEffectMove(mob, target, typeEffect, power, tick, duration);
+        return MobStatusEffectMove(mob, target, typeEffect, power, tick, duration)
     end
 
-    return tpz.msg.basic.SKILL_MISS;
-end;
+    return tpz.msg.basic.SKILL_MISS
+end
 
 -- similar to statuseffect move except it will only take effect if facing
 function MobGazeMove(mob, target, typeEffect, power, tick, duration)
     if (target:isFacing(mob)) then
-        return MobStatusEffectMove(mob, target, typeEffect, power, tick, duration);
+        return MobStatusEffectMove(mob, target, typeEffect, power, tick, duration)
     end
-    return tpz.msg.basic.SKILL_NO_EFFECT;
-end;
+    return tpz.msg.basic.SKILL_NO_EFFECT
+end
 
 function MobBuffMove(mob, typeEffect, power, tick, duration)
 
     if (mob:addStatusEffect(typeEffect,power,tick,duration)) then
-        return tpz.msg.basic.SKILL_GAIN_EFFECT;
+        return tpz.msg.basic.SKILL_GAIN_EFFECT
     end
-    return tpz.msg.basic.SKILL_NO_EFFECT;
-end;
+    return tpz.msg.basic.SKILL_NO_EFFECT
+end
 
 function MobHealMove(target, heal)
 
-    local mobHP = target:getHP();
-    local mobMaxHP = target:getMaxHP();
+    local mobHP = target:getHP()
+    local mobMaxHP = target:getMaxHP()
 
     if (mobHP+heal > mobMaxHP) then
-        heal = mobMaxHP - mobHP;
+        heal = mobMaxHP - mobHP
     end
 
-    target:wakeUp();
+    target:wakeUp()
 
-    target:addHP(heal);
+    target:addHP(heal)
 
-    return heal;
+    return heal
 end
 
 function MobTakeAoEShadow(mob, target, max)
@@ -733,34 +733,34 @@ function MobTakeAoEShadow(mob, target, max)
     -- this is completely crap and should be using actual nin skill
     -- TODO fix this
     if (target:getMainJob() == tpz.job.NIN and math.random() < 0.6) then
-        max = max - 1;
+        max = max - 1
         if (max < 1) then
-            max = 1;
+            max = 1
         end
     end
 
-    return math.random(1, max);
-end;
+    return math.random(1, max)
+end
 
 function MobTPMod(tp)
     -- increase damage based on tp
     if (tp >= 3000) then
-        return 2;
+        return 2
     elseif (tp >= 2000) then
-        return 1.5;
+        return 1.5
     end
-    return 1;
-end;
+    return 1
+end
 
 function fTP(tp,ftp1,ftp2,ftp3)
     if (tp < 1000) then
-        tp = 1000;
+        tp = 1000
     end
     if (tp >= 1000 and tp < 1500) then
-        return ftp1 + ( ((ftp2-ftp1)/500) * (tp-1000));
+        return ftp1 + ( ((ftp2-ftp1)/500) * (tp-1000))
     elseif (tp >= 1500 and tp <= 3000) then
         -- generate a straight line between ftp2 and ftp3 and find point @ tp
-        return ftp2 + ( ((ftp3-ftp2)/1500) * (tp-1500));
+        return ftp2 + ( ((ftp3-ftp2)/1500) * (tp-1500))
     end
-    return 1; -- no ftp mod
-end;
+    return 1 -- no ftp mod
+end

--- a/scripts/globals/porter_moogle_util.lua
+++ b/scripts/globals/porter_moogle_util.lua
@@ -2,10 +2,10 @@
 -- Porter Moogle Utilities
 -- desc: Common functionality for Porter Moogles.
 -----------------------------------
-require("scripts/globals/common");
+require("scripts/globals/common")
 
 -- Item IDs for all of the slips.
-local slipIds = { 29312, 29313, 29314, 29315, 29316, 29317, 29318, 29319, 29320, 29321, 29322, 29323, 29324, 29325, 29326, 29327, 29328, 29329, 29330, 29331, 29332, 29333, 29334, 29335, 29336, 29337, 29338, 29339 };
+local slipIds = { 29312, 29313, 29314, 29315, 29316, 29317, 29318, 29319, 29320, 29321, 29322, 29323, 29324, 29325, 29326, 29327, 29328, 29329, 29330, 29331, 29332, 29333, 29334, 29335, 29336, 29337, 29338, 29339 }
 
 -- Item IDs for the items stored on each slip. Zero-based index in the table represents the bit indicating if the slip has the item stored.
 local slipItems = {
@@ -37,13 +37,13 @@ local slipItems = {
     [slipIds[26]] = { 23063, 23130, 23197, 23264, 23331, 23064, 23131, 23198, 23265, 23332, 23065, 23132, 23199, 23266, 23333, 23066, 23133, 23200, 23267, 23334, 23067, 23134, 23201, 23268, 23335, 23068, 23135, 23202, 23269, 23336, 23069, 23136, 23203, 23270, 23337, 23070, 23137, 23204, 23271, 23338, 23071, 23138, 23205, 23272, 23339, 23072, 23139, 23206, 23273, 23340, 23073, 23140, 23207, 23274, 23341, 23074, 23141, 23208, 23275, 23342, 23075, 23142, 23209, 23276, 23343, 23076, 23143, 23210, 23277, 23344, 23077, 23144, 23211, 23278, 23345, 23078, 23145, 23212, 23279, 23346, 23079, 23146, 23213, 23280, 23347, 23080, 23147, 23214, 23281, 23348, 23081, 23148, 23215, 23282, 23349, 23082, 23149, 23216, 23283, 23350, 23083, 23150, 23217, 23284, 23351, 23084, 23151, 23218, 23285, 23352 },
     [slipIds[27]] = { 23398, 23465, 23532, 23599, 23666, 23399, 23466, 23533, 23600, 23667, 23400, 23467, 23534, 23601, 23668, 23401, 23468, 23535, 23602, 23669, 23402, 23469, 23536, 23603, 23670, 23403, 23470, 23537, 23604, 23671, 23404, 23471, 23538, 23605, 23672, 23405, 23472, 23539, 23606, 23673, 23406, 23473, 23540, 23607, 23674, 23407, 23474, 23541, 23608, 23675, 23408, 23475, 23542, 23609, 23676, 23409, 23476, 23543, 23610, 23677, 23410, 23477, 23544, 23611, 23678, 23411, 23478, 23545, 23612, 23679, 23412, 23479, 23546, 23613, 23680, 23413, 23480, 23547, 23614, 23681, 23414, 23481, 23548, 23615, 23682, 23415, 23482, 23549, 23616, 23683, 23416, 23483, 23550, 23617, 23684, 23417, 23484, 23551, 23618, 23685, 23418, 23485, 23552, 23619, 23686, 23419, 23486, 23553, 23620, 23687 },
     [slipIds[28]] = { 21515, 21561, 21617, 21670, 21718, 21775, 21826, 21879, 21918, 21971, 22027, 22082, 22108, 22214, 21516, 21562, 21618, 21671, 21719, 21776, 21827, 21880, 21919, 21972, 22028, 22083, 22109, 22215, 21517, 21563, 21619, 21672, 21720, 21777, 21828, 21881, 21920, 21973, 22029, 22084, 22110, 22216, 21518, 21564, 21620, 21673, 21721, 21778, 21829, 21882, 21921, 21974, 22030, 22085, 22111, 22217, 21519, 21565, 21621, 21674, 21722, 21779, 21830, 21883, 21922, 21975, 22031, 22086, 22112, 22218 }
-};
+}
 
 ----------------------------------------------------------------------
 -- desc : Checks if the supplied item is a Moogle Storage Slip.
 ----------------------------------------------------------------------
 local function isSlip(itemId)
-    return (slipItems[itemId] ~= nil);
+    return (slipItems[itemId] ~= nil)
 end
 
 ----------------------------------------------------------------------
@@ -52,35 +52,35 @@ end
 local function isStorableOn(slipId, itemId)
     for _, id in ipairs(slipItems[slipId]) do
         if (id == itemId) then
-            return true;
+            return true
         end
     end
     
-    printf('Item %s is not storable on %s', itemId, slipId);
-    return false;
+    printf('Item %s is not storable on %s', itemId, slipId)
+    return false
 end
 
 ----------------------------------------------------------------------
 -- desc : Gets IDs of retrievable items from the extra data on a slip.
 ----------------------------------------------------------------------
 local function getItemsOnSlip(extra, slipId)
-    local slip = slipItems[slipId];
+    local slip = slipItems[slipId]
     
-    local itemsOnSlip = {};
-    local x = 1;
+    local itemsOnSlip = {}
+    local x = 1
     for k,v in ipairs(slip) do
-        local byte = extra[math.floor((k - 1) / 8) + 1];
+        local byte = extra[math.floor((k - 1) / 8) + 1]
         if byte < 0 then
-            byte = byte + 256;
+            byte = byte + 256
         end
                 
         if (bit.band(bit.rshift(byte, (k - 1) % 8), 1) ~= 0) then
-            itemsOnSlip[x] = v;
-            x = x + 1;
+            itemsOnSlip[x] = v
+            x = x + 1
         end
     end
     
-    return itemsOnSlip;
+    return itemsOnSlip
 end
 
 ----------------------------------------------------------------------
@@ -99,22 +99,22 @@ end
 -- desc : Converts the 8 bit extra data into 32 bit params for events.
 ----------------------------------------------------------------------
 local function int8ToInt32(extra)
-    local params = {};
-    local int32 = '';
+    local params = {}
+    local int32 = ''
     
     for k,v in ipairs(extra) do
-        int32 = string.format('%02x%s', v, int32);
+        int32 = string.format('%02x%s', v, int32)
         if (k % 4 == 0) then
-            params[#params + 1] = tonumber(int32, 16);
-            int32 = '';
+            params[#params + 1] = tonumber(int32, 16)
+            int32 = ''
         end
     end
     
     if (int32 ~= '') then
-        params[#params + 1] = tonumber(int32, 16);
+        params[#params + 1] = tonumber(int32, 16)
     end
     
-    return params;
+    return params
 end
 
 ----------------------------------------------------------------------
@@ -123,23 +123,23 @@ end
 --        storable items.
 ----------------------------------------------------------------------
 local function getSlipId(trade)
-    local slipId = 0;
-    local slips = 0;
+    local slipId = 0
+    local slips = 0
     
     for _, itemId in ipairs(slipIds) do
         if (trade:hasItemQty(itemId, 1)) then
-            slips = slips + 1;
+            slips = slips + 1
             if (slipId == 0) then
-                slipId = itemId;
+                slipId = itemId
             end
         end
     end
     
     if (slips == trade:getItemCount() and slips > 1) then
-        slipId = 0;
+        slipId = 0
     end
     
-    return slipId, slips;
+    return slipId, slips
 end
 
 ----------------------------------------------------------------------
@@ -147,18 +147,18 @@ end
 --        slip in the trade window.
 ----------------------------------------------------------------------
 local function getStorableItems(player, trade, slipId)
-    local storableItemIds = { };
+    local storableItemIds = { }
     
     for i = 0, 7 do
-        local slotItemId = trade:getItemId(i);
+        local slotItemId = trade:getItemId(i)
         if (slotItemId ~= 0 and isSlip(slotItemId) ~= true and player:hasItem(slotItemId)) then
             if (isStorableOn(slipId, slotItemId)) then
-                storableItemIds[#storableItemIds+1] = slotItemId;
+                storableItemIds[#storableItemIds+1] = slotItemId
             end
         end
     end
     
-    return storableItemIds;
+    return storableItemIds
 end
 
 ----------------------------------------------------------------------
@@ -167,40 +167,40 @@ end
 ----------------------------------------------------------------------
 local function storeItems(player, storableItemIds, slipId, e)
     if (#storableItemIds > 0) then
-        local param0 = 0;
-        local param1 = 0;
+        local param0 = 0
+        local param1 = 0
         if (#storableItemIds == 1) then
-            param0 = storableItemIds[1];
-            param1 = 0;
+            param0 = storableItemIds[1]
+            param1 = 0
         else
-            param0 = #storableItemIds;
-            param1 = 1;
+            param0 = #storableItemIds
+            param1 = 1
         end
         
         -- idk
-        local extra = { };
+        local extra = { }
         for i = 0, 23 do
-            extra[i] = 0;
+            extra[i] = 0
         end
         
         for k, v in ipairs(slipItems[slipId]) do
             if find(storableItemIds, v) ~= nil then
-                local bitmask = extra[math.floor((k - 1) / 8)];
+                local bitmask = extra[math.floor((k - 1) / 8)]
                 if bitmask < 0 then
-                    bitmask = bitmask + 256;
+                    bitmask = bitmask + 256
                 end
-                extra[math.floor((k - 1) / 8)] = bit.bor(bitmask, bit.lshift(1, (k - 1) % 8));
+                extra[math.floor((k - 1) / 8)] = bit.bor(bitmask, bit.lshift(1, (k - 1) % 8))
             end
         end
         
-        local result = player:storeWithPorterMoogle(slipId, extra, storableItemIds);
+        local result = player:storeWithPorterMoogle(slipId, extra, storableItemIds)
         
         if (result == 0) then
-            player:startEvent(e.STORE_EVENT_ID, param0, param1);
+            player:startEvent(e.STORE_EVENT_ID, param0, param1)
         elseif (result == 1) then
-            player:startEvent(e.ALREADY_STORED_ID);
+            player:startEvent(e.ALREADY_STORED_ID)
         elseif (result == 2) then
-            player:startEvent(e.MAGIAN_TRIAL_ID);
+            player:startEvent(e.MAGIAN_TRIAL_ID)
         end
     end
 end
@@ -210,7 +210,7 @@ end
 --        is index 0, Storage Slip 2 is index 1, etc).
 ----------------------------------------------------------------------
 local function getSlipIndex(slipId)
-    return find(slipIds, slipId) - 1;
+    return find(slipIds, slipId) - 1
 end
 
 ----------------------------------------------------------------------
@@ -218,12 +218,12 @@ end
 --        retrieval event.
 ----------------------------------------------------------------------
 local function startRetrieveProcess(player, eventId, slipId)
-    local extra = player:getRetrievableItemsForSlip(slipId);
-    local params = int8ToInt32(extra);
-    local slipIndex = getSlipIndex(slipId);
+    local extra = player:getRetrievableItemsForSlip(slipId)
+    local params = int8ToInt32(extra)
+    local slipIndex = getSlipIndex(slipId)
     
-    player:setLocalVar('slipId', slipId);
-    player:startEvent(eventId, params[1], params[2], params[3], params[4], params[5], params[6], nil, slipIndex);
+    player:setLocalVar('slipId', slipId)
+    player:startEvent(eventId, params[1], params[2], params[3], params[4], params[5], params[6], nil, slipIndex)
 end
 
 ----------------------------------------------------------------------
@@ -231,15 +231,15 @@ end
 --        supplied in the trade.
 ----------------------------------------------------------------------
 function porterMoogleTrade(player, trade, e)
-    local slipId, slipCount = getSlipId(trade);
-    if (slipId == 0 or slipCount > 1) then return; end;
+    local slipId, slipCount = getSlipId(trade)
+    if (slipId == 0 or slipCount > 1) then return end
     
-    local storableItemIds = getStorableItems(player, trade, slipId);
+    local storableItemIds = getStorableItems(player, trade, slipId)
     
     if (#storableItemIds > 0) then
-        storeItems(player, storableItemIds, slipId, e);
+        storeItems(player, storableItemIds, slipId, e)
     else
-        startRetrieveProcess(player, e.RETRIEVE_EVENT_ID, slipId);
+        startRetrieveProcess(player, e.RETRIEVE_EVENT_ID, slipId)
     end
 end
 
@@ -249,30 +249,30 @@ end
 --        updates the user's event data.
 ----------------------------------------------------------------------
 function porterEventUpdate(player, csid, option, RETRIEVE_EVENT_ID)
-    local slipId = player:getLocalVar('slipId');
+    local slipId = player:getLocalVar('slipId')
     if (csid == RETRIEVE_EVENT_ID and slipId ~= 0 and slipId ~= nil) then
-        local extra = player:getRetrievableItemsForSlip(slipId);
-        local itemsOnSlip = getItemsOnSlip(extra, slipId);
-        local retrievedItemId = itemsOnSlip[option + 1];
+        local extra = player:getRetrievableItemsForSlip(slipId)
+        local itemsOnSlip = getItemsOnSlip(extra, slipId)
+        local retrievedItemId = itemsOnSlip[option + 1]
         
         if (player:hasItem(retrievedItemId) or player:getFreeSlotsCount() == 0) then
-            player:messageSpecial(zones[player:getZoneID()].text.ITEM_CANNOT_BE_OBTAINED, retrievedItemId);
+            player:messageSpecial(zones[player:getZoneID()].text.ITEM_CANNOT_BE_OBTAINED, retrievedItemId)
         else
-            local k = find(slipItems[slipId], retrievedItemId);
-            local extraId = math.floor((k - 1) / 8);
-            local bitmask = extra[extraId + 1];
+            local k = find(slipItems[slipId], retrievedItemId)
+            local extraId = math.floor((k - 1) / 8)
+            local bitmask = extra[extraId + 1]
             if bitmask < 0 then
-                bitmask = bitmask + 256;
+                bitmask = bitmask + 256
             end
-            bitmask = bit.band(bitmask, bit.bnot(bit.lshift(1, (k - 1) % 8)));
-            extra[extraId + 1] = bitmask;
+            bitmask = bit.band(bitmask, bit.bnot(bit.lshift(1, (k - 1) % 8)))
+            extra[extraId + 1] = bitmask
 
-            player:retrieveItemFromSlip(slipId, retrievedItemId, extraId, bitmask);
-            player:messageSpecial(zones[player:getZoneID()].text.RETRIEVE_DIALOG_ID, retrievedItemId, nil, nil, retrievedItemId, false);
+            player:retrieveItemFromSlip(slipId, retrievedItemId, extraId, bitmask)
+            player:messageSpecial(zones[player:getZoneID()].text.RETRIEVE_DIALOG_ID, retrievedItemId, nil, nil, retrievedItemId, false)
         end
         
-        local params = int8ToInt32(extra);
-        player:updateEvent(params[1], params[2], params[3], params[4], params[5], params[6], slipId);
+        local params = int8ToInt32(extra)
+        player:updateEvent(params[1], params[2], params[3], params[4], params[5], params[6], slipId)
     end
 end
 
@@ -282,21 +282,21 @@ end
 function porterEventFinish(player, csid, option, TALK_EVENT_ID)
     if (csid == TALK_EVENT_ID and option < 1000) then
         -- This is just because hilarious.
-        option = math.floor(option / 16) + (option % 16);
-        local hasItem = player:hasItem(slipIds[option]);
+        option = math.floor(option / 16) + (option % 16)
+        local hasItem = player:hasItem(slipIds[option])
         if (hasItem or player:getFreeSlotsCount() == 0) then
-            player:messageSpecial(zones[player:getZoneID()].text.ITEM_CANNOT_BE_OBTAINED, slipIds[option]);
-            return;
+            player:messageSpecial(zones[player:getZoneID()].text.ITEM_CANNOT_BE_OBTAINED, slipIds[option])
+            return
         end
 
         if (player:delGil(1000)) then
-            player:addItem(slipIds[option]);
-            player:messageSpecial(zones[player:getZoneID()].text.ITEM_OBTAINED, slipIds[option]);
+            player:addItem(slipIds[option])
+            player:messageSpecial(zones[player:getZoneID()].text.ITEM_OBTAINED, slipIds[option])
         else
-            player:messageSpecial(zones[player:getZoneID()].text.NOT_HAVE_ENOUGH_GIL, slipIds[option]);
-            return;
+            player:messageSpecial(zones[player:getZoneID()].text.NOT_HAVE_ENOUGH_GIL, slipIds[option])
+            return
         end
     else
-        player:setLocalVar('slipId', 0);
+        player:setLocalVar('slipId', 0)
     end
 end

--- a/scripts/globals/quests.lua
+++ b/scripts/globals/quests.lua
@@ -10,9 +10,9 @@ tpz.quest = tpz.quest or {}
 --
 -----------------------------------
 
-QUEST_AVAILABLE = 0;
-QUEST_ACCEPTED  = 1;
-QUEST_COMPLETED = 2;
+QUEST_AVAILABLE = 0
+QUEST_ACCEPTED  = 1
+QUEST_COMPLETED = 2
 
 -- Log IDs defined as "enums" here to tie into quest_rewrite
 -- branch that will be merged in at a later date. Used

--- a/scripts/globals/settings.lua
+++ b/scripts/globals/settings.lua
@@ -6,148 +6,148 @@
 -- Anything scripted can be customized with proper script editing.
 
 -- PLEASE REQUIRE THIS SCRIPT IN ANY SCRIPTS YOU DO: ADD THIS LINE TO THE TOP!!!!
--- require("scripts/globals/settings");
+-- require("scripts/globals/settings")
 -- With this script added to yours, you can pull variables from it!!
 
 -- Always include status.lua, which defines mods
--- require("scripts/globals/status");
+-- require("scripts/globals/status")
 
 -- Common functions
-require("scripts/globals/common");
+require("scripts/globals/common")
 
 -- Enable Expansion (1= yes 0= no)
-ENABLE_COP     = 0;
-ENABLE_TOAU    = 0;
-ENABLE_WOTG    = 0;
-ENABLE_ACP     = 0;
-ENABLE_AMK     = 0;
-ENABLE_ASA     = 0;
-ENABLE_ABYSSEA = 0;
-ENABLE_SOA     = 0;
-ENABLE_ROV     = 0;
-ENABLE_VOIDWATCH = 0; -- Not an expansion, but has its own storyline.
+ENABLE_COP     = 0
+ENABLE_TOAU    = 0
+ENABLE_WOTG    = 0
+ENABLE_ACP     = 0
+ENABLE_AMK     = 0
+ENABLE_ASA     = 0
+ENABLE_ABYSSEA = 0
+ENABLE_SOA     = 0
+ENABLE_ROV     = 0
+ENABLE_VOIDWATCH = 0 -- Not an expansion, but has its own storyline.
 
 -- FIELDS OF VALOR/Grounds of Valor settings
-ENABLE_FIELD_MANUALS  = 1; -- Enables Fields of Valor
-ENABLE_GROUNDS_TOMES  = 1; -- Enables Grounds of Valor
-REGIME_WAIT = 1; -- Make people wait till 00:00 game time as in retail. If it's 0, there is no wait time.
+ENABLE_FIELD_MANUALS  = 1 -- Enables Fields of Valor
+ENABLE_GROUNDS_TOMES  = 1 -- Enables Grounds of Valor
+REGIME_WAIT = 1 -- Make people wait till 00:00 game time as in retail. If it's 0, there is no wait time.
 
 -- TREASURE CASKETS
 -- Retail droprate = 0.1 (10%) with no other effects active
 -- Set to 0 to disable caskets.
 -- max is clamped to 1.0 (100%)
-CASKET_DROP_RATE = 0.1;
+CASKET_DROP_RATE = 0.1
 
 -- Setting to lock content more accurately to the content you have defined above
 -- This generally results in a more accurate presentation of your selected expansions
 -- as well as a less confusing player experience for things that are disabled (things that are disabled are not loaded)
 -- This feature correlates to the content_tag column in the SQL files
-RESTRICT_CONTENT = 0;
+RESTRICT_CONTENT = 0
 
 -- CHARACTER CONFIG
-INITIAL_LEVEL_CAP = 50; -- The initial level cap for new players.  There seems to be a hardcap of 255.
-MAX_LEVEL = 75; -- Level max of the server, lowers the attainable cap by disabling Limit Break quests.
-NORMAL_MOB_MAX_LEVEL_RANGE_MIN = 0; -- Lower Bound of Max Level Range for Normal Mobs (0 = Uncapped)
-NORMAL_MOB_MAX_LEVEL_RANGE_MAX = 0; -- Upper Bound of Max Level Range for Normal Mobs (0 = Uncapped)
-START_GIL = 10; -- Amount of gil given to newly created characters.
-START_INVENTORY = 30; -- Starting inventory and satchel size.  Ignores values < 30.  Do not set above 80!
-OPENING_CUTSCENE_ENABLE = 0; -- Set to 1 to enable opening cutscenes, 0 to disable.
-SUBJOB_QUEST_LEVEL = 18; -- Minimum level to accept either subjob quest.  Set to 0 to start the game with subjobs unlocked.
-ADVANCED_JOB_LEVEL = 30; -- Minimum level to accept advanced job quests.  Set to 0 to start the game with advanced jobs.
-ALL_MAPS = 0; -- Set to 1 to give starting characters all the maps.
-UNLOCK_OUTPOST_WARPS = 0; -- Set to 1 to give starting characters all outpost warps.  2 to add Tu'Lia and Tavnazia.
+INITIAL_LEVEL_CAP = 50 -- The initial level cap for new players.  There seems to be a hardcap of 255.
+MAX_LEVEL = 75 -- Level max of the server, lowers the attainable cap by disabling Limit Break quests.
+NORMAL_MOB_MAX_LEVEL_RANGE_MIN = 0 -- Lower Bound of Max Level Range for Normal Mobs (0 = Uncapped)
+NORMAL_MOB_MAX_LEVEL_RANGE_MAX = 0 -- Upper Bound of Max Level Range for Normal Mobs (0 = Uncapped)
+START_GIL = 10 -- Amount of gil given to newly created characters.
+START_INVENTORY = 30 -- Starting inventory and satchel size.  Ignores values < 30.  Do not set above 80!
+OPENING_CUTSCENE_ENABLE = 0 -- Set to 1 to enable opening cutscenes, 0 to disable.
+SUBJOB_QUEST_LEVEL = 18 -- Minimum level to accept either subjob quest.  Set to 0 to start the game with subjobs unlocked.
+ADVANCED_JOB_LEVEL = 30 -- Minimum level to accept advanced job quests.  Set to 0 to start the game with advanced jobs.
+ALL_MAPS = 0 -- Set to 1 to give starting characters all the maps.
+UNLOCK_OUTPOST_WARPS = 0 -- Set to 1 to give starting characters all outpost warps.  2 to add Tu'Lia and Tavnazia.
 
-SHOP_PRICE      = 1.000; -- Multiplies prices in NPC shops.
-GIL_RATE        = 1.000; -- Multiplies gil earned from quests.  Won't always display in game.
-BAYLD_RATE      = 1.000; -- Multiples bayld earned from quests.
-EXP_RATE        = 1.000; -- Multiplies exp earned from fov and quests.
-TABS_RATE       = 1.000; -- Multiplies tabs earned from fov.
-CURE_POWER      = 1.000; -- Multiplies amount healed from Healing Magic, including the relevant Blue Magic.
-ELEMENTAL_POWER = 1.000; -- Multiplies damage dealt by Elemental and non-drain Dark Magic.
-DIVINE_POWER    = 1.000; -- Multiplies damage dealt by Divine Magic.
-NINJUTSU_POWER  = 1.000; -- Multiplies damage dealt by Ninjutsu Magic.
-BLUE_POWER      = 1.000; -- Multiplies damage dealt by Blue Magic.
-DARK_POWER      = 1.000; -- Multiplies amount drained by Dark Magic.
-ITEM_POWER      = 1.000; -- Multiplies the effect of items such as Potions and Ethers.
-WEAPON_SKILL_POWER  = 1.000; -- Multiplies damage dealt by Weapon Skills.
-WEAPON_SKILL_POINTS = 1.000; -- Multiplies points earned during weapon unlocking.
-USE_ADOULIN_WEAPON_SKILL_CHANGES = false; -- true/false. Change to toggle new Adoulin weapon skill damage calculations
+SHOP_PRICE      = 1.000 -- Multiplies prices in NPC shops.
+GIL_RATE        = 1.000 -- Multiplies gil earned from quests.  Won't always display in game.
+BAYLD_RATE      = 1.000 -- Multiples bayld earned from quests.
+EXP_RATE        = 1.000 -- Multiplies exp earned from fov and quests.
+TABS_RATE       = 1.000 -- Multiplies tabs earned from fov.
+CURE_POWER      = 1.000 -- Multiplies amount healed from Healing Magic, including the relevant Blue Magic.
+ELEMENTAL_POWER = 1.000 -- Multiplies damage dealt by Elemental and non-drain Dark Magic.
+DIVINE_POWER    = 1.000 -- Multiplies damage dealt by Divine Magic.
+NINJUTSU_POWER  = 1.000 -- Multiplies damage dealt by Ninjutsu Magic.
+BLUE_POWER      = 1.000 -- Multiplies damage dealt by Blue Magic.
+DARK_POWER      = 1.000 -- Multiplies amount drained by Dark Magic.
+ITEM_POWER      = 1.000 -- Multiplies the effect of items such as Potions and Ethers.
+WEAPON_SKILL_POWER  = 1.000 -- Multiplies damage dealt by Weapon Skills.
+WEAPON_SKILL_POINTS = 1.000 -- Multiplies points earned during weapon unlocking.
+USE_ADOULIN_WEAPON_SKILL_CHANGES = false -- true/false. Change to toggle new Adoulin weapon skill damage calculations
 
-HARVESTING_BREAK_CHANCE = 33; -- % chance for the sickle to break during harvesting.  Set between 0 and 100.
-EXCAVATION_BREAK_CHANCE = 33; -- % chance for the pickaxe to break during excavation.  Set between 0 and 100.
-LOGGING_BREAK_CHANCE    = 33; -- % chance for the hatchet to break during logging.  Set between 0 and 100.
-MINING_BREAK_CHANCE     = 33; -- % chance for the pickaxe to break during mining.  Set between 0 and 100.
-HARVESTING_RATE         = 50; -- % chance to recieve an item from haresting.  Set between 0 and 100.
-EXCAVATION_RATE         = 50; -- % chance to recieve an item from excavation.  Set between 0 and 100.
-LOGGING_RATE            = 50; -- % chance to recieve an item from logging.  Set between 0 and 100.
-MINING_RATE             = 50; -- % chance to recieve an item from mining.  Set between 0 and 100.
-DIGGING_RATE            = 85; -- % chance to receive an item from chocbo digging during favorable weather.  Set between 0 and 100.
+HARVESTING_BREAK_CHANCE = 33 -- % chance for the sickle to break during harvesting.  Set between 0 and 100.
+EXCAVATION_BREAK_CHANCE = 33 -- % chance for the pickaxe to break during excavation.  Set between 0 and 100.
+LOGGING_BREAK_CHANCE    = 33 -- % chance for the hatchet to break during logging.  Set between 0 and 100.
+MINING_BREAK_CHANCE     = 33 -- % chance for the pickaxe to break during mining.  Set between 0 and 100.
+HARVESTING_RATE         = 50 -- % chance to recieve an item from haresting.  Set between 0 and 100.
+EXCAVATION_RATE         = 50 -- % chance to recieve an item from excavation.  Set between 0 and 100.
+LOGGING_RATE            = 50 -- % chance to recieve an item from logging.  Set between 0 and 100.
+MINING_RATE             = 50 -- % chance to recieve an item from mining.  Set between 0 and 100.
+DIGGING_RATE            = 85 -- % chance to receive an item from chocbo digging during favorable weather.  Set between 0 and 100.
 
-HEALING_TP_CHANGE       = -100; -- Change in TP for each healing tick. Default is -100
+HEALING_TP_CHANGE       = -100 -- Change in TP for each healing tick. Default is -100
 
 -- SE implemented coffer/chest illusion time in order to prevent coffer farming. No-one in the same area can open a chest or coffer for loot (gil, gems & items)
 -- till a random time between MIN_ILLSION_TIME and MAX_ILLUSION_TIME. During this time players can loot keyitem and item related to quests (AF, maps... etc.)
-COFFER_MAX_ILLUSION_TIME = 3600;  -- 1 hour
-COFFER_MIN_ILLUSION_TIME = 1800;  -- 30 minutes
-CHEST_MAX_ILLUSION_TIME  = 3600;  -- 1 hour
-CHEST_MIN_ILLUSION_TIME  = 1800;  -- 30 minutes
+COFFER_MAX_ILLUSION_TIME = 3600  -- 1 hour
+COFFER_MIN_ILLUSION_TIME = 1800  -- 30 minutes
+CHEST_MAX_ILLUSION_TIME  = 3600  -- 1 hour
+CHEST_MIN_ILLUSION_TIME  = 1800  -- 30 minutes
 
 -- Sets spawn type for: Behemoth, Fafnir, Adamantoise, King Behemoth, Nidhog, Aspidochelone.
 -- Use 0 for timed spawns, 1 for force pop only, 2 for both
-LandKingSystem_NQ = 0;
-LandKingSystem_HQ = 0;
+LandKingSystem_NQ = 0
+LandKingSystem_HQ = 0
 
 -- DYNAMIS SETTINGS
-    BETWEEN_2DYNA_WAIT_TIME = 24;       -- Hours before player can re-enter Dynamis. Default is 1 Earthday (24 hours).
-        DYNA_MIDNIGHT_RESET = true;     -- if true, makes the wait time count by number of server midnights instead of full 24 hour intervals
-             DYNA_LEVEL_MIN = 65;       -- level min for entering in Dynamis
-    TIMELESS_HOURGLASS_COST = 500000;   -- refund for the timeless hourglass for Dynamis.
-   PRISMATIC_HOURGLASS_COST = 50000;    -- cost of the prismatic hourglass for Dynamis.
-     CURRENCY_EXCHANGE_RATE = 100;      -- X Tier 1 ancient currency -> 1 Tier 2, and so on.  Certain values may conflict with shop items.  Not designed to exceed 198.
-RELIC_2ND_UPGRADE_WAIT_TIME = 7200;     -- wait time for 2nd relic upgrade (stage 2 -> stage 3) in seconds. 7200s = 2 hours.
-RELIC_3RD_UPGRADE_WAIT_TIME = 3600;     -- wait time for 3rd relic upgrade (stage 3 -> stage 4) in seconds. 3600s = 1 hour.
-FREE_COP_DYNAMIS = 0 ; -- Authorize player to entering inside COP Dynamis without completing COP mission ( 1 = enable 0= disable)
+    BETWEEN_2DYNA_WAIT_TIME = 24       -- Hours before player can re-enter Dynamis. Default is 1 Earthday (24 hours).
+        DYNA_MIDNIGHT_RESET = true     -- if true, makes the wait time count by number of server midnights instead of full 24 hour intervals
+             DYNA_LEVEL_MIN = 65       -- level min for entering in Dynamis
+    TIMELESS_HOURGLASS_COST = 500000   -- refund for the timeless hourglass for Dynamis.
+   PRISMATIC_HOURGLASS_COST = 50000    -- cost of the prismatic hourglass for Dynamis.
+     CURRENCY_EXCHANGE_RATE = 100      -- X Tier 1 ancient currency -> 1 Tier 2, and so on.  Certain values may conflict with shop items.  Not designed to exceed 198.
+RELIC_2ND_UPGRADE_WAIT_TIME = 7200     -- wait time for 2nd relic upgrade (stage 2 -> stage 3) in seconds. 7200s = 2 hours.
+RELIC_3RD_UPGRADE_WAIT_TIME = 3600     -- wait time for 3rd relic upgrade (stage 3 -> stage 4) in seconds. 3600s = 1 hour.
+FREE_COP_DYNAMIS = 0  -- Authorize player to entering inside COP Dynamis without completing COP mission ( 1 = enable 0= disable)
 
 -- QUEST/MISSION SPECIFIC SETTINGS
-AF1_QUEST_LEVEL = 40; -- Minimum level to start AF1 quest
-AF2_QUEST_LEVEL = 50; -- Minimum level to start AF2 quest
-AF3_QUEST_LEVEL = 50; -- Minimum level to start AF3 quest
-OldSchoolG1 = false; -- Set to true to require farming Exoray Mold, Bombd Coal, and Ancient Papyrus drops instead of allowing key item method.
-OldSchoolG2 = false; -- Set true to require the NMs for "Atop the Highest Mountains" be dead to get KI like before SE changed it.
-FrigiciteDuration = 30; -- When OldSChoolG2 is enabled, this is the time (in seconds) you have from killing Boreal NMs to click the "???" target.
+AF1_QUEST_LEVEL = 40 -- Minimum level to start AF1 quest
+AF2_QUEST_LEVEL = 50 -- Minimum level to start AF2 quest
+AF3_QUEST_LEVEL = 50 -- Minimum level to start AF3 quest
+OldSchoolG1 = false -- Set to true to require farming Exoray Mold, Bombd Coal, and Ancient Papyrus drops instead of allowing key item method.
+OldSchoolG2 = false -- Set true to require the NMs for "Atop the Highest Mountains" be dead to get KI like before SE changed it.
+FrigiciteDuration = 30 -- When OldSChoolG2 is enabled, this is the time (in seconds) you have from killing Boreal NMs to click the "???" target.
 
 -- SPELL SPECIFIC SETTINGS
-DIA_OVERWRITE = 1; --Set to 1 to allow Bio to overwrite same tier Dia.  Default is 1.
-BIO_OVERWRITE = 0; --Set to 1 to allow Dia to overwrite same tier Bio.  Default is 0.
-STONESKIN_CAP = 350; -- soft cap for hp absorbed by stoneskin
-BLINK_SHADOWS = 2;   -- number of shadows supplied by Blink spell
-SPIKE_EFFECT_DURATION = 180; -- the duration of RDM, BLM spikes effects (not Reprisal)
-ELEMENTAL_DEBUFF_DURATION = 120; -- base duration of elemental debuffs
-AQUAVEIL_COUNTER = 1;  -- Base amount of hits Aquaveil absorbs to prevent spell interrupts. Retail is 1.
-ABSORB_SPELL_AMOUNT = 8; -- how much of a stat gets absorbed by DRK absorb spells - expected to be a multiple of 8.
-ABSORB_SPELL_TICK = 9; -- duration of 1 absorb spell tick
-SNEAK_INVIS_DURATION_MULTIPLIER = 1; -- multiplies duration of sneak,invis,deodorize to reduce player torture. 1 = retail behavior.
-USE_OLD_CURE_FORMULA = false; -- true/false. if true, uses older cure formula (3*MND + VIT + 3*(healing skill/5)) // cure 6 will use the newer formula
-USE_OLD_MAGIC_DAMAGE = false; -- true/false. if true, uses older magic damage formulas
+DIA_OVERWRITE = 1 --Set to 1 to allow Bio to overwrite same tier Dia.  Default is 1.
+BIO_OVERWRITE = 0 --Set to 1 to allow Dia to overwrite same tier Bio.  Default is 0.
+STONESKIN_CAP = 350 -- soft cap for hp absorbed by stoneskin
+BLINK_SHADOWS = 2   -- number of shadows supplied by Blink spell
+SPIKE_EFFECT_DURATION = 180 -- the duration of RDM, BLM spikes effects (not Reprisal)
+ELEMENTAL_DEBUFF_DURATION = 120 -- base duration of elemental debuffs
+AQUAVEIL_COUNTER = 1  -- Base amount of hits Aquaveil absorbs to prevent spell interrupts. Retail is 1.
+ABSORB_SPELL_AMOUNT = 8 -- how much of a stat gets absorbed by DRK absorb spells - expected to be a multiple of 8.
+ABSORB_SPELL_TICK = 9 -- duration of 1 absorb spell tick
+SNEAK_INVIS_DURATION_MULTIPLIER = 1 -- multiplies duration of sneak,invis,deodorize to reduce player torture. 1 = retail behavior.
+USE_OLD_CURE_FORMULA = false -- true/false. if true, uses older cure formula (3*MND + VIT + 3*(healing skill/5)) // cure 6 will use the newer formula
+USE_OLD_MAGIC_DAMAGE = false -- true/false. if true, uses older magic damage formulas
 
 -- CELEBRATIONS
-EXPLORER_MOOGLE_LV = 10; -- Enables Explorer Moogle teleports and sets required level. Zero to disable.
-HALLOWEEN_2005 = 0; -- Set to 1 to Enable the 2005 version of Harvest Festival, will start on Oct. 20 and end Nov. 1.
-HALLOWEEN_YEAR_ROUND = 0; -- Set to 1 to have Harvest Festival initialize outside of normal times.
+EXPLORER_MOOGLE_LV = 10 -- Enables Explorer Moogle teleports and sets required level. Zero to disable.
+HALLOWEEN_2005 = 0 -- Set to 1 to Enable the 2005 version of Harvest Festival, will start on Oct. 20 and end Nov. 1.
+HALLOWEEN_YEAR_ROUND = 0 -- Set to 1 to have Harvest Festival initialize outside of normal times.
 
 -- MISC
-HOMEPOINT_HEAL = 0; --Set to 1 if you want Home Points to heal you like in single-player Final Fantasy games.
-RIVERNE_PORTERS = 120; -- Time in seconds that Unstable Displacements in Cape Riverne stay open after trading a scale.
-LANTERNS_STAY_LIT = 1200; -- time in seconds that lanterns in the Den of Rancor stay lit.
-ENABLE_COP_ZONE_CAP = 1; -- enable or disable lvl cap
-TIMEZONE_OFFSET = 9.0; -- Offset from UTC used to determine when "JP Midnight" is for the server.  Default is JST (+9.0).
-ALLOW_MULTIPLE_EXP_RINGS = 0; -- Set to 1 to remove ownership restrictions on the Chariot/Empress/Emperor Band trio.
-BYPASS_EXP_RING_ONE_PER_WEEK = 0; -- -- Set to 1 to bypass the limit of one ring per Conquest Tally Week.
-NUMBER_OF_DM_EARRINGS = 1; -- Number of earrings players can simultaneously own from Divine Might before scripts start blocking them (Default: 1)
-HOMEPOINT_TELEPORT = 0; -- Enables the homepoint teleport system
-DIG_ABUNDANCE_BONUS = 0; -- Increase chance of digging up an item (450  = item digup chance +45)
-DIG_FATIGUE = 1; -- Set to 0 to disable Dig Fatigue
-DIG_GRANT_BURROW = 0; -- Set to 1 to grant burrow ability
-DIG_GRANT_BORE = 0; -- Set to 1 to grant bore ability
-ENM_COOLDOWN = 120;  -- Number of hours before a player can obtain same KI for ENMs (default: 5 days)
-FORCE_SPAWN_QM_RESET_TIME = 300; -- Number of seconds the ??? remains hidden for after the despawning of the mob it force spawns.
+HOMEPOINT_HEAL = 0 --Set to 1 if you want Home Points to heal you like in single-player Final Fantasy games.
+RIVERNE_PORTERS = 120 -- Time in seconds that Unstable Displacements in Cape Riverne stay open after trading a scale.
+LANTERNS_STAY_LIT = 1200 -- time in seconds that lanterns in the Den of Rancor stay lit.
+ENABLE_COP_ZONE_CAP = 1 -- enable or disable lvl cap
+TIMEZONE_OFFSET = 9.0 -- Offset from UTC used to determine when "JP Midnight" is for the server.  Default is JST (+9.0).
+ALLOW_MULTIPLE_EXP_RINGS = 0 -- Set to 1 to remove ownership restrictions on the Chariot/Empress/Emperor Band trio.
+BYPASS_EXP_RING_ONE_PER_WEEK = 0 -- -- Set to 1 to bypass the limit of one ring per Conquest Tally Week.
+NUMBER_OF_DM_EARRINGS = 1 -- Number of earrings players can simultaneously own from Divine Might before scripts start blocking them (Default: 1)
+HOMEPOINT_TELEPORT = 0 -- Enables the homepoint teleport system
+DIG_ABUNDANCE_BONUS = 0 -- Increase chance of digging up an item (450  = item digup chance +45)
+DIG_FATIGUE = 1 -- Set to 0 to disable Dig Fatigue
+DIG_GRANT_BURROW = 0 -- Set to 1 to grant burrow ability
+DIG_GRANT_BORE = 0 -- Set to 1 to grant bore ability
+ENM_COOLDOWN = 120  -- Number of hours before a player can obtain same KI for ENMs (default: 5 days)
+FORCE_SPAWN_QM_RESET_TIME = 300 -- Number of seconds the ??? remains hidden for after the despawning of the mob it force spawns.

--- a/scripts/globals/spells/bluemagic/cimicine_discharge.lua
+++ b/scripts/globals/spells/bluemagic/cimicine_discharge.lua
@@ -36,7 +36,7 @@ function onSpellCast(caster, target, spell)
     local resist = applyResistance(caster, target, spell, params)
 
     if resist < 0.5 then
-        spell:setMsg(tpz.msg.basic.MAGIC_RESIST); --resist message
+        spell:setMsg(tpz.msg.basic.MAGIC_RESIST) --resist message
     else
         if target:addStatusEffect(tpz.effect.SLOW, 2000, 0, getBlueEffectDuration(caster, resist, tpz.effect.SLOW)) then
             spell:setMsg(tpz.msg.basic.MAGIC_ENFEEB_IS)

--- a/scripts/globals/spells/bluemagic/refueling.lua
+++ b/scripts/globals/spells/bluemagic/refueling.lua
@@ -31,7 +31,7 @@ function onSpellCast(caster, target, spell)
 
         if (diffMerit > 0) then
             duration = duration + (duration / 100)* diffMerit
-        end;
+        end
 
         caster:delStatusEffect(tpz.effect.DIFFUSION)
     end

--- a/scripts/globals/spells/trust/Shantotto_II.lua
+++ b/scripts/globals/spells/trust/Shantotto_II.lua
@@ -1,7 +1,7 @@
 -----------------------------------------
 -- Trust: Shantotto II
 -----------------------------------------
--- require("scripts/globals/trust");
+-- require("scripts/globals/trust")
 -----------------------------------------
 
 function onMagicCastingCheck(caster,target,spell)

--- a/scripts/globals/spells/trust/shantotto.lua
+++ b/scripts/globals/spells/trust/shantotto.lua
@@ -1,7 +1,7 @@
 -----------------------------------------
 -- Spell: Shantotto
 -----------------------------------------
--- require("scripts/globals/trust");
+-- require("scripts/globals/trust")
 -----------------------------------------
 
 function onMagicCastingCheck(caster,target,spell)

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1546,7 +1546,7 @@ tpz.mod =
     -- SPARE = 958, -- stuff
     -- SPARE = 959, -- stuff
     -- SPARE = 960, -- stuff
-};
+}
 
 tpz.latent =
 {

--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -26,7 +26,7 @@ function AvatarPhysicalMove(avatar,target,skill,numberofhits,accmod,dmgmod,dmgmo
     -- add on native crit hit rate (guesstimated, it actually follows an exponential curve)
     local critrate = (avatar:getStat(tpz.mod.DEX) - target:getStat(tpz.mod.AGI)) * 0.005 -- assumes +0.5% crit rate per 1 dDEX
     critrate = critrate + avatar:getMod(tpz.mod.CRITHITRATE) / 100
-    critrate = utils.clamp(critrate, 0.05, 0.2);
+    critrate = utils.clamp(critrate, 0.05, 0.2)
 
     -- Applying pDIF
     if ratio <= 1 then

--- a/scripts/globals/utils.lua
+++ b/scripts/globals/utils.lua
@@ -1,6 +1,6 @@
 require("scripts/globals/status")
 
-utils = {};
+utils = {}
 
 -- Shuffles a table and returns a copy of it, not the original.
 function utils.shuffle(tab)
@@ -18,44 +18,44 @@ end
 
 function utils.clamp(input, min_val, max_val)
     if input < min_val then
-        input = min_val;
+        input = min_val
     elseif max_val ~= nil and input > max_val then
-        input = max_val;
+        input = max_val
     end
-    return input;
-end;
+    return input
+end
 
 -- returns unabsorbed damage
 function utils.stoneskin(target, dmg)
     --handling stoneskin
     if (dmg > 0) then
-        skin = target:getMod(tpz.mod.STONESKIN);
+        skin = target:getMod(tpz.mod.STONESKIN)
         if (skin > 0) then
             if (skin > dmg) then --absorb all damage
-                target:delMod(tpz.mod.STONESKIN,dmg);
-                return 0;
+                target:delMod(tpz.mod.STONESKIN,dmg)
+                return 0
             else --absorbs some damage then wear
-                target:delStatusEffect(tpz.effect.STONESKIN);
-                target:setMod(tpz.mod.STONESKIN, 0);
-                return dmg - skin;
+                target:delStatusEffect(tpz.effect.STONESKIN)
+                target:setMod(tpz.mod.STONESKIN, 0)
+                return dmg - skin
             end
         end
     end
 
-    return dmg;
-end;
+    return dmg
+end
 
 function utils.takeShadows(target, dmg, shadowbehav)
     if (shadowbehav == nil) then
-        shadowbehav = 1;
+        shadowbehav = 1
     end
 
-    local targShadows = target:getMod(tpz.mod.UTSUSEMI);
-    local shadowType = tpz.mod.UTSUSEMI;
+    local targShadows = target:getMod(tpz.mod.UTSUSEMI)
+    local shadowType = tpz.mod.UTSUSEMI
 
     if (targShadows == 0) then --try blink, as utsusemi always overwrites blink this is okay
-        targShadows = target:getMod(tpz.mod.BLINK);
-        shadowType = tpz.mod.BLINK;
+        targShadows = target:getMod(tpz.mod.BLINK)
+        shadowType = tpz.mod.BLINK
     end
 
     if (targShadows > 0) then
@@ -63,59 +63,59 @@ function utils.takeShadows(target, dmg, shadowbehav)
 
         if (targShadows >= shadowbehav) then --no damage, just suck the shadows
 
-            local shadowsLeft = targShadows - shadowbehav;
+            local shadowsLeft = targShadows - shadowbehav
 
-            target:setMod(shadowType, shadowsLeft);
+            target:setMod(shadowType, shadowsLeft)
 
             if (shadowsLeft > 0 and shadowType == tpz.mod.UTSUSEMI) then --update icon
-                effect = target:getStatusEffect(tpz.effect.COPY_IMAGE);
+                effect = target:getStatusEffect(tpz.effect.COPY_IMAGE)
                 if (effect ~= nil) then
                     if (shadowsLeft == 1) then
-                        effect:setIcon(tpz.effect.COPY_IMAGE);
+                        effect:setIcon(tpz.effect.COPY_IMAGE)
                     elseif (shadowsLeft == 2) then
-                        effect:setIcon(tpz.effect.COPY_IMAGE_2);
+                        effect:setIcon(tpz.effect.COPY_IMAGE_2)
                     elseif (shadowsLeft == 3) then
-                        effect:setIcon(tpz.effect.COPY_IMAGE_3);
+                        effect:setIcon(tpz.effect.COPY_IMAGE_3)
                     end
                 end
             end
             -- remove icon
             if (shadowsLeft <= 0) then
-                target:delStatusEffect(tpz.effect.COPY_IMAGE);
-                target:delStatusEffect(tpz.effect.BLINK);
+                target:delStatusEffect(tpz.effect.COPY_IMAGE)
+                target:delStatusEffect(tpz.effect.BLINK)
             end
 
-            return 0;
+            return 0
         else --less shadows than this move will take, remove all and factor damage down
-            target:delStatusEffect(tpz.effect.COPY_IMAGE);
-            target:delStatusEffect(tpz.effect.BLINK);
-            return dmg * ((shadowbehav-targShadows)/shadowbehav);
+            target:delStatusEffect(tpz.effect.COPY_IMAGE)
+            target:delStatusEffect(tpz.effect.BLINK)
+            return dmg * ((shadowbehav-targShadows)/shadowbehav)
         end
     end
 
-    return dmg;
-end;
+    return dmg
+end
 
 -- returns true if taken by third eye
 function utils.thirdeye(target)
     --third eye doesnt care how many shadows, so attempt to anticipate, but reduce
     --chance of anticipate based on previous successful anticipates.
-    local teye = target:getStatusEffect(tpz.effect.THIRD_EYE);
+    local teye = target:getStatusEffect(tpz.effect.THIRD_EYE)
 
     if (teye == nil) then
-        return false;
+        return false
     end
 
-    local prevAnt = teye:getPower();
+    local prevAnt = teye:getPower()
 
     if ( prevAnt == 0 or (math.random()*100) < (80-(prevAnt*10)) ) then
         --anticipated!
-        target:delStatusEffect(tpz.effect.THIRD_EYE);
-        return true;
+        target:delStatusEffect(tpz.effect.THIRD_EYE)
+        return true
     end
 
-    return false;
-end;
+    return false
+end
 
 -----------------------------------
 --     SKILL LEVEL CALCULATOR
@@ -129,240 +129,240 @@ end;
 
 function utils.getSkillLvl(rank,level)
 
-    local skill = 0; --Failsafe
+    local skill = 0 --Failsafe
 
     if (level <= 50) then --Levels 1-50
         if (rank == 1 or rank == 2) then --A-Rated Skill
-            skill = (((level-1)*3)+6);
+            skill = (((level-1)*3)+6)
         elseif (rank == 3 or rank == 4 or rank == 5) then --B-Rated Skill
-            skill = (((level-1)*2.9)+5);
+            skill = (((level-1)*2.9)+5)
         elseif (rank == 6 or rank == 7 or rank == 8) then --C-Rated Skill
-            skill = (((level-1)*2.8)+5);
+            skill = (((level-1)*2.8)+5)
         elseif (rank == 9) then --D-Rated Skill
-            skill = (((level-1)*2.7)+4);
+            skill = (((level-1)*2.7)+4)
         elseif (rank == 10) then --E-Rated Skill
-            skill = (((level-1)*2.5)+4);
+            skill = (((level-1)*2.5)+4)
         elseif (rank == 11) then --F-Rated Skill
-            skill = (((level-1)*2.3)+4);
+            skill = (((level-1)*2.3)+4)
         end
     elseif (level > 50 and level <= 60) then --Levels 51-60
         if (rank == 1 or rank == 2) then --A-Rated Skill
-            skill = (((level-50)*5)+153);
+            skill = (((level-50)*5)+153)
         elseif (rank == 3 or rank == 4 or rank == 5) then --B-Rated Skill
-            skill = (((level-50)*4.9)+147);
+            skill = (((level-50)*4.9)+147)
         elseif (rank == 6 or rank == 7 or rank == 8) then --C-Rated Skill
-            skill = (((level-50)*4.8)+142);
+            skill = (((level-50)*4.8)+142)
         elseif (rank == 9) then --D-Rated Skill
-            skill = (((level-50)*4.7)+136);
+            skill = (((level-50)*4.7)+136)
         elseif (rank == 10) then --E-Rated Skill
-            skill = (((level-50)*4.5)+126);
+            skill = (((level-50)*4.5)+126)
         elseif (rank == 11) then --F-Rated Skill
-            skill = (((level-50)*4.3)+116);
+            skill = (((level-50)*4.3)+116)
         end
     elseif (level > 60 and level <= 70) then --Levels 61-70
         if (rank == 1) then --A+ Rated Skill
-            skill = (((level-60)*4.85)+203);
+            skill = (((level-60)*4.85)+203)
         elseif (rank == 2) then --A- Rated Skill
-            skill = (((level-60)*4.10)+203);
+            skill = (((level-60)*4.10)+203)
         elseif (rank == 3) then --B+ Rated Skill
-            skill = (((level-60)*3.70)+196);
+            skill = (((level-60)*3.70)+196)
         elseif (rank == 4) then --B Rated Skill
-            skill = (((level-60)*3.23)+196);
+            skill = (((level-60)*3.23)+196)
         elseif (rank == 5) then --B- Rated Skill
-            skill = (((level-60)*2.70)+196);
+            skill = (((level-60)*2.70)+196)
         elseif (rank == 6) then --C+ Rated Skill
-            skill = (((level-60)*2.50)+190);
+            skill = (((level-60)*2.50)+190)
         elseif (rank == 7) then --C Rated Skill
-            skill = (((level-60)*2.25)+190);
+            skill = (((level-60)*2.25)+190)
         elseif (rank == 8) then --C- Rated Skill
-            skill = (((level-60)*2.00)+190);
+            skill = (((level-60)*2.00)+190)
         elseif (rank == 9) then --D Rated Skill
-            skill = (((level-60)*1.85)+183);
+            skill = (((level-60)*1.85)+183)
         elseif (rank == 10) then --E Rated Skill
-            skill = (((level-60)*1.95)+171);
+            skill = (((level-60)*1.95)+171)
         elseif (rank == 11) then --F Rated Skill
-            skill = (((level-60)*2.05)+159);
+            skill = (((level-60)*2.05)+159)
         end
     else --Level 71 and above
         if (rank == 1) then --A+ Rated Skill
-            skill = (((level-70)*5)+251);
+            skill = (((level-70)*5)+251)
         elseif (rank == 2) then --A- Rated Skill
-            skill = (((level-70)*5)+244);
+            skill = (((level-70)*5)+244)
         elseif (rank == 3) then --B+ Rated Skill
-            skill = (((level-70)*3.70)+233);
+            skill = (((level-70)*3.70)+233)
         elseif (rank == 4) then --B Rated Skill
-            skill = (((level-70)*3.23)+228);
+            skill = (((level-70)*3.23)+228)
         elseif (rank == 5) then --B- Rated Skill
-            skill = (((level-70)*2.70)+223);
+            skill = (((level-70)*2.70)+223)
         elseif (rank == 6) then --C+ Rated Skill
-            skill = (((level-70)*3)+215);
+            skill = (((level-70)*3)+215)
         elseif (rank == 7) then --C Rated Skill
-            skill = (((level-70)*2.6)+212);
+            skill = (((level-70)*2.6)+212)
         elseif (rank == 8) then --C- Rated Skill
-            skill = (((level-70)*2.00)+210);
+            skill = (((level-70)*2.00)+210)
         elseif (rank == 9) then --D Rated Skill
-            skill = (((level-70)*1.85)+201);
+            skill = (((level-70)*1.85)+201)
         elseif (rank == 10) then --E Rated Skill
-            skill = (((level-70)*1.95)+190);
+            skill = (((level-70)*1.95)+190)
         elseif (rank == 11) then --F Rated Skill
-            skill = (((level-70)*2)+179);
+            skill = (((level-70)*2)+179)
         end
     end
 
-    return skill;
+    return skill
 
-end;
+end
 
 function utils.getMobSkillLvl(rank, level)
      if(level > 50) then
          if(rank == 1) then
-             return 153+(level-50)*5.0;
+             return 153+(level-50)*5.0
          end
          if(rank == 2) then
-             return 147+(level-50)*4.9;
+             return 147+(level-50)*4.9
          end
          if(rank == 3) then
-             return 136+(level-50)*4.8;
+             return 136+(level-50)*4.8
          end
          if(rank == 4) then
-             return 126+(level-50)*4.7;
+             return 126+(level-50)*4.7
          end
          if(rank == 5) then
-             return 116+(level-50)*4.5;
+             return 116+(level-50)*4.5
          end
          if(rank == 6) then
-             return 106+(level-50)*4.4;
+             return 106+(level-50)*4.4
          end
          if(rank == 7) then
-             return 96+(level-50)*4.3;
+             return 96+(level-50)*4.3
          end
      end
 
      if(rank == 1) then
-         return 6+(level-1)*3.0;
+         return 6+(level-1)*3.0
      end
      if(rank == 2) then
-         return 5+(level-1)*2.9;
+         return 5+(level-1)*2.9
      end
      if(rank == 3) then
-         return 5+(level-1)*2.8;
+         return 5+(level-1)*2.8
      end
      if(rank == 4) then
-         return 4+(level-1)*2.7;
+         return 4+(level-1)*2.7
      end
      if(rank == 5) then
-         return 4+(level-1)*2.5;
+         return 4+(level-1)*2.5
      end
      if(rank == 6) then
-         return 3+(level-1)*2.4;
+         return 3+(level-1)*2.4
      end
      if(rank == 7) then
-         return 3+(level-1)*2.3;
+         return 3+(level-1)*2.3
      end
-    return 0;
-end;
+    return 0
+end
 
 -- Returns 1 if attacker has a bonus
 -- Returns 0 no bonus
 -- Returns -1 if weak against
 function utils.getSystemStrengthBonus(attacker, defender)
-    local attackerSystem = attacker:getSystem();
-    local defenderSystem = defender:getSystem();
+    local attackerSystem = attacker:getSystem()
+    local defenderSystem = defender:getSystem()
 
     if (attackerSystem == tpz.eco.BEAST) then
         if (defenderSystem == tpz.eco.LIZARD) then
-            return 1;
+            return 1
         elseif (defenderSystem == tpz.eco.PLANTOID) then
-            return -1;
+            return -1
         end
     end
 
     if (attackerSystem == tpz.eco.LIZARD) then
         if (defenderSystem == tpz.eco.VERMIN) then
-            return 1;
+            return 1
         elseif (defenderSystem == tpz.eco.BEAST) then
-            return -1;
+            return -1
         end
     end
 
     if (attackerSystem == tpz.eco.VERMIN) then
         if (defenderSystem == tpz.eco.PLANTOID) then
-            return 1;
+            return 1
         elseif (defenderSystem == tpz.eco.LIZARD) then
-            return -1;
+            return -1
         end
     end
 
     if (attackerSystem == tpz.eco.PLANTOID) then
         if (defenderSystem == tpz.eco.BEAST) then
-            return 1;
+            return 1
         elseif (defenderSystem == tpz.eco.VERMIN) then
-            return -1;
+            return -1
         end
     end
 
     if (attackerSystem == tpz.eco.AQUAN) then
         if (defenderSystem == tpz.eco.AMORPH) then
-            return 1;
+            return 1
         elseif (defenderSystem == tpz.eco.BIRD) then
-            return -1;
+            return -1
         end
     end
 
     if (attackerSystem == tpz.eco.AMORPH) then
         if (defenderSystem == tpz.eco.BIRD) then
-            return 1;
+            return 1
         elseif (defenderSystem == tpz.eco.AQUAN) then
-            return -1;
+            return -1
         end
     end
 
     if (attackerSystem == tpz.eco.BIRD) then
         if (defenderSystem == tpz.eco.AQUAN) then
-            return 1;
+            return 1
         elseif (defenderSystem == tpz.eco.AMORPH) then
-            return -1;
+            return -1
         end
     end
 
     if (attackerSystem == tpz.eco.UNDEAD) then
         if (defenderSystem == tpz.eco.ARCANA) then
-            return 1;
+            return 1
         end
     end
 
     if (attackerSystem == tpz.eco.ARCANA) then
         if (defenderSystem == tpz.eco.UNDEAD) then
-            return 1;
+            return 1
         end
     end
 
     if (attackerSystem == tpz.eco.DRAGON) then
         if (defenderSystem == tpz.eco.DEMON) then
-            return 1;
+            return 1
         end
     end
 
     if (attackerSystem == tpz.eco.DEMON) then
         if (defenderSystem == tpz.eco.DRAGON) then
-            return 1;
+            return 1
         end
     end
 
     if (attackerSystem == tpz.eco.LUMORIAN) then
         if (defenderSystem == tpz.eco.LUMINION) then
-            return 1;
+            return 1
         end
     end
 
     if (attackerSystem == tpz.eco.LUMINION) then
         if (defenderSystem == tpz.eco.LUMORIAN) then
-            return 1;
+            return 1
         end
     end
 
-    return 0;
-end;
+    return 0
+end
 
 -------------------------------------------------------
 -- Returns true if player has any tier of given relic,

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -112,7 +112,7 @@ function calculateRawWSDmg(attacker, target, wsID, tp, action, wsParams, calcPar
         end
 
         -- Add on native crit hit rate (guesstimated, it actually follows an exponential curve)
-        nativecrit = (attacker:getStat(tpz.mod.DEX) - target:getStat(tpz.mod.AGI))*0.005; -- assumes +0.5% crit rate per 1 dDEX
+        nativecrit = (attacker:getStat(tpz.mod.DEX) - target:getStat(tpz.mod.AGI))*0.005 -- assumes +0.5% crit rate per 1 dDEX
         if (nativecrit > 0.2) then -- caps only apply to base rate, not merits and mods
             nativecrit = 0.2
         elseif (nativecrit < 0.05) then
@@ -143,7 +143,7 @@ function calculateRawWSDmg(attacker, target, wsID, tp, action, wsParams, calcPar
     hitdmg, calcParams = getSingleHitDamage(attacker, target, dmg, wsParams, calcParams)
     finaldmg = finaldmg + hitdmg
 
-    -- Have to calculate added bonus for SA/TA here; since it is done outside of the fTP multiplier
+    -- Have to calculate added bonus for SA/TA here since it is done outside of the fTP multiplier
     if attacker:getMainJob() == tpz.job.THF then
         -- Add DEX/AGI bonus to first hit if THF main and valid Sneak/Trick Attack
         if calcParams.sneakApplicable then 
@@ -649,7 +649,7 @@ function fTP(tp,ftp1,ftp2,ftp3)
     else
         print("fTP error: TP value is not between 1000-3000!")
     end
-    return 1; -- no ftp mod
+    return 1 -- no ftp mod
 end
 
 function calculatedIgnoredDef(tp, def, ignore1, ignore2, ignore3)
@@ -658,7 +658,7 @@ function calculatedIgnoredDef(tp, def, ignore1, ignore2, ignore3)
     elseif (tp>=2000 and tp<=3000) then
         return (ignore2 + ( ((ignore3-ignore2)/1000) * (tp-2000)))*def
     end
-    return 1; -- no def ignore mod
+    return 1 -- no def ignore mod
 end
 
 -- Given the raw ratio value (atk/def) and levels, returns the cRatio (min then max)
@@ -928,7 +928,7 @@ function getAlpha(level)
     elseif (level < 99) then
         alpha = 0.85
     else
-        alpha = 1; 
+        alpha = 1 
     end
     return alpha
 end
@@ -944,7 +944,7 @@ function getMultiAttacks(attacker, target, numHits)
 
     -- Add Ambush Augments to Triple Attack
     if (attacker:hasTrait(76) and attacker:isBehind(target, 23)) then -- TRAIT_AMBUSH
-        tripleRate = tripleRate + attacker:getMerit(tpz.merit.AMBUSH) / 3; -- Value of Ambush is 3 per mert, augment gives +1 Triple Attack per merit
+        tripleRate = tripleRate + attacker:getMerit(tpz.merit.AMBUSH) / 3 -- Value of Ambush is 3 per mert, augment gives +1 Triple Attack per merit
     end
 
     -- QA/TA/DA can only proc on the first hit of each weapon or each fist


### PR DESCRIPTION
Command applied:
find . -type f -name "*.lua" | xargs -d '\n' sed -i 's/;//g'

Semicolons are not appropriate in Lua per the style guidelines:
https://github.com/project-topaz/topaz/blob/master/CONTRIBUTING.md

NOTE: I skipped /globals/weaponskills for now, since many files have
a valid use of semicolons (for multiple statements on the same line).
I'll audit those separately.

This change is just a style change, no functionality has been changed.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](https://github.com/project-topaz/topaz/blob/master/CONTRIBUTOR_AGREEMENT.md), as written on this date