### PR TITLE
Remove mounted status when attacking

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -655,6 +655,11 @@ void SmallPacket0x01A(map_session_data_t* session, CCharEntity* PChar, CBasicPac
     break;
     case 0x02: // attack
     {
+        if (PChar->isMounted())
+        {
+            PChar->StatusEffectContainer->DelStatusEffectSilent(EFFECT_MOUNTED);
+        }
+
         PChar->PAI->Engage(TargID);
     }
     break;


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](https://github.com/project-topaz/topaz/blob/master/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

This closes https://github.com/project-topaz/topaz/issues/412
(The bug I made earlier)