### PR TITLE
Fix buying Magicked Astrolabe

### DIFF
--- a/scripts/zones/Windurst_Waters/npcs/Churano-Shurano.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Churano-Shurano.lua
@@ -1,37 +1,45 @@
 -----------------------------------
 -- Area: Windurst Waters
 --  NPC: Churano-Shurano
--- Working 100%
+-- !pos -60.8 -11.2 98.9 238
 -----------------------------------
-local ID = require("scripts/zones/Windurst_Waters/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
+local ID = require("scripts/zones/Windurst_Waters/IDs")
+require("scripts/globals/settings")
+require("scripts/globals/keyitems")
+require("scripts/globals/npc_util")
 -----------------------------------
 
-function onTrade(player,npc,trade)
-end;
+function onTrade(player, npc, trade)
+end
 
 function onTrigger(player,npc)
-    if (player:hasKeyItem(tpz.ki.MAGICKED_ASTROLABE) == false) then
-        local cost = 10000;
-        if (player:getCharVar("Astrolabe") == 0) then
-            player:startEvent(1080, cost);
+    if not player:hasKeyItem(tpz.ki.MAGICKED_ASTROLABE) then
+        local cost = 10000
+        if player:getLocalVar("Astrolabe") == 0 then
+            player:startEvent(1080, cost)
         else
-            player:startEvent(1081, cost);
+            player:startEvent(1081, cost)
         end
     else
-        player:startEvent(280);
+        player:startEvent(280)
     end
-end;
+end
 
-function onEventUpdate(player,csid,option)
-end;
-
-function onEventFinish(player,csid,option)
-    if (csid == 1080 and option == 1) then
-        player:setCharVar("Astrolabe", 1);
-    elseif (csid == 1081 and option == 1 and player:delGil(10000)) then
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED,tpz.ki.MAGICKED_ASTROLABE);
-        player:addKeyItem(tpz.ki.MAGICKED_ASTROLABE);
+function onEventUpdate(player, csid, option)
+    if csid == 1080 or csid == 1081 then
+        if option == 1 and player:getGil() >= 10000 then
+            player:updateEvent(tpz.ki.MAGICKED_ASTROLABE)
+        else
+            player:updateEvent(0)
+        end
     end
-end;
+end
+
+function onEventFinish(player, csid, option)
+    if csid == 1080 and option ~= tpz.ki.MAGICKED_ASTROLABE then
+        player:setLocalVar("Astrolabe", 1)
+    elseif (csid == 1080 or csid == 1081) and option == tpz.ki.MAGICKED_ASTROLABE and player:getGil() >= 10000 then
+        npcUtil.giveKeyItem(player, tpz.ki.MAGICKED_ASTROLABE)
+        player:delGil(10000)
+    end
+end


### PR DESCRIPTION
The first param for the event update dictates the option sent by the client back to the server onEventFinish. It needed to be the key item ID for the Astrolabe for the event to not display the "partial payment" line.

Fixes #418 

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](https://github.com/project-topaz/topaz/blob/master/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

