### PR TITLE
Remove some left-over code from the mage merit changes

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -1344,7 +1344,11 @@ function calculateDuration(duration, magicSkill, spellGroup, caster, target, use
         end
     elseif magicSkill == tpz.skill.ENFEEBLING_MAGIC then -- Enfeebling Magic
         if caster:hasStatusEffect(tpz.effect.SABOTEUR) then
-            duration = duration * 2
+            if target:isNM() then
+                duration = duration * 1.25
+            else
+                duration = duration * 2
+            end
         end
 
         -- After Saboteur according to bg-wiki

--- a/scripts/globals/spells/bio.lua
+++ b/scripts/globals/spells/bio.lua
@@ -48,14 +48,12 @@ function onSpellCast(caster,target,spell)
     -- Check for Dia
     local dia = target:getStatusEffect(tpz.effect.DIA)
 
-    -- Calculate DoT effect.  Caps at 3.  Known breakpoints.
+    -- Calculate DoT effect
+    -- http://wiki.ffo.jp/html/1954.html
     local dotdmg = 0
-    if skillLvl > 80 then
-        dotdmg = 3
-    elseif skillLvl > 40 then
-        dotdmg = 2
-    else
-        dotdmg = 1
+    if     skillLvl > 80 then dotdmg = 3
+    elseif skillLvl > 40 then dotdmg = 2
+    else                      dotdmg = 1
     end
 
     -- Do it!

--- a/scripts/globals/spells/bio.lua
+++ b/scripts/globals/spells/bio.lua
@@ -14,7 +14,8 @@ function onMagicCastingCheck(caster,target,spell)
 end
 
 function onSpellCast(caster,target,spell)
-    local basedmg = caster:getSkillLevel(tpz.skill.DARK_MAGIC) / 4
+    local skillLvl = caster:getSkillLevel(tpz.skill.DARK_MAGIC)
+    local basedmg = skillLvl / 4
     local params = {}
     params.dmg = basedmg
     params.multiplier = 1
@@ -47,8 +48,15 @@ function onSpellCast(caster,target,spell)
     -- Check for Dia
     local dia = target:getStatusEffect(tpz.effect.DIA)
 
-    -- Calculate DoT effect (rough, though fairly accurate)
-    local dotdmg = 2 + math.floor(caster:getSkillLevel(tpz.skill.DARK_MAGIC) / 60)
+    -- Calculate DoT effect.  Caps at 3.  Known breakpoints.
+    local dotdmg = 0
+    if skillLvl > 80 then
+        dotdmg = 3
+    elseif skillLvl > 40 then
+        dotdmg = 2
+    else
+        dotdmg = 1
+    end
 
     -- Do it!
     target:addStatusEffect(tpz.effect.BIO, dotdmg, 3, duration, 0, 10, 1)

--- a/scripts/globals/spells/bio_ii.lua
+++ b/scripts/globals/spells/bio_ii.lua
@@ -14,7 +14,8 @@ function onMagicCastingCheck(caster,target,spell)
 end
 
 function onSpellCast(caster,target,spell)
-    local basedmg = caster:getSkillLevel(tpz.skill.DARK_MAGIC) / 4
+    local skillLvl = caster:getSkillLevel(tpz.skill.DARK_MAGIC)
+    local basedmg = skillLvl / 4
     local params = {}
     params.dmg = basedmg
     params.multiplier = 2
@@ -47,8 +48,26 @@ function onSpellCast(caster,target,spell)
     -- Check for Dia
     local dia = target:getStatusEffect(tpz.effect.DIA)
 
-    -- Calculate DoT effect (rough, though fairly accurate)
-    local dotdmg = 3 + math.floor(caster:getSkillLevel(tpz.skill.DARK_MAGIC) / 60)
+    -- Calculate DoT effect. Unknown formula, but known cap of 8 and some known breakpoints.
+    local dotdmg = 0
+    if skillLvl > 290 then
+        dotdmg = 8
+    elseif skillLvl > 268 then
+        dotdmg = 7
+    -- known breakpoints above this line. unknown breakpoints below. for unknown breakpoints, I divided the remaining skill equally
+    elseif skillLvl > 223 then
+        dotdmg = 6
+    elseif skillLvl > 178 then
+        dotdmg = 5
+    elseif skillLvl > 133 then
+        dotdmg = 4
+    elseif skillLvl > 88 then
+        dotdmg = 3
+    elseif skillLvl > 43 then
+        dotdmg = 2
+    else
+        dotdmg = 1
+    end
 
     -- Do it!
     target:addStatusEffect(tpz.effect.BIO, dotdmg, 3, duration, 0, 15, 2)

--- a/scripts/globals/spells/bio_ii.lua
+++ b/scripts/globals/spells/bio_ii.lua
@@ -48,26 +48,11 @@ function onSpellCast(caster,target,spell)
     -- Check for Dia
     local dia = target:getStatusEffect(tpz.effect.DIA)
 
-    -- Calculate DoT effect. Unknown formula, but known cap of 8 and some known breakpoints.
-    local dotdmg = 0
-    if skillLvl > 290 then
-        dotdmg = 8
-    elseif skillLvl > 268 then
-        dotdmg = 7
-    -- known breakpoints above this line. unknown breakpoints below. for unknown breakpoints, I divided the remaining skill equally
-    elseif skillLvl > 223 then
-        dotdmg = 6
-    elseif skillLvl > 178 then
-        dotdmg = 5
-    elseif skillLvl > 133 then
-        dotdmg = 4
-    elseif skillLvl > 88 then
-        dotdmg = 3
-    elseif skillLvl > 43 then
-        dotdmg = 2
-    else
-        dotdmg = 1
-    end
+    -- Calculate DoT effect
+    -- http://wiki.ffo.jp/html/1954.html
+    -- This formula gives correct values for every breakpoint listed on that site
+    local dotdmg = math.floor((skillLvl + 29) / 40)
+    dotdmg = utils.clamp(dotdmg, 3, 8)
 
     -- Do it!
     target:addStatusEffect(tpz.effect.BIO, dotdmg, 3, duration, 0, 15, 2)

--- a/scripts/globals/spells/bio_iii.lua
+++ b/scripts/globals/spells/bio_iii.lua
@@ -48,9 +48,25 @@ function onSpellCast(caster,target,spell)
     -- Check for Dia
     local dia = target:getStatusEffect(tpz.effect.DIA)
 
-    -- Calculate DoT effect. Known formula and cap of 17.
-    local dotdmg = math.floor((skillLvl + 59) / 27)
-    dotdmg = utils.clamp(dotdmg, 1, 17)
+    -- Calculate DoT effect
+    -- http://wiki.ffo.jp/html/1954.html
+    -- this is a tiered calculation that has at least three tiers,
+    -- so I'll use breakpoints for human readability
+    local dotdmg = 0
+    if     skillLvl > 400 then dotdmg = 17
+    elseif skillLvl > 373 then dotdmg = 16
+    elseif skillLvl > 346 then dotdmg = 15
+    elseif skillLvl > 319 then dotdmg = 14
+    elseif skillLvl > 291 then dotdmg = 13
+    elseif skillLvl > 280 then dotdmg = 12
+    elseif skillLvl > 269 then dotdmg = 11
+    elseif skillLvl > 258 then dotdmg = 10
+    elseif skillLvl > 246 then dotdmg =  9
+    elseif skillLvl > 211 then dotdmg =  8
+    elseif skillLvl > 171 then dotdmg =  7
+    elseif skillLvl > 131 then dotdmg =  6
+    else                       dotdmg =  5
+    end
 
     -- Do it!
     target:addStatusEffect(tpz.effect.BIO, dotdmg, 3, duration, 0, 20, 3)

--- a/scripts/globals/spells/bio_iii.lua
+++ b/scripts/globals/spells/bio_iii.lua
@@ -1,8 +1,6 @@
 -----------------------------------------
 -- Spell: Bio III
 -- Deals dark damage that weakens an enemy's attacks and gradually reduces its HP.
--- caster:getMerit() returns a value which is equal to the number of merit points TIMES the value of each point
--- Bio III value per point is '30' This is a constant set in the table 'merits'
 -----------------------------------------
 require("scripts/globals/settings")
 require("scripts/globals/status")
@@ -16,7 +14,8 @@ function onMagicCastingCheck(caster,target,spell)
 end
 
 function onSpellCast(caster,target,spell)
-    local basedmg = caster:getSkillLevel(tpz.skill.DARK_MAGIC) / 4
+    local skillLvl = caster:getSkillLevel(tpz.skill.DARK_MAGIC)
+    local basedmg = skillLvl / 4
     local params = {}
     params.dmg = basedmg
     params.multiplier = 3
@@ -44,17 +43,14 @@ function onSpellCast(caster,target,spell)
     local final = finalMagicAdjustments(caster, target, spell, dmg)
 
     -- Calculate duration
-    local duration = caster:getMerit(tpz.merit.BIO_III)
-    -- If caster has the spell but no merits in it, they are either a mob or we assume they are GM or otherwise gifted with max duration
-    if duration == 0 then
-        duration = 150
-    end
+    local duration = 180
 
     -- Check for Dia
     local dia = target:getStatusEffect(tpz.effect.DIA)
 
-    -- Calculate DoT effect (rough, though fairly accurate)
-    local dotdmg = 4 + math.floor(caster:getSkillLevel(tpz.skill.DARK_MAGIC) / 60)
+    -- Calculate DoT effect. Known formula and cap of 17.
+    local dotdmg = math.floor((skillLvl + 59) / 27)
+    dotdmg = utils.clamp(dotdmg, 1, 17)
 
     -- Do it!
     target:addStatusEffect(tpz.effect.BIO, dotdmg, 3, duration, 0, 20, 3)

--- a/scripts/globals/spells/blind_ii.lua
+++ b/scripts/globals/spells/blind_ii.lua
@@ -1,7 +1,5 @@
 -----------------------------------------
 -- Spell: Blind II
--- caster:getMerit() returns a value which is equal to the number of merit points TIMES the value of each point
--- Blind II value per point is '1' This is a constant set in the table 'merits'
 -----------------------------------------
 require("scripts/globals/magic")
 require("scripts/globals/msg")
@@ -14,8 +12,6 @@ function onMagicCastingCheck(caster, target, spell)
 end
 
 function onSpellCast(caster, target, spell)
-    local merits = caster:getMerit(tpz.merit.BLIND_II)
-
     -- Pull base stats.
     local dINT = caster:getStat(tpz.mod.INT) - target:getStat(tpz.mod.MND) -- blind uses caster INT vs target MND
 
@@ -23,10 +19,6 @@ function onSpellCast(caster, target, spell)
     -- Min cap: 15 at -80 dINT
     -- Max cap: 90 at 120 dINT
     local basePotency = utils.clamp(math.floor(dINT / 3 * 8 + 45), 15, 90)
-
-    if (merits > 1) then
-        basePotency = basePotency + merits - 1
-    end
 
     local potency = calculatePotency(basePotency, spell:getSkillType(), caster, target)
 
@@ -36,7 +28,7 @@ function onSpellCast(caster, target, spell)
     local params = {}
     params.diff = dINT
     params.skillType = tpz.skill.ENFEEBLING_MAGIC
-    params.bonus = merits * 2
+    params.bonus = 0
     params.effect = tpz.effect.BLINDNESS
     local resist = applyResistanceEffect(caster, target, spell, params)
 

--- a/scripts/globals/spells/dia_iii.lua
+++ b/scripts/globals/spells/dia_iii.lua
@@ -1,8 +1,6 @@
 -----------------------------------------
 -- Spell: Dia III
 -- Lowers an enemy's defense and gradually deals light elemental damage.
--- caster:getMerit() returns a value which is equal to the number of merit points TIMES the value of each point
--- Dia III value per point is '30' This is a constant set in the table 'merits'
 -----------------------------------------
 require("scripts/globals/settings")
 require("scripts/globals/status")
@@ -44,12 +42,8 @@ function onSpellCast(caster, target, spell)
     local final = finalMagicAdjustments(caster, target, spell, dmg)
 
     -- Calculate duration and bonus
-    local duration = calculateDuration(caster:getMerit(tpz.merit.DIA_III), spell:getSkillType(), spell:getSpellGroup(), caster, target)
+    local duration = calculateDuration(180, spell:getSkillType(), spell:getSpellGroup(), caster, target)
     local dotBonus = caster:getMod(tpz.mod.DIA_DOT) -- Dia Wand
-    -- If caster has the spell but no merits in it, they are either a mob or we assume they are GM or otherwise gifted with max duration
-    if duration == 0 then
-        duration = 150
-    end
 
     -- Check for Bio
     local bio = target:getStatusEffect(tpz.effect.BIO)

--- a/scripts/globals/spells/doton_san.lua
+++ b/scripts/globals/spells/doton_san.lua
@@ -16,11 +16,6 @@ function onSpellCast(caster,target,spell)
     local bonusAcc = 0
     local bonusMab = caster:getMerit(tpz.merit.DOTON_EFFECT) -- T1 mag atk
 
-    if(caster:getMerit(tpz.merit.DOTON_SAN) ~= 0) then -- T2 mag atk/mag acc, don't want to give a penalty to entities that can cast this without merits
-        bonusMab = bonusMab + caster:getMerit(tpz.merit.DOTON_SAN) - 5 -- merit gives 5 power but no bonus with one invest, thus subtract 5
-        bonusAcc = bonusAcc + caster:getMerit(tpz.merit.DOTON_SAN) - 5
-    end
-
     local params = {}
 
     params.dmg = 134

--- a/scripts/globals/spells/huton_san.lua
+++ b/scripts/globals/spells/huton_san.lua
@@ -16,11 +16,6 @@ function onSpellCast(caster,target,spell)
     local bonusAcc = 0
     local bonusMab = caster:getMerit(tpz.merit.HUTON_EFFECT) -- T1 mag atk
 
-    if(caster:getMerit(tpz.merit.HUTON_SAN) ~= 0) then -- T2 mag atk/mag acc, don't want to give a penalty to entities that can cast this without merits
-        bonusMab = bonusMab + caster:getMerit(tpz.merit.HUTON_SAN) - 5 -- merit gives 5 power but no bonus with one invest, thus subtract 5
-        bonusAcc = bonusAcc + caster:getMerit(tpz.merit.HUTON_SAN) - 5
-    end
-
     local params = {}
 
     params.dmg = 134

--- a/scripts/globals/spells/hyoton_san.lua
+++ b/scripts/globals/spells/hyoton_san.lua
@@ -16,11 +16,6 @@ function onSpellCast(caster,target,spell)
     local bonusAcc = 0
     local bonusMab = caster:getMerit(tpz.merit.HYOTON_EFFECT) -- T1 mag atk
 
-    if(caster:getMerit(tpz.merit.HYOTON_SAN) ~= 0) then -- T2 mag atk/mag acc, don't want to give a penalty to entities that can cast this without merits
-        bonusMab = bonusMab + caster:getMerit(tpz.merit.HYOTON_SAN) - 5 -- merit gives 5 power but no bonus with one invest, thus subtract 5
-        bonusAcc = bonusAcc + caster:getMerit(tpz.merit.HYOTON_SAN) - 5
-    end
-
     local params = {}
 
     params.dmg = 134

--- a/scripts/globals/spells/katon_san.lua
+++ b/scripts/globals/spells/katon_san.lua
@@ -16,11 +16,6 @@ function onSpellCast(caster,target,spell)
     local bonusAcc = 0
     local bonusMab = caster:getMerit(tpz.merit.KATON_EFFECT) -- T1 mag atk
 
-    if(caster:getMerit(tpz.merit.KATON_SAN) ~= 0) then -- T2 mag atk/mag acc, don't want to give a penalty to entities that can cast this without merits
-        bonusMab = bonusMab + caster:getMerit(tpz.merit.KATON_SAN) - 5 -- merit gives 5 power but no bonus with one invest, thus subtract 5
-        bonusAcc = bonusAcc + caster:getMerit(tpz.merit.KATON_SAN) - 5
-    end
-
     local params = {}
 
     params.dmg = 134

--- a/scripts/globals/spells/paralyze_ii.lua
+++ b/scripts/globals/spells/paralyze_ii.lua
@@ -1,8 +1,6 @@
 -----------------------------------------
 -- Spell: Paralyze II
 -- Spell accuracy is most highly affected by Enfeebling Magic Skill, Magic Accuracy, and MND.
--- caster:getMerit() returns a value which is equal to the number of merit points TIMES the value of each point
--- Paralyze II value per point is '1' This is a constant set in the table 'merits'
 -----------------------------------------
 require("scripts/globals/magic")
 require("scripts/globals/msg")
@@ -15,17 +13,11 @@ function onMagicCastingCheck(caster, target, spell)
 end
 
 function onSpellCast(caster, target, spell)
-    local merits = caster:getMerit(tpz.merit.PARALYZE_II)
-
     -- Pull base stats
     local dMND = caster:getStat(tpz.mod.MND) - target:getStat(tpz.mod.MND)
 
     -- Base potency
     local potency = utils.clamp(math.floor(dMND / 4) + 20, 10, 30)
-
-    if (merits > 1) then
-        potency = potency + merits - 1
-    end
 
     potency = calculatePotency(potency, spell:getSkillType(), caster, target)
 
@@ -33,7 +25,7 @@ function onSpellCast(caster, target, spell)
     local params = {}
     params.diff = dMND
     params.skillType = tpz.skill.ENFEEBLING_MAGIC
-    params.bonus = merits * 2
+    params.bonus = 0
     params.effect = tpz.effect.PARALYSIS
     local resist = applyResistanceEffect(caster, target, spell, params)
 

--- a/scripts/globals/spells/phalanx.lua
+++ b/scripts/globals/spells/phalanx.lua
@@ -1,5 +1,5 @@
 -----------------------------------------
---   Spell: PHALANX
+-- Spell: Phalanx
 -----------------------------------------
 require("scripts/globals/magic")
 require("scripts/globals/msg")
@@ -17,11 +17,9 @@ function onSpellCast(caster, target, spell)
     duration = calculateDurationForLvl(duration, 33, target:getMainLvl())
 
     if enhskill <= 300 then
-        final = math.max(enhskill / 10 - 2, 0)
-    elseif enhskill > 300 then
-        final = (enhskill - 300) / 29 + 28
+        final = math.max(math.floor(enhskill / 10) - 2, 0)
     else
-        print("Warning: Unknown enhancing magic skill for phalanx.")
+        final = math.floor((enhskill - 300.5) / 28.5) + 28
     end
 
     -- Cap at 35

--- a/scripts/globals/spells/phalanx_ii.lua
+++ b/scripts/globals/spells/phalanx_ii.lua
@@ -1,7 +1,5 @@
 -----------------------------------------
--- Spell: PHALANX
--- caster:getMerit() returns a value which is equal to the number of merit points TIMES the value of each point
--- Phalanx II value per point is '3' This is a constant set in the table 'merits'
+-- Spell: Phalanx II
 -----------------------------------------
 require("scripts/globals/magic")
 require("scripts/globals/msg")
@@ -15,12 +13,14 @@ end
 function onSpellCast(caster, target, spell)
     local enhskill = caster:getSkillLevel(tpz.skill.ENHANCING_MAGIC)
     local final = 0
-    local merits = caster:getMerit(tpz.merit.PHALANX_II)
-
-    local duration = calculateDuration(90 + 10 * merits, spell:getSkillType(), spell:getSpellGroup(), caster, target)
+    local duration = calculateDuration(240, spell:getSkillType(), spell:getSpellGroup(), caster, target)
     duration = calculateDurationForLvl(duration, 75, target:getMainLvl())
 
-    final = enhskill / 25 + merits + 1
+    if enhskill <= 300 then
+        final = math.floor(enhskill / 25) + 16
+    else
+        final = math.floor((enhskill - 300.5) / 28.5) + 28
+    end
 
     if target:addStatusEffect(tpz.effect.PHALANX,final,0,duration) then
         spell:setMsg(tpz.msg.basic.MAGIC_GAIN_EFFECT)

--- a/scripts/globals/spells/raiton_san.lua
+++ b/scripts/globals/spells/raiton_san.lua
@@ -16,11 +16,6 @@ function onSpellCast(caster,target,spell)
     local bonusAcc = 0
     local bonusMab = caster:getMerit(tpz.merit.RAITON_EFFECT) -- T1 mag atk
 
-    if(caster:getMerit(tpz.merit.RAITON_SAN) ~= 0) then -- T2 mag atk/mag acc, don't want to give a penalty to entities that can cast this without merits
-        bonusMab = bonusMab + caster:getMerit(tpz.merit.RAITON_SAN) - 5 -- merit gives 5 power but no bonus with one invest, thus subtract 5
-        bonusAcc = bonusAcc + caster:getMerit(tpz.merit.RAITON_SAN) - 5
-    end
-
     local params = {}
 
     params.dmg = 134

--- a/scripts/globals/spells/shellra_v.lua
+++ b/scripts/globals/spells/shellra_v.lua
@@ -11,7 +11,6 @@ function onMagicCastingCheck(caster,target,spell)
 end
 
 function onSpellCast(caster,target,spell)
-    local meritBonus = caster:getMerit(tpz.merit.SHELLRA_V)
     local power = 29 -- according to bg-wiki
 
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)

