### PR TITLE
mob UDMG fixes

### DIFF
--- a/scripts/zones/Dynamis-Xarcabard/mobs/Yang.lua
+++ b/scripts/zones/Dynamis-Xarcabard/mobs/Yang.lua
@@ -11,8 +11,8 @@ end;
 function onMobSpawn(mob)
     local dynaLord = GetMobByID(17330177);
     if (dynaLord:getLocalVar("physImmune") < 2) then -- both dragons have not been killed initially
-        dynaLord:addMod(tpz.mod.UDMGPHYS, 100);
-        dynaLord:addMod(tpz.mod.UDMGRANGE, 100);
+        dynaLord:setMod(tpz.mod.UDMGPHYS, -100);
+        dynaLord:setMod(tpz.mod.UDMGRANGE, -100);
         dynaLord:setLocalVar("physImmune", 0);
         mob:setSpawn(-364,-35.974,24.254); -- Reset Yang's spawn point to initial spot.
     else
@@ -39,8 +39,8 @@ function onMobDespawn(mob)
     -- localVars clear on death, so setting it on its partner
     Ying:setLocalVar("YangToD", os.time());
     if (dynaLord:getLocalVar("physImmune") == 0) then
-        dynaLord:delMod(tpz.mod.UDMGPHYS, 100);
-        dynaLord:delMod(tpz.mod.UDMGRANGE, 100);
+        dynaLord:setMod(tpz.mod.UDMGPHYS, 0);
+        dynaLord:setMod(tpz.mod.UDMGRANGE, 0);
         if (dynaLord:getLocalVar("magImmune") == 1) then -- other dragon is also dead
             dynaLord:setLocalVar("physImmune", 2);
             dynaLord:setLocalVar("magImmune", 2);

--- a/scripts/zones/Dynamis-Xarcabard/mobs/Ying.lua
+++ b/scripts/zones/Dynamis-Xarcabard/mobs/Ying.lua
@@ -11,8 +11,8 @@ end;
 function onMobSpawn(mob)
     local dynaLord = GetMobByID(17330177);
     if (dynaLord:getLocalVar("magImmune") < 2) then -- both dragons have not been killed initially
-        dynaLord:addMod(tpz.mod.UDMGMAGIC, 100);
-        dynaLord:addMod(tpz.mod.UDMGBREATH, 100);
+        dynaLord:setMod(tpz.mod.UDMGMAGIC, -100);
+        dynaLord:setMod(tpz.mod.UDMGBREATH, -100);
         dynaLord:setLocalVar("magImmune", 0);
         mob:setSpawn(-364,-35.661,17.254); -- Reset Ying's spawn point to initial spot.
     else
@@ -39,8 +39,8 @@ function onMobDespawn(mob)
     -- localVars clear on death, so setting it on its partner
     Yang:setLocalVar("YingToD", os.time());
     if (dynaLord:getLocalVar("magImmune") == 0) then
-        dynaLord:delMod(tpz.mod.UDMGMAGIC, 100);
-        dynaLord:delMod(tpz.mod.UDMGBREATH, 100);
+        dynaLord:setMod(tpz.mod.UDMGMAGIC, 0);
+        dynaLord:setMod(tpz.mod.UDMGBREATH, 0);
         if (dynaLord:getLocalVar("physImmune") == 1) then -- other dragon is also dead
             dynaLord:setLocalVar("physImmune", 2);
             dynaLord:setLocalVar("magImmune", 2);

--- a/scripts/zones/Wajaom_Woodlands/mobs/Tinnin.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Tinnin.lua
@@ -19,7 +19,7 @@ function onMobInitialize(mob)
     mob:setMobMod(tpz.mobMod.GIL_MAX, 30000)
     mob:setMobMod(tpz.mobMod.MUG_GIL, 8000)
     mob:setMobMod(tpz.mobMod.DRAW_IN, 1)
-    mob:setMod(tpz.mod.UDMGBREATH, 0) -- immune to breath damage
+    mob:setMod(tpz.mod.UDMGBREATH, -100) -- immune to breath damage
     mob:setMobMod(tpz.mobMod.IDLE_DESPAWN, 300)
 end
 


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Tinnin: should be immune to breath damage.

Dynamis Lord: should be immune to damage before initial Ying/Yang die, not take double damage. (Because Dynamis Lord is now force-popped, this code probably doesn't matter anymore)