### PR TITLE
Fix Trust party size counting

### DIFF
--- a/scripts/globals/trust.lua
+++ b/scripts/globals/trust.lua
@@ -55,9 +55,8 @@ tpz.trust.canCast = function(caster, spell, not_allowed_trust_ids)
                         end
                     end
                 end
-            else
-                num_trusts = num_trusts + 1
             end
+            num_trusts = num_trusts + 1
         end
         num_pt = num_pt + 1
     end


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Just before I submitted my original Trust PR I jiggled the party and trust counting logic a bit and this got broken. Was picked up by @cocosolos.

Tested all my original scenarios, works as intended.