--- a/scripts/globals/spells/slow_ii.lua
+++ b/scripts/globals/spells/slow_ii.lua
@@ -13,16 +13,11 @@ end
 
 function onSpellCast(caster, target, spell)
     local dMND = caster:getStat(tpz.mod.MND) - target:getStat(tpz.mod.MND)
-    local merits = caster:getMerit(tpz.merit.SLOW_II)
 
     -- Lowest ~12.5%
     -- Highest ~35.1%
     local power = utils.clamp(math.floor(dMND * 226 / 15) + 2380, 1250, 3510)
     power = calculatePotency(power, spell:getSkillType(), caster, target)
-
-    if merits > 1 then
-        power = power + merits - 1
-    end
 
     --Duration, including resistance.
     local duration = calculateDuration(180, spell:getSkillType(), spell:getSpellGroup(), caster, target)
@@ -30,7 +25,7 @@ function onSpellCast(caster, target, spell)
     local params = {}
     params.diff = dMND
     params.skillType = tpz.skill.ENFEEBLING_MAGIC
-    params.bonus = merits * 2
+    params.bonus = 0
     params.effect = tpz.effect.SLOW
     local resist = applyResistanceEffect(caster, target, spell, params)
 

--- a/scripts/globals/spells/suiton_san.lua
+++ b/scripts/globals/spells/suiton_san.lua
@@ -16,11 +16,6 @@ function onSpellCast(caster,target,spell)
     local bonusAcc = 0
     local bonusMab = caster:getMerit(tpz.merit.SUITON_EFFECT) -- T1 mag atk
 
