### PR TITLE
Make caskets stop trying to disappear players

### DIFF
--- a/scripts/globals/caskets.lua
+++ b/scripts/globals/caskets.lua
@@ -723,7 +723,7 @@ local function giveItem(player, npc, itemNum)
                     if player:addItem(itemID, 33) then
                         messageChest(player, "PLAYER_OBTAINS_ITEM", itemID, 0, 0, 0)
                         npc:setLocalVar(itemQuery, 0)
-                        checkItemChestIsEmpty(player, npc)
+                        checkItemChestIsEmpty(npc)
                     end
                 else
                     if player:addItem(itemID) then


### PR DESCRIPTION
`checkItemChestIsEmpty` [only takes an argument of `npc`; after dealing with some not-lua-local vars, it then calls `removeChest` on this first argument](https://github.com/project-topaz/topaz/blob/release/scripts/globals/caskets.lua#L421-L428).

[At which point the chest tries to disappear the player.](https://github.com/project-topaz/topaz/blob/release/scripts/globals/caskets.lua#L338)

To be fair, it does technically succeed in this endeavor. Unfortunately, it disappears the rest of the server in addition to the intended victim.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

