### PR TITLE
Fixed Evisceration WS Quest

### DIFF
--- a/scripts/zones/Gustav_Tunnel/IDs.lua
+++ b/scripts/zones/Gustav_Tunnel/IDs.lua
@@ -19,6 +19,7 @@ zones[tpz.zone.GUSTAV_TUNNEL] =
         GEOMAGNETRON_ATTUNED     = 7010,  -- Your <keyitem> has been attuned to a geomagnetic fount in the corresponding locale.
         CONQUEST_BASE            = 7049,  -- Tallying conquest results...
         FISHING_MESSAGE_OFFSET   = 7208,  -- You can't fish here.
+        SENSE_OMINOUS_PRESENCE   = 7310,  -- You sense an ominous presence...
         REGIME_REGISTERED        = 9578,  -- New training regime registered!
         COMMON_SENSE_SURVIVAL    = 10662, -- It appears that you have arrived at a new survival guide provided by the Adventurers' Mutual Aid Network. Common sense dictates that you should now be able to teleport here from similar tomes throughout the world.
         PLAYER_OBTAINS_ITEM      = 10630, -- <name> obtains <item>!

--- a/scripts/zones/Kazham/npcs/Jakoh_Wahcondalo.lua
+++ b/scripts/zones/Kazham/npcs/Jakoh_Wahcondalo.lua
@@ -23,14 +23,14 @@ end
 function onTrigger(player,npc)
     local wsQuestEvent = tpz.wsquest.getTriggerEvent(wsQuest,player)
 
-    if (wsQuestEvent ~= nil) then
-        player:startEvent(wsQuestEvent)
-    elseif (player:getCurrentMission(ZILART) == tpz.mission.id.zilart.KAZAMS_CHIEFTAINESS) then
+    if (player:getCurrentMission(ZILART) == tpz.mission.id.zilart.KAZAMS_CHIEFTAINESS) then
         player:startEvent(114)
-    elseif (player:getCurrentMission(ZILART) == tpz.mission.id.zilart.THE_TEMPLE_OF_UGGALEPIH) then
-        player:startEvent(115)
     elseif (player:getCurrentMission(WINDURST) == tpz.mission.id.windurst.AWAKENING_OF_THE_GODS and player:getCharVar("MissionStatus") == 2) then
         player:startEvent(265)
+    elseif (wsQuestEvent ~= nil) then
+        player:startEvent(wsQuestEvent)
+    elseif (player:getCurrentMission(ZILART) == tpz.mission.id.zilart.THE_TEMPLE_OF_UGGALEPIH) then
+        player:startEvent(115)
     else
         player:startEvent(113)
     end


### PR DESCRIPTION
*Fixed server crash on NM spawn due to undefined text.
*Rearranged onTrigger order to prevent blocking Zilart/Windurst Mission progress until Evisceration quest is completed.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [X] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [X] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