-    if(caster:getMerit(tpz.merit.SUITON_SAN) ~= 0) then -- T2 mag atk/mag acc, don't want to give a penalty to entities that can cast this without merits
-        bonusMab = bonusMab + caster:getMerit(tpz.merit.SUITON_SAN) - 5 -- merit gives 5 power but no bonus with one invest, thus subtract 5
-        bonusAcc = bonusAcc + caster:getMerit(tpz.merit.SUITON_SAN) - 5
-    end
-
     local params = {}
 
     params.dmg = 134


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

~edit: **Hold review on this**.  I found some other left-over merit stuff and will fix where needed.~

bio: adjust DoT potency to known buckets
http://wiki.ffo.jp/html/1954.html

bio ii: adjust DoT potency to known buckets
http://wiki.ffo.jp/html/1954.html

bio iii: merit no longer affects duration. adjust DoT potency to known buckets
http://wiki.ffo.jp/html/1954.html

blind ii, paralyze ii, slow ii: merits no longer affects potency

dia iii: merit no longer affects duration

phalanx and phalanx ii: adjusted formula from bgwiki.  phalanx ii merit no longer does anything.

shellra v: removed unused variable

ninjustu san-tier nukes: spell-specific merits no longer do anything.

saboteur: when enfeebling NMs, only grant a +25% duration, rather than a +100% duration.

**Ready for review!**