### PR TITLE
Fix starting WOTG maw events

### DIFF
--- a/scripts/globals/maws.lua
+++ b/scripts/globals/maws.lua
@@ -63,6 +63,7 @@ tpz.maws.onTrigger = function(player, npc)
     local maw = pastMaws[player:getZoneID()]
     local hasMaw = player:hasTeleport(MAW, maw.bit)
     local event = nil
+    local event_params = nil
 
     if maw.cs.msn and meetsMission2Reqs(player) then
         event = maw.cs.msn
@@ -72,13 +73,18 @@ tpz.maws.onTrigger = function(player, npc)
         local hasFeather = player:hasKeyItem(tpz.ki.PURE_WHITE_FEATHER)
         if maw.cs.new and not hasFeather then
             event = maw.cs.new
+            event_params = {maw.bit}
         elseif maw.cs.add then
             event = maw.cs.add
         end
     end
 
     if event then
-        player:startEvent(event)
+        if event_params then
+            player:startEvent(event, unpack(event_params))
+        else
+            player:startEvent(event)
+        end
     else
         player:messageSpecial(ID.text.NOTHING_HAPPENS)
     end


### PR DESCRIPTION
Client expects a param for these events and will hang if it doesn't get them. Params were in the original maw files, but got lost during the teleport refactor. Batallia's maw has been working this whole time due to the client expecting a param of zero for that zone, but Sauromuge and Rolanberry have not.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

