### PR TITLE
Fix pet claiming on initial hit

### DIFF
--- a/src/map/ai/states/ability_state.cpp
+++ b/src/map/ai/states/ability_state.cpp
@@ -83,8 +83,8 @@ void CAbilityState::ApplyEnmity()
             !(m_PAbility->getCE() == 0 && m_PAbility->getVE() == 0))
         {
             CMobEntity* mob = (CMobEntity*)PTarget;
-            battleutils::ClaimMob(mob, m_PEntity);
             mob->PEnmityContainer->UpdateEnmity(m_PEntity, m_PAbility->getCE(), m_PAbility->getVE(), false, m_PAbility->getID() == ABILITY_CHARM);
+            battleutils::ClaimMob(mob, m_PEntity);
         }
     }
     else if (PTarget->allegiance == m_PEntity->allegiance)

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -303,13 +303,13 @@ void CMagicState::ApplyEnmity(CBattleEntity* PTarget, int ce, int ve)
 
                 if (!(m_PSpell->isHeal()) || m_PSpell->tookEffect())  //can't claim mob with cure unless it does damage
                 {
+                    mob->PEnmityContainer->UpdateEnmity(m_PEntity, ce, ve);
+                    enmityApplied = true;
                     if (PTarget->isDead())
                     { // claim mob only on death (for aoe)
                         battleutils::ClaimMob(PTarget, m_PEntity);
                     }
                     battleutils::DirtyExp(PTarget, m_PEntity);
-                    mob->PEnmityContainer->UpdateEnmity(m_PEntity, ce, ve);
-                    enmityApplied = true;
                 }
             }
         }

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1336,7 +1336,10 @@ void CBattleEntity::OnCastFinished(CMagicState& state, action_t& action)
     }
     if ((!(PSpell->isHeal()) || PSpell->tookEffect()) && PActionTarget->isAlive())
     {
-        battleutils::ClaimMob(PActionTarget, this);
+        if (objtype != TYPE_PET)
+        {
+            battleutils::ClaimMob(PActionTarget, this);
+        }
     }
 
     // TODO: Pixies will probably break here, once they're added.

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1629,7 +1629,6 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
         if (actionTarget.reaction != REACTION_HIT && actionTarget.reaction != REACTION_BLOCK && actionTarget.reaction != REACTION_GUARD)
         {
             actionTarget.param = 0;
-            battleutils::ClaimMob(PTarget, this);
         }
 
         if (actionTarget.reaction != REACTION_EVADE && actionTarget.reaction != REACTION_PARRY)
@@ -1661,8 +1660,10 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
                 attackRound.DeleteAttackSwing();
         }
         else
+        {
             attackRound.DeleteAttackSwing();
-
+        }
+        battleutils::ClaimMob(PTarget, this);
         if (list.actionTargets.size() == 8)
         {
             break;

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -728,8 +728,9 @@ void CMobEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
         PTarget->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DETECTABLE);
     }
     PTarget = static_cast<CBattleEntity*>(state.GetTarget());
-    if (PTarget->isDead() || (objtype == TYPE_PET && static_cast<CPetEntity*>(this)->getPetType() == PETTYPE_AVATAR))
+    if (PTarget->objtype == TYPE_MOB && (PTarget->isDead() || (objtype == TYPE_PET && static_cast<CPetEntity*>(this)->getPetType() == PETTYPE_AVATAR)))
     {
+        static_cast<CMobEntity*>(PTarget)->PEnmityContainer->UpdateEnmity(this, 0, 0);
         battleutils::ClaimMob(PTarget, this);
     }
     battleutils::DirtyExp(PTarget, this);

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -1064,6 +1064,7 @@ void CMobEntity::OnCastFinished(CMagicState& state, action_t& action)
 bool CMobEntity::OnAttack(CAttackState& state, action_t& action)
 {
     static_cast<CMobController*>(PAI->GetController())->TapDeaggroTime();
+    auto PTarget = static_cast<CBattleEntity*>(state.GetTarget());
 
     if (getMobMod(MOBMOD_ATTACK_SKILL_LIST))
     {
@@ -1071,6 +1072,12 @@ bool CMobEntity::OnAttack(CAttackState& state, action_t& action)
     }
     else
     {
-        return CBattleEntity::OnAttack(state, action);
+        bool success = CBattleEntity::OnAttack(state, action);
+        if (success && PTarget && PTarget->objtype == TYPE_MOB)
+        {
+            static_cast<CMobEntity*>(PTarget)->PEnmityContainer->UpdateEnmity(this, 0, 0);
+            battleutils::ClaimMob(PTarget, this);
+        }
+        return success;
     }
 }

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -728,7 +728,7 @@ void CMobEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
         PTarget->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DETECTABLE);
     }
     PTarget = static_cast<CBattleEntity*>(state.GetTarget());
-    if (PTarget->isDead())
+    if (PTarget->isDead() || (objtype == TYPE_PET && static_cast<CPetEntity*>(this)->getPetType() == PETTYPE_AVATAR))
     {
         battleutils::ClaimMob(PTarget, this);
     }


### PR DESCRIPTION
Fixes various issues with pets and claiming. Applies initial enmity when pets attack so physical attacks now claim on the first hit, pet spells no longer claim, SMN bloodpacts now claim, other pet abilities no longer claim.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

