### PR TITLE
Fix Lumber Jack spawn. Always spawns after Weeping Willow is defeated.

### DIFF
--- a/scripts/zones/Batallia_Downs/mobs/Weeping_Willow.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Weeping_Willow.lua
@@ -18,7 +18,9 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
+    local LUMBER_JACK = mob:getID() + 6
     -- Retail behavior is for it to walk back to where willow died if unclaimed *unless* willow was pulled down the cliff
     -- In that case, it will walk back near where Willow was spawned at.
-    GetMobByID(mob:getID() + 6):setSpawn(mob:getXPos(), mob:getYPos(), mob:getZPos())
+    GetMobByID(LUMBER_JACK):setSpawn(mob:getXPos(), mob:getYPos(), mob:getZPos())
+    SpawnMob(LUMBER_JACK)
 end


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Notes:
Jack does not pop claimed or pre Aggro'd at all.

Jack's ID is not in the IDs.lua because no other script ever needs the ID.

I messed up the spawn way back in 764f6cddf6e2020ec2b76fdc6947b74fb0357d44
I had corrected the method for setting its spawn position but accidentally removed the command that actually spawns him. Somehow nobody noticed this.