### PR TITLE
Docking Message when traveling to Nashmau and Al Zahbi

### DIFF
--- a/scripts/globals/transport.lua
+++ b/scripts/globals/transport.lua
@@ -1,0 +1,36 @@
+------------------------------------
+-- Transport
+------------------------------------
+require("scripts/globals/zone")
+------------------------------------
+
+tpz = tpz or {}
+tpz.transport = tpz.transport or {}
+
+tpz.transport.message =
+{
+    NEARING = 0,
+    DOCKING = 1
+}
+
+tpz.transport.epochOffset =
+{
+    NEARING = 265,
+    DOCKING = 290
+}
+
+tpz.transport.messageTime =
+{
+    SILVER_SEA = 480
+}
+
+-------------------------------------------------
+-- public functions
+-------------------------------------------------
+
+tpz.transport.captainMessage = function(npc, triggerID, messages)
+    local playersInZone = npc:getZone():getPlayers()
+    for _, player in pairs(playersInZone) do
+        player:showText(player, messages[triggerID])
+    end
+end

--- a/scripts/zones/Silver_Sea_route_to_Al_Zahbi/IDs.lua
+++ b/scripts/zones/Silver_Sea_route_to_Al_Zahbi/IDs.lua
@@ -15,6 +15,8 @@ zones[tpz.zone.SILVER_SEA_ROUTE_TO_AL_ZAHBI] =
         GIL_OBTAINED            = 6389, -- Obtained <number> gil.
         KEYITEM_OBTAINED        = 6391, -- Obtained key item: <keyitem>.
         FISHING_MESSAGE_OFFSET  = 7049, -- You can't fish here.
+        DOCKING_IN_AL_ZAHBI     = 7309, -- We are now docking in Al Zahbi.
+        NEARING_AL_ZAHBI        = 7310, -- We are nearing Al Zahbi.
         YAHLIQ_SHOP_DIALOG      = 7312, -- You've picked the best place to shop for your items, guaranteed!
         ON_WAY_TO_AL_ZAHBI      = 7313, -- We are on our way to Al Zahbi. We will be arriving soon.
     },

--- a/scripts/zones/Silver_Sea_route_to_Al_Zahbi/npcs/Shadeeu.lua
+++ b/scripts/zones/Silver_Sea_route_to_Al_Zahbi/npcs/Shadeeu.lua
@@ -4,18 +4,34 @@
 -- Notes: Tells ship ETA time
 -- !pos 0.340 -12.232 -4.120 58
 -----------------------------------
-local ID = require("scripts/zones/Silver_Sea_route_to_Al_Zahbi/IDs");
+local ID = require("scripts/zones/Silver_Sea_route_to_Al_Zahbi/IDs")
+require("scripts/globals/transport")
 -----------------------------------
 
+local messages =
+{
+    [tpz.transport.message.NEARING] = ID.text.NEARING_AL_ZAHBI,
+    [tpz.transport.message.DOCKING] = ID.text.DOCKING_IN_AL_ZAHBI
+}
+
+function onSpawn(npc)
+    npc:addPeriodicTrigger(tpz.transport.message.NEARING, tpz.transport.messageTime.SILVER_SEA, tpz.transport.epochOffset.NEARING)
+    npc:addPeriodicTrigger(tpz.transport.message.DOCKING, tpz.transport.messageTime.SILVER_SEA, tpz.transport.epochOffset.DOCKING)
+end
+
+function onTimeTrigger(npc, triggerID)
+    tpz.transport.captainMessage(npc, triggerID, messages)
+end
+
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    player:messageSpecial(ID.text.ON_WAY_TO_AL_ZAHBI,0,0); -- Earth Time, Vana Hours. Needs a get-time function for boat?
-end;
+    player:messageSpecial(ID.text.ON_WAY_TO_AL_ZAHBI,0,0) -- Earth Time, Vana Hours. Needs a get-time function for boat?
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-end;
+end

--- a/scripts/zones/Silver_Sea_route_to_Nashmau/IDs.lua
+++ b/scripts/zones/Silver_Sea_route_to_Nashmau/IDs.lua
@@ -15,6 +15,8 @@ zones[tpz.zone.SILVER_SEA_ROUTE_TO_NASHMAU] =
         GIL_OBTAINED            = 6389, -- Obtained <number> gil.
         KEYITEM_OBTAINED        = 6391, -- Obtained key item: <keyitem>.
         FISHING_MESSAGE_OFFSET  = 7049, -- You can't fish here.
+        DOCKING_IN_NASHMAU      = 7309, -- We are now docking in Nashmau.
+        NEARING_NASHMAU         = 7310, -- We are nearing Nashmau.
         JIDWAHN_SHOP_DIALOG     = 7312, -- Would you care for some items to use on your travels?
         ON_WAY_TO_NASHMAU       = 7313, -- We are on our way to Nashmau. We will be arriving soon.
     },

--- a/scripts/zones/Silver_Sea_route_to_Nashmau/Zone.lua
+++ b/scripts/zones/Silver_Sea_route_to_Nashmau/Zone.lua
@@ -7,26 +7,26 @@ local ID = require("scripts/zones/Silver_Sea_route_to_Nashmau/IDs")
 -----------------------------------
 
 function onInitialize(zone)
-end;
+end
 
 function onZoneIn(player,prevZone)
-    local cs = -1;
+    local cs = -1
 
-    return cs;
-end;
+    return cs
+end
 
 function onTransportEvent(player,transport)
-    player:startEvent(1025);
-end;
+    player:startEvent(1025)
+end
 
 function onRegionEnter(player,region)
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
     if (csid == 1025) then
-        player:setPos(0,0,0,0,53);
+        player:setPos(0,0,0,0,53)
     end
-end;
+end

--- a/scripts/zones/Silver_Sea_route_to_Nashmau/npcs/Qudamahf.lua
+++ b/scripts/zones/Silver_Sea_route_to_Nashmau/npcs/Qudamahf.lua
@@ -4,18 +4,34 @@
 -- Notes: Tells ship ETA time
 -- !pos 0.340 -12.232 -4.120 58
 -----------------------------------
-local ID = require("scripts/zones/Silver_Sea_route_to_Nashmau/IDs");
+local ID = require("scripts/zones/Silver_Sea_route_to_Nashmau/IDs")
+require("scripts/globals/transport")
 -----------------------------------
 
+local messages =
+{
+    [tpz.transport.message.NEARING] = ID.text.NEARING_NASHMAU,
+    [tpz.transport.message.DOCKING] = ID.text.DOCKING_IN_NASHMAU
+}
+
+function onSpawn(npc)
+    npc:addPeriodicTrigger(tpz.transport.message.NEARING, tpz.transport.messageTime.SILVER_SEA, tpz.transport.epochOffset.NEARING)
+    npc:addPeriodicTrigger(tpz.transport.message.DOCKING, tpz.transport.messageTime.SILVER_SEA, tpz.transport.epochOffset.DOCKING)
+end
+
+function onTimeTrigger(npc, triggerID)
+    tpz.transport.captainMessage(npc, triggerID, messages)
+end
+
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    player:messageSpecial(ID.text.ON_WAY_TO_NASHMAU,0,0); -- Earth Time, Vana Hours. Needs a get-time function for boat?
-end;
+    player:messageSpecial(ID.text.ON_WAY_TO_NASHMAU,0,0) -- Earth Time, Vana Hours. Needs a get-time function for boat?
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-end;
+end


### PR DESCRIPTION
Added ID for message (as it's not part of CS) for boat silver sea routes
added onspawn on boat captains that handle triggers based on vana epoch
create transport global (so it can be used for other boats and airships)
also removed semicolons for those files

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](https://github.com/project-topaz/topaz/blob/master/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

