### PR TITLE
make all NMs not charmable

### DIFF
--- a/src/map/instance_loader.cpp
+++ b/src/map/instance_loader.cpp
@@ -230,6 +230,14 @@ CInstance* CInstanceLoader::LoadInstance(CInstance* instance)
 
             PMob->setMobMod(MOBMOD_CHARMABLE, Sql_GetUIntData(SqlInstanceHandle, 65));
 
+            // Overwrite base family charmables depending on mob type. Disallowed mobs which should be charmable
+            // can be set in mob_spawn_mods or in their onInitialize
+            if (PMob->m_Type & MOBTYPE_EVENT || PMob->m_Type & MOBTYPE_FISHED || PMob->m_Type & MOBTYPE_BATTLEFIELD ||
+                PMob->m_Type & MOBTYPE_NOTORIOUS)
+            {
+                PMob->setMobMod(MOBMOD_CHARMABLE, 0);
+            }
+
             // must be here first to define mobmods
             mobutils::InitializeMob(PMob, zone);
             PMob->PInstance = instance;

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -562,7 +562,7 @@ void CalculateStats(CMobEntity * PMob)
     }
 
     if(PMob->m_Type & MOBTYPE_EVENT || PMob->m_Type & MOBTYPE_FISHED || PMob->m_Type & MOBTYPE_BATTLEFIELD ||
-        zoneType == ZONETYPE_BATTLEFIELD || zoneType == ZONETYPE_DYNAMIS)
+        PMob->m_Type & MOBTYPE_NOTORIOUS || zoneType == ZONETYPE_BATTLEFIELD || zoneType == ZONETYPE_DYNAMIS)
     {
         PMob->setMobMod(MOBMOD_CHARMABLE, 0);
     }

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -561,12 +561,6 @@ void CalculateStats(CMobEntity * PMob)
         PMob->ResetGilPurse();
     }
 
-    if(PMob->m_Type & MOBTYPE_EVENT || PMob->m_Type & MOBTYPE_FISHED || PMob->m_Type & MOBTYPE_BATTLEFIELD ||
-        PMob->m_Type & MOBTYPE_NOTORIOUS || zoneType == ZONETYPE_BATTLEFIELD || zoneType == ZONETYPE_DYNAMIS)
-    {
-        PMob->setMobMod(MOBMOD_CHARMABLE, 0);
-    }
-
     // Check for possible miss-setups
     if (PMob->getMobMod(MOBMOD_SPECIAL_SKILL) != 0 && PMob->getMobMod(MOBMOD_SPECIAL_COOL) == 0)
     {

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -367,8 +367,9 @@ void LoadMOBList()
         while (Sql_NextRow(SqlHandle) == SQL_SUCCESS)
         {
             uint16 ZoneID = (uint16)Sql_GetUIntData(SqlHandle, 0);
+            ZONETYPE zoneType = GetZone(ZoneID)->GetType();
 
-            if (GetZone(ZoneID)->GetType() != ZONETYPE_DUNGEON_INSTANCED)
+            if (zoneType != ZONETYPE_DUNGEON_INSTANCED)
             {
                 CMobEntity* PMob = new CMobEntity;
 
@@ -492,6 +493,14 @@ void LoadMOBList()
                 PMob->m_Detects = Sql_GetUIntData(SqlHandle, 66);
 
                 PMob->setMobMod(MOBMOD_CHARMABLE, Sql_GetUIntData(SqlHandle, 67));
+
+                // Overwrite base family charmables depending on mob type. Disallowed mobs which should be charmable
+                // can be set in mob_spawn_mods or in their onInitialize
+                if (PMob->m_Type & MOBTYPE_EVENT || PMob->m_Type & MOBTYPE_FISHED || PMob->m_Type & MOBTYPE_BATTLEFIELD ||
+                    PMob->m_Type & MOBTYPE_NOTORIOUS || zoneType == ZONETYPE_BATTLEFIELD || zoneType == ZONETYPE_DYNAMIS)
+                {
+                    PMob->setMobMod(MOBMOD_CHARMABLE, 0);
+                }
 
                 // must be here first to define mobmods
                 mobutils::InitializeMob(PMob, GetZone(ZoneID));


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](https://github.com/project-topaz/topaz/blob/master/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

not all NMs were being tagged on initialize for being uncharmable. this will correct that.
if you need a NM to be charmable will have to tag it with mobMod Charmable, 1 anywhere in script beside onMobInitialize