### PR TITLE
Fix gil split with treasure chests

### DIFF
--- a/scripts/globals/treasure.lua
+++ b/scripts/globals/treasure.lua
@@ -1475,10 +1475,8 @@ tpz.treasure.onTrade = function(player, npc, trade, chestType)
         local gilAmount = math.random(info.gil[2], info.gil[3])
         local gil = gilAmount/#membersInZone
         for i = 1, #membersInZone do
-            if player:getZoneID() == membersInZone[i]:getZoneID() then
-                membersInZone[i]:addGil(gil)
-                membersInZone[i]:messageSpecial(ID.text.GIL_OBTAINED, gil)
-            end
+            membersInZone[i]:addGil(gil)
+            membersInZone[i]:messageSpecial(ID.text.GIL_OBTAINED, gil)
         end
 
     -- gem

--- a/scripts/globals/treasure.lua
+++ b/scripts/globals/treasure.lua
@@ -1465,18 +1465,19 @@ tpz.treasure.onTrade = function(player, npc, trade, chestType)
 
     -- gil
     if roll <= info.gil[1] then
-        players = player:getParty()
-        for i = 1, #players, 1 do
-            if player:getZoneID() ~= players[i]:getZoneID() then
-                table.remove(players, i)
+        local partyMembers = player:getAlliance()
+        local membersInZone = {}
+        for i = 1, #partyMembers do
+            if player:getZoneID() == partyMembers[i]:getZoneID() then
+                table.insert(membersInZone, partyMembers[i])
             end
         end
         local gilAmount = math.random(info.gil[2], info.gil[3])
-        local gil = gilAmount/#players
-        for i = 1, #players, 1 do
-            if player:getZoneID() == players[i]:getZoneID() then
-                players[i]:addGil(gil)
-                players[i]:messageSpecial(ID.text.GIL_OBTAINED, gil)
+        local gil = gilAmount/#membersInZone
+        for i = 1, #membersInZone do
+            if player:getZoneID() == membersInZone[i]:getZoneID() then
+                membersInZone[i]:addGil(gil)
+                membersInZone[i]:messageSpecial(ID.text.GIL_OBTAINED, gil)
             end
         end
 


### PR DESCRIPTION
table.remove was messing up index causing out of range errors,
also split gil with alliance and not just party.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

