### PR TITLE
no longer need mobmod with no xp pull for bcnms

### DIFF
--- a/scripts/zones/Horlais_Peak/mobs/Cottontail.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Cottontail.lua
@@ -6,10 +6,6 @@
 require("scripts/globals/status")
 -----------------------------------
 
-function onMobInitialize(mob)
-    mob:setMobMod(tpz.mobMod.NO_DROPS, 1)
-end
-
 function onMobSpawn(mob) 
  	mob:setMobMod(tpz.mobMod.CHARMABLE, 1)
 end

--- a/scripts/zones/Horlais_Peak/mobs/Helltail_Harry.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Helltail_Harry.lua
@@ -6,14 +6,10 @@
 require("scripts/globals/status")
 -----------------------------------
 
-function onMobInitialize(mob)
-    mob:setMobMod(tpz.mobMod.NO_DROPS, 1)
-end
-
 function onMobSpawn(mob)
-    mob:setMod(tpz.mod.SLEEPRES, 1000) -- needs to be set as full immunity but worried that setting it will knock out chance of lullaby 
+    mob:setMod(tpz.mod.SLEEPRES, 1000) 
     mob:setMod(tpz.mod.SILENCERES, 900)
-    mob:setMod(tpz.mod.LULLABYRES, 700) -- this is for lullaby since he can be slept with it, just not easily
+    mob:setMod(tpz.mod.LULLABYRES, 700)
 end
 
 function onMobDeath(mob, player, isKiller)


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](https://github.com/project-topaz/topaz/blob/master/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

with the PR that gave no exp in a bcnm battlefield this mob mod is now void