### PR TITLE
Claim drop grace period

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -484,6 +484,16 @@ void CMobController::CastSpell(SpellID spellid)
 
 void CMobController::DoCombatTick(time_point tick)
 {
+    if (PMob->m_OwnerID.targid != 0 && static_cast<CCharEntity*>(PMob->GetEntity(PMob->m_OwnerID.targid))->PClaimedMob != static_cast<CBattleEntity*>(PMob))
+    {
+        if (m_Tick >= m_DeclaimTime + 3s)
+        {
+            PMob->m_OwnerID.clean();
+            PMob->updatemask |= UPDATE_STATUS;
+        }
+    }
+
+
     HandleEnmity();
     PTarget = static_cast<CBattleEntity*>(PMob->GetEntity(PMob->GetBattleTargetID()));
 
@@ -995,6 +1005,11 @@ bool CMobController::CanAggroTarget(CBattleEntity* PTarget)
 void CMobController::TapDeaggroTime()
 {
     m_DeaggroTime = m_Tick;
+}
+
+void CMobController::TapDeclaimTime()
+{
+    m_DeclaimTime = m_Tick;
 }
 
 bool CMobController::Cast(uint16 targid, SpellID spellid)

--- a/src/map/ai/controllers/mob_controller.h
+++ b/src/map/ai/controllers/mob_controller.h
@@ -44,6 +44,7 @@ public:
 
     bool CanAggroTarget(CBattleEntity*);
     void TapDeaggroTime();
+    void TapDeclaimTime();
     virtual bool Cast(uint16 targid, SpellID spellid) override;
 
 protected:
@@ -81,6 +82,7 @@ private:
     time_point m_LastMobSkillTime;
     time_point m_LastSpecialTime;
     time_point m_DeaggroTime;
+    time_point m_DeclaimTime;
     time_point m_NeutralTime;
     time_point m_WaitTime;
 

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -620,6 +620,7 @@ bool CCharEntity::CanUseSpell(CSpell* PSpell)
 
 void CCharEntity::OnChangeTarget(CBattleEntity* PNewTarget)
 {
+    battleutils::RelinquishClaim(this);
     pushPacket(new CLockOnPacket(this, PNewTarget));
     PLatentEffectContainer->CheckLatentsTargetChange();
 }
@@ -632,7 +633,6 @@ void CCharEntity::OnEngage(CAttackState& state)
 
 void CCharEntity::OnDisengage(CAttackState& state)
 {
-    battleutils::RelinquishClaim(this);
     CBattleEntity::OnDisengage(state);
     if (state.HasErrorMsg())
     {

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4064,8 +4064,7 @@ namespace battleutils
                     if (PDefender->isAlive() && attacker->PClaimedMob && attacker->PClaimedMob != PDefender
                         && attacker->PClaimedMob->isAlive() && attacker->PClaimedMob->m_OwnerID.id == attacker->id)
                     { // unclaim any other living mobs owned by attacker
-                        attacker->PClaimedMob->m_OwnerID.clean();
-                        attacker->PClaimedMob->updatemask |= UPDATE_STATUS;
+                        static_cast<CMobController*>(attacker->PClaimedMob->PAI->GetController())->TapDeclaimTime();
                         attacker->PClaimedMob = nullptr;
                     }
                     if (!mob->CalledForHelp())
@@ -4150,8 +4149,7 @@ namespace battleutils
             });
             if (!found)
             { // if mob didn't pass to someone else, unclaim it
-                mob->m_OwnerID.clean();
-                mob->updatemask |= UPDATE_STATUS;
+                static_cast<CMobController*>(mob->PAI->GetController())->TapDeclaimTime();
             }
         }
         PChar->PClaimedMob = nullptr;

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4081,6 +4081,12 @@ namespace battleutils
                         }
                         else
                         { // mob is unclaimed
+                            if (PDefender->isDead())
+                            { // always give rewards on the killing blow
+                                mob->m_OwnerID.id = PAttacker->id;
+                                mob->m_OwnerID.targid = PAttacker->targid;
+                                return;
+                            }
                             PAttacker->ForAlliance([&PAttacker, &PDefender, &mob, &attacker](CBattleEntity* PMember){
                                 if (mob->PEnmityContainer->GetHighestEnmity() == PMember || mob->PEnmityContainer->GetHighestEnmity() == PMember->PPet)
                                 { // someone in your alliance is top of hate list, claim for your alliance


### PR DESCRIPTION
This adds a short grace period before claim drops and also fixes an issue were rewards are not distributed when proper claim isn't achieved before death. This still isn't 100% as there are some situations where claim does drop instantly, needs more retail testing. Also moved the call to RelinquishClaim from OnDisengage to OnChangeTarget.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

