### PR TITLE
Fix new GCC warning in Trust branch

### DIFF
--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -582,22 +582,6 @@ public:
     }
 
     template        <typename F, typename... Args>
-    void            ForPartyWithTrusts(F func, Args&&... args)
-    {
-        if (PParty) {
-            for (auto PMember : PParty->members) {
-                func(PMember, std::forward<Args>(args)...);
-                for (auto PTrust : static_cast<CCharEntity*>(PMember)->PTrusts) {
-                    func(PTrust, std::forward<Args>(args)...);
-                }
-            }
-        }
-        else {
-            func(this, std::forward<Args>(args)...);
-        }
-    }
-
-    template        <typename F, typename... Args>
     void            ForAlliance(F func, Args&&... args)
     {
         if (PParty) {

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -213,7 +213,21 @@ public:
     CAutomatonEntity*       PAutomaton;                     // Automaton statistics
 
     std::vector<CTrustEntity*> PTrusts; // Active trusts
-
+    template        <typename F, typename... Args>
+    void            ForPartyWithTrusts(F func, Args&&... args)
+    {
+        if (PParty) {
+            for (auto PMember : PParty->members) {
+                func(PMember, std::forward<Args>(args)...);
+                for (auto PTrust : static_cast<CCharEntity*>(PMember)->PTrusts) {
+                    func(PTrust, std::forward<Args>(args)...);
+                }
+            }
+        }
+        else {
+            func(this, std::forward<Args>(args)...);
+        }
+    }
 
     // These missions do not need a list of completed, because client automatically
     // displays earlier missions completed

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -8500,9 +8500,9 @@ inline int32 CLuaBaseEntity::getParty(lua_State* L)
 
 inline int32 CLuaBaseEntity::getPartyWithTrusts(lua_State* L)
 {
-    TPZ_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
 
-    CParty* party = ((CBattleEntity*)m_PBaseEntity)->PParty;
+    CParty* party = ((CCharEntity*)m_PBaseEntity)->PParty;
 
     int size = 0;
     if (party)
@@ -8516,7 +8516,7 @@ inline int32 CLuaBaseEntity::getPartyWithTrusts(lua_State* L)
 
     lua_createtable(L, size, 0);
     int i = 1;
-    ((CBattleEntity*)m_PBaseEntity)->ForPartyWithTrusts([&L, &i](CBattleEntity* member)
+    ((CCharEntity*)m_PBaseEntity)->ForPartyWithTrusts([&L, &i](CBattleEntity* member)
     {
         lua_getglobal(L, CLuaBaseEntity::className);
         lua_pushstring(L, "new");


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**Work:**
In hindsight, I shouldn't have been using `CCharEntity` stuff inside `CBattleEntity`. This moves `ForPartyWithTrusts()` into `CCharEntity` and blocks incorrect usage from the lua side with debug break.

**Tested:**
Summoning trusts, the only current use of this function.
Warning is gone 👍 