### PR TITLE
Phomiuna Acqueducts - Fixed Oil Lamps and Doors

### DIFF
--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0r9.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0r9.lua
@@ -7,7 +7,9 @@ function onTrade(player,npc,trade)
 end;
 
 function onTrigger(player,npc)
-    if (npc:getAnimation() == 9) then
+    if player:getCharVar('X_MARKS_THE_SPOT') == 4 then
+        player:startEvent(37)
+    elseif (npc:getAnimation() == 9) then
         npc:openDoor();
     end
 end;
@@ -16,4 +18,7 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
-end;
+    if csid == 37 then
+        player:setCharVar('X_MARKS_THE_SPOT',5)
+    end
+end

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rm.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rm.lua
@@ -1,10 +1,8 @@
 -----------------------------------
--- Area: Phomiuna_Aqueducts
---  NPC: _0rm (Oil lamp)
--- Notes: Opens South door at J-7 from inside.
--- !pos -63.703 -26.227 83.000 27
------------------------------------
-require("scripts/globals/missions");
+--    Area: Phomiuna_Aqueducts
+--  NPC: Oil Lamp - North (West)
+-- Opens Door at F-7 from inside.
+--  ID: 16888052 !pos -63 -26 83
 -----------------------------------
 
 function onTrade(player,npc,trade)
@@ -16,7 +14,7 @@ function onTrigger(player,npc)
 
     if (GetNPCByID(DoorOffset):getAnimation() == 9) then
         if (player:getZPos() < 84) then
-            npc:openDoor(15); -- lamp animation
+            npc:openDoor(7); -- lamp animation
             GetNPCByID(DoorOffset):openDoor(7); -- _0rf
         end
     end

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rm.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rm.lua
@@ -1,8 +1,8 @@
 -----------------------------------
---    Area: Phomiuna_Aqueducts
---  NPC: Oil Lamp - North (West)
+-- Area: Phomiuna_Aqueducts
+-- NPC: Oil Lamp - North (West)
 -- Opens Door at F-7 from inside.
---  ID: 16888052 !pos -63 -26 83
+-- !pos -63 -26 83
 -----------------------------------
 
 function onTrade(player,npc,trade)

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rm.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rm.lua
@@ -6,23 +6,23 @@
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
 
-    local DoorOffset = npc:getID() - 1;
+    local DoorOffset = npc:getID() - 1
 
     if (GetNPCByID(DoorOffset):getAnimation() == 9) then
         if (player:getZPos() < 84) then
-            npc:openDoor(7); -- lamp animation
-            GetNPCByID(DoorOffset):openDoor(7); -- _0rf
+            npc:openDoor(7) -- lamp animation
+            GetNPCByID(DoorOffset):openDoor(7) -- _0rf
         end
     end
 
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-end;
+end

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rn.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rn.lua
@@ -1,7 +1,7 @@
 -----------------------------------
--- Area: Phomiuna_Aqueducts
---  NPC: _0rn (Oil lamp)
--- !pos -60 -23 60 27
+--    Area: Phomiuna_Aqueducts
+--  NPC: Oil Lamp - Water (West)
+-- ID: 16888067  !pos -63 -26 77
 -----------------------------------
 require("scripts/globals/missions");
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rn.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rn.lua
@@ -3,37 +3,35 @@
 --  NPC: Oil Lamp - Water (West)
 -- ID: 16888067  !pos -63 -26 77
 -----------------------------------
-require("scripts/globals/missions");
-local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");
+local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
 
-    local DoorOffset = npc:getID();
+    local DoorOffset = npc:getID()
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+2); -- water lamp
-    npc:openDoor(7); -- lamp animation
+    player:messageSpecial(ID.text.LAMP_OFFSET+2) -- water lamp
+    npc:openDoor(7) -- lamp animation
 
-    local element = VanadielDayElement();
-    -- printf("element: %u",element);
+    local element = VanadielDayElement()
 
     if (element == 2) then -- waterday
         if (GetNPCByID(DoorOffset+7):getAnimation() == 8) then -- lamp fire open?
-            GetNPCByID(DoorOffset-2):openDoor(15); -- Open Door _0rk
+            GetNPCByID(DoorOffset-2):openDoor(15) -- Open Door _0rk
         end
     elseif (element == 5) then -- lighningday
         if (GetNPCByID(DoorOffset+2):getAnimation() == 8) then -- lamp lightning open?
-            GetNPCByID(DoorOffset-2):openDoor(15); -- Open Door _0rk
+            GetNPCByID(DoorOffset-2):openDoor(15) -- Open Door _0rk
         end
     end
 
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-end;
+end

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rn.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rn.lua
@@ -1,7 +1,7 @@
 -----------------------------------
---    Area: Phomiuna_Aqueducts
---  NPC: Oil Lamp - Water (West)
--- ID: 16888067  !pos -63 -26 77
+-- Area: Phomiuna_Aqueducts
+-- NPC: Oil Lamp - Water (West)
+-- !pos -63 -26 77
 -----------------------------------
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0ro.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0ro.lua
@@ -3,37 +3,35 @@
 --   NPC: Oil Lamp - Ice (West)
 -- ID: 16888068  !pos -63 -26 73
 -----------------------------------
-require("scripts/globals/missions");
-local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");
+local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
 
-    local DoorOffset = npc:getID();
+    local DoorOffset = npc:getID()
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+4); -- ice lamp
-    npc:openDoor(7); -- lamp animation
+    player:messageSpecial(ID.text.LAMP_OFFSET+4) -- ice lamp
+    npc:openDoor(7) -- lamp animation
 
-    local element = VanadielDayElement();
-    -- printf("element: %u",element);
+    local element = VanadielDayElement()
 
     if (element == 0) then -- fireday
         if (GetNPCByID(DoorOffset+6):getAnimation() == 8) then -- lamp fire open?
-            GetNPCByID(DoorOffset-3):openDoor(15); -- Open Door _0rk
+            GetNPCByID(DoorOffset-3):openDoor(15) -- Open Door _0rk
         end
     elseif (element == 4) then -- iceday
         if (GetNPCByID(DoorOffset+5):getAnimation() == 8) then -- lamp wind open?
-            GetNPCByID(DoorOffset-3):openDoor(15); -- Open Door _0rk
+            GetNPCByID(DoorOffset-3):openDoor(15) -- Open Door _0rk
         end
     end
 
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-end;
+end

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0ro.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0ro.lua
@@ -1,7 +1,7 @@
 -----------------------------------
---    Area: Phomiuna_Aqueducts
---   NPC: Oil Lamp - Ice (West)
--- ID: 16888068  !pos -63 -26 73
+-- Area: Phomiuna_Aqueducts
+-- NPC: Oil Lamp - Ice (West)
+-- !pos -63 -26 73
 -----------------------------------
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0ro.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0ro.lua
@@ -1,7 +1,7 @@
 -----------------------------------
--- Area: Phomiuna_Aqueducts
---  NPC: Oil lamp
--- !pos -60 -23 60 27
+--    Area: Phomiuna_Aqueducts
+--   NPC: Oil Lamp - Ice (West)
+-- ID: 16888068  !pos -63 -26 73
 -----------------------------------
 require("scripts/globals/missions");
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rp.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rp.lua
@@ -1,7 +1,7 @@
 -----------------------------------
--- Area: Phomiuna_Aqueducts
---  NPC: Oil lamp
--- !pos -60 -23 60 27
+--    Area: Phomiuna_Aqueducts
+-- NPC: Oil Lamp - Thunder (West)
+-- ID: 16888069  !pos -63 -26 67
 -----------------------------------
 require("scripts/globals/missions");
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rp.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rp.lua
@@ -3,37 +3,35 @@
 -- NPC: Oil Lamp - Thunder (West)
 -- ID: 16888069  !pos -63 -26 67
 -----------------------------------
-require("scripts/globals/missions");
-local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");
+local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
 
-    local DoorOffset = npc:getID();
+    local DoorOffset = npc:getID()
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+5); -- lighting lamp
-    npc:openDoor(7); -- lamp animation
+    player:messageSpecial(ID.text.LAMP_OFFSET+5) -- lighting lamp
+    npc:openDoor(7) -- lamp animation
 
-    local element = VanadielDayElement();
-    -- printf("element: %u",element);
+    local element = VanadielDayElement()
 
     if (element == 5) then -- lightningday
         if (GetNPCByID(DoorOffset-2):getAnimation() == 8) then -- lamp water open ?
-            GetNPCByID(DoorOffset-4):openDoor(15); -- Open Door _0rk
+            GetNPCByID(DoorOffset-4):openDoor(15) -- Open Door _0rk
         end
     elseif (element == 1) then -- earthday
         if (GetNPCByID(DoorOffset+2):getAnimation() == 8) then -- lamp earth open ?
-            GetNPCByID(DoorOffset-4):openDoor(15); -- Open Door _0rk
+            GetNPCByID(DoorOffset-4):openDoor(15) -- Open Door _0rk
         end
     end
 
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-end;
+end

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rp.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rp.lua
@@ -1,7 +1,7 @@
 -----------------------------------
---    Area: Phomiuna_Aqueducts
+-- Area: Phomiuna_Aqueducts
 -- NPC: Oil Lamp - Thunder (West)
--- ID: 16888069  !pos -63 -26 67
+-- !pos -63 -26 67
 -----------------------------------
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rq.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rq.lua
@@ -1,7 +1,7 @@
 -----------------------------------
--- Area: Phomiuna_Aqueducts
---  NPC: Oil lamp
--- !pos -60 -23 60 27
+--    Area: Phomiuna_Aqueducts
+--  NPC: Oil Lamp - Light (West)
+-- ID: 16888070  !pos -63 -26 63
 -----------------------------------
 require("scripts/globals/missions");
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rq.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rq.lua
@@ -3,33 +3,31 @@
 --  NPC: Oil Lamp - Light (West)
 -- ID: 16888070  !pos -63 -26 63
 -----------------------------------
-require("scripts/globals/missions");
-local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");
+local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
 
-    local DoorOffset = npc:getID();
+    local DoorOffset = npc:getID()
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+6); -- light lamp
-    npc:openDoor(7); -- lamp animation
+    player:messageSpecial(ID.text.LAMP_OFFSET+6) -- light lamp
+    npc:openDoor(7) -- lamp animation
 
-    local element = VanadielDayElement();
-    -- printf("element: %u",element);
+    local element = VanadielDayElement()
 
     if (element == 6 or element == 7) then -- lightday or darkday
         if (GetNPCByID(DoorOffset+1):getAnimation() == 8) then -- lamp dark open?
-            GetNPCByID(DoorOffset-5):openDoor(15); -- Open Door _0rk
+            GetNPCByID(DoorOffset-5):openDoor(15) -- Open Door _0rk
         end
     end
 
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-end;
+end

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rq.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rq.lua
@@ -1,7 +1,7 @@
 -----------------------------------
---    Area: Phomiuna_Aqueducts
---  NPC: Oil Lamp - Light (West)
--- ID: 16888070  !pos -63 -26 63
+-- Area: Phomiuna_Aqueducts
+-- NPC: Oil Lamp - Light (West)
+-- !pos -63 -26 63
 -----------------------------------
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rr.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rr.lua
@@ -1,7 +1,7 @@
 -----------------------------------
---    Area: Phomiuna_Aqueducts
+-- Area: Phomiuna_Aqueducts
 -- NPC: Oil Lamp - Darkness (West)
--- ID: 16888071  !pos -63 -26 57
+-- !pos -63 -26 57
 -----------------------------------
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rr.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rr.lua
@@ -3,33 +3,31 @@
 -- NPC: Oil Lamp - Darkness (West)
 -- ID: 16888071  !pos -63 -26 57
 -----------------------------------
-require("scripts/globals/missions");
-local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");
+local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
 
-    local DoorOffset = npc:getID();
+    local DoorOffset = npc:getID()
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+7); -- dark lamp
-    npc:openDoor(7); -- lamp animation
+    player:messageSpecial(ID.text.LAMP_OFFSET+7) -- dark lamp
+    npc:openDoor(7) -- lamp animation
 
-    local element = VanadielDayElement();
-    -- printf("element: %u",element);
+    local element = VanadielDayElement()
 
     if (element == 6 or element == 7) then -- lightday or darkday
         if (GetNPCByID(DoorOffset-1):getAnimation() == 8) then -- lamp light open ?
-            GetNPCByID(DoorOffset-6):openDoor(15); -- Open Door _0rk
+            GetNPCByID(DoorOffset-6):openDoor(15) -- Open Door _0rk
         end
     end
 
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-end;
+end

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rs.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rs.lua
@@ -1,7 +1,7 @@
 -----------------------------------
---    Area: Phomiuna_Aqueducts
---  NPC: Oil Lamp - Earth (West)
--- ID: 16888072  !pos -63 -26 53
+-- Area: Phomiuna_Aqueducts
+-- NPC: Oil Lamp - Earth (West)
+-- !pos -63 -26 53
 -----------------------------------
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rs.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rs.lua
@@ -1,7 +1,7 @@
 -----------------------------------
--- Area: Phomiuna_Aqueducts
---  NPC: Oil lamp
--- !pos -60 -23 60 27
+--    Area: Phomiuna_Aqueducts
+--  NPC: Oil Lamp - Earth (West)
+-- ID: 16888072  !pos -63 -26 53
 -----------------------------------
 require("scripts/globals/missions");
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rs.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rs.lua
@@ -3,37 +3,35 @@
 --  NPC: Oil Lamp - Earth (West)
 -- ID: 16888072  !pos -63 -26 53
 -----------------------------------
-require("scripts/globals/missions");
-local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");
+local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
 
-    local DoorOffset = npc:getID();
+    local DoorOffset = npc:getID()
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+1); -- earth lamp
-    npc:openDoor(7); -- lamp animation
+    player:messageSpecial(ID.text.LAMP_OFFSET+1) -- earth lamp
+    npc:openDoor(7) -- lamp animation
 
-    local element = VanadielDayElement();
-    -- printf("element: %u",element);
+    local element = VanadielDayElement()
 
     if (element == 3) then -- wind day
         if (GetNPCByID(DoorOffset+1):getAnimation() == 8) then -- lamp wind open?
-            GetNPCByID(DoorOffset-7):openDoor(15); -- Open Door _0rk
+            GetNPCByID(DoorOffset-7):openDoor(15) -- Open Door _0rk
         end
     elseif (element == 1) then -- earth day
         if (GetNPCByID(DoorOffset-3):getAnimation() == 8) then -- lamp lightning open?
-            GetNPCByID(DoorOffset-7):openDoor(15); -- Open Door _0rk
+            GetNPCByID(DoorOffset-7):openDoor(15) -- Open Door _0rk
         end
     end
 
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-end;
+end

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rt.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rt.lua
@@ -1,7 +1,7 @@
 -----------------------------------
--- Area: Phomiuna_Aqueducts
---  NPC: Oil lamp
--- !pos -60 -23 60 27
+--    Area: Phomiuna_Aqueducts
+--   NPC: Oil Lamp - Wind (West)
+-- ID: 16888073  !pos -63 -26 47
 -----------------------------------
 require("scripts/globals/missions");
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rt.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rt.lua
@@ -1,7 +1,7 @@
 -----------------------------------
---    Area: Phomiuna_Aqueducts
---   NPC: Oil Lamp - Wind (West)
--- ID: 16888073  !pos -63 -26 47
+-- Area: Phomiuna_Aqueducts
+-- NPC: Oil Lamp - Wind (West)
+-- !pos -63 -26 47
 -----------------------------------
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rt.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rt.lua
@@ -3,37 +3,35 @@
 --   NPC: Oil Lamp - Wind (West)
 -- ID: 16888073  !pos -63 -26 47
 -----------------------------------
-require("scripts/globals/missions");
-local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");
+local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
 
-    local DoorOffset = npc:getID();
+    local DoorOffset = npc:getID()
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+3); -- wind lamp
-    npc:openDoor(7); -- lamp animation
+    player:messageSpecial(ID.text.LAMP_OFFSET+3) -- wind lamp
+    npc:openDoor(7) -- lamp animation
 
-    local element = VanadielDayElement();
-    -- printf("element: %u",element);
+    local element = VanadielDayElement()
 
     if (element == 3) then -- winday
         if (GetNPCByID(DoorOffset-1):getAnimation() == 8) then -- lamp earth open?
-            GetNPCByID(DoorOffset-8):openDoor(15); -- Open Door _0rk
+            GetNPCByID(DoorOffset-8):openDoor(15) -- Open Door _0rk
         end
     elseif (element == 4) then -- iceday
         if (GetNPCByID(DoorOffset-5):getAnimation() == 8) then -- lamp ice open?
-            GetNPCByID(DoorOffset-8):openDoor(15); -- Open Door _0rk
+            GetNPCByID(DoorOffset-8):openDoor(15) -- Open Door _0rk
         end
     end
 
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-end;
+end

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0ru.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0ru.lua
@@ -1,7 +1,7 @@
 -----------------------------------
--- Area: Phomiuna_Aqueducts
---  NPC: Oil lamp
--- !pos -63.699 -26.227 43.009 27
+--    Area: Phomiuna_Aqueducts
+--   NPC: Oil Lamp - Fire (West)
+-- ID: 16888074  !pos -63 -26 43
 -----------------------------------
 require("scripts/globals/missions");
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0ru.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0ru.lua
@@ -1,7 +1,7 @@
 -----------------------------------
---    Area: Phomiuna_Aqueducts
---   NPC: Oil Lamp - Fire (West)
--- ID: 16888074  !pos -63 -26 43
+-- Area: Phomiuna_Aqueducts
+-- NPC: Oil Lamp - Fire (West)
+-- !pos -63 -26 43
 -----------------------------------
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0ru.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0ru.lua
@@ -3,38 +3,35 @@
 --   NPC: Oil Lamp - Fire (West)
 -- ID: 16888074  !pos -63 -26 43
 -----------------------------------
-require("scripts/globals/missions");
-local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");
+local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
 
-    local DoorOffset = npc:getID();
+    local DoorOffset = npc:getID()
 
-    player:messageSpecial(ID.text.LAMP_OFFSET); -- fire lamp
-    npc:openDoor(7); -- lamp animation
+    player:messageSpecial(ID.text.LAMP_OFFSET) -- fire lamp
+    npc:openDoor(7) -- lamp animation
 
-    local element = VanadielDayElement();
-    -- printf("element: %u",element);
+    local element = VanadielDayElement()
 
     if (element == 0) then -- fireday
         if (GetNPCByID(DoorOffset-6):getAnimation() == 8) then -- ice lamp open?
-            GetNPCByID(DoorOffset-9):openDoor(15); -- Door _0rk
+            GetNPCByID(DoorOffset-9):openDoor(15) -- Door _0rk
         end
     elseif (element == 2) then  -- waterday
         if (GetNPCByID(DoorOffset-5):getAnimation() == 8) then -- water lamp open?
-            GetNPCByID(DoorOffset-9):openDoor(15); -- Door _0rk
+            GetNPCByID(DoorOffset-9):openDoor(15) -- Door _0rk
         end
     end
 
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-
-end;
+end

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rv.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rv.lua
@@ -6,23 +6,23 @@
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
 
-    local DoorOffset = npc:getID() - 1;
+    local DoorOffset = npc:getID() - 1
 
     if (GetNPCByID(DoorOffset):getAnimation() == 9) then
         if (player:getZPos() > 35) then
-            npc:openDoor(7); -- lamp animation
-            GetNPCByID(DoorOffset):openDoor(7); -- _0rg
+            npc:openDoor(7) -- lamp animation
+            GetNPCByID(DoorOffset):openDoor(7) -- _0rg
         end
     end
 
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-end;
+end

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rv.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rv.lua
@@ -1,10 +1,8 @@
 -----------------------------------
--- Area: Phomiuna_Aqueducts
---  NPC: _0rv (Oil lamp)
--- Notes: Opens north door at J-9 from inside.
--- !pos -63.703 -26.227 37.000 27
------------------------------------
-require("scripts/globals/missions");
+--    Area: Phomiuna_Aqueducts
+--  NPC: Oil Lamp - South (West)
+-- Opens Door at F-9 from inside.
+--  ID: 16888055 !pos -63 -26 37
 -----------------------------------
 
 function onTrade(player,npc,trade)
@@ -15,7 +13,7 @@ function onTrigger(player,npc)
     local DoorOffset = npc:getID() - 1;
 
     if (GetNPCByID(DoorOffset):getAnimation() == 9) then
-        if (player:getZPos() > 36) then
+        if (player:getZPos() > 35) then
             npc:openDoor(7); -- lamp animation
             GetNPCByID(DoorOffset):openDoor(7); -- _0rg
         end
@@ -27,5 +25,4 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
-
 end;

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rv.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rv.lua
@@ -1,8 +1,8 @@
 -----------------------------------
---    Area: Phomiuna_Aqueducts
---  NPC: Oil Lamp - South (West)
+-- Area: Phomiuna_Aqueducts
+-- NPC: Oil Lamp - South (West)
 -- Opens Door at F-9 from inside.
---  ID: 16888055 !pos -63 -26 37
+-- !pos -63 -26 37
 -----------------------------------
 
 function onTrade(player,npc,trade)

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rw.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rw.lua
@@ -1,8 +1,8 @@
 -----------------------------------
--- Area: Phomiuna_Aqueducts
---  NPC: _0rw (Oil Lamp)
--- Notes: Opens south door at J-9 from inside.
--- !pos 103.703 -26.180 83.000 27
+--    Area: Phomiuna_Aqueducts
+--  NPC: Oil Lamp - North (East)
+-- Opens Door at J-7 from inside.
+--  ID: 16888057 !pos 104 -26 83
 -----------------------------------
 
 function onTrade(player,npc,trade)

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rw.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rw.lua
@@ -1,8 +1,8 @@
 -----------------------------------
---    Area: Phomiuna_Aqueducts
---  NPC: Oil Lamp - North (East)
+-- Area: Phomiuna_Aqueducts
+-- NPC: Oil Lamp - North (East)
 -- Opens Door at J-7 from inside.
---  ID: 16888057 !pos 104 -26 83
+-- !pos 104 -26 83
 -----------------------------------
 
 function onTrade(player,npc,trade)

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rw.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rw.lua
@@ -6,23 +6,23 @@
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
 
-    local DoorOffset = npc:getID() - 1;
+    local DoorOffset = npc:getID() - 1
 
     if (GetNPCByID(DoorOffset):getAnimation() == 9) then
         if (player:getZPos() < 85) then
-            npc:openDoor(7); -- torch animation
-            GetNPCByID(DoorOffset):openDoor(7); -- _0rh
+            npc:openDoor(7) -- torch animation
+            GetNPCByID(DoorOffset):openDoor(7) -- _0rh
         end
     end
 
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-end;
+end

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rx.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rx.lua
@@ -1,7 +1,7 @@
 -----------------------------------
---    Area: Phomiuna_Aqueducts
---  NPC: Oil Lamp - Water (East)
--- ID: 16888080  !pos 104 -26 77
+-- Area: Phomiuna_Aqueducts
+-- NPC: Oil Lamp - Water (East)
+-- !pos 104 -26 77
 -----------------------------------
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rx.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rx.lua
@@ -3,37 +3,35 @@
 --  NPC: Oil Lamp - Water (East)
 -- ID: 16888080  !pos 104 -26 77
 -----------------------------------
-require("scripts/globals/missions");
-local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");
+local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
 
-    local DoorOffset = npc:getID();
+    local DoorOffset = npc:getID()
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+2); -- water lamp
-    npc:openDoor(7); -- lamp animation
+    player:messageSpecial(ID.text.LAMP_OFFSET+2) -- water lamp
+    npc:openDoor(7) -- lamp animation
 
-    local element = VanadielDayElement();
-    -- printf("element: %u",element);
+    local element = VanadielDayElement()
 
     if (element == 2) then -- waterday
         if (GetNPCByID(DoorOffset+7):getAnimation() == 8) then -- lamp fire open?
-            GetNPCByID(DoorOffset-2):openDoor(15); -- Open Door _0rk
+            GetNPCByID(DoorOffset-2):openDoor(15) -- Open Door _0rl
         end
     elseif (element == 5) then -- lighningday
         if (GetNPCByID(DoorOffset+2):getAnimation() == 8) then -- lamp lightning open?
-            GetNPCByID(DoorOffset-2):openDoor(15); -- Open Door _0rk
+            GetNPCByID(DoorOffset-2):openDoor(15) -- Open Door _0rl
         end
     end
 
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-end;
+end

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rx.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rx.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 --    Area: Phomiuna_Aqueducts
--- NPC: Oil Lamp - Darkness (West)
--- ID: 16888071  !pos -63 -26 57
+--  NPC: Oil Lamp - Water (East)
+-- ID: 16888080  !pos 104 -26 77
 -----------------------------------
 require("scripts/globals/missions");
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");
@@ -14,15 +14,19 @@ function onTrigger(player,npc)
 
     local DoorOffset = npc:getID();
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+7); -- dark lamp
+    player:messageSpecial(ID.text.LAMP_OFFSET+2); -- water lamp
     npc:openDoor(7); -- lamp animation
 
     local element = VanadielDayElement();
     -- printf("element: %u",element);
 
-    if (element == 6 or element == 7) then -- lightday or darkday
-        if (GetNPCByID(DoorOffset-1):getAnimation() == 8) then -- lamp light open ?
-            GetNPCByID(DoorOffset-6):openDoor(15); -- Open Door _0rk
+    if (element == 2) then -- waterday
+        if (GetNPCByID(DoorOffset+7):getAnimation() == 8) then -- lamp fire open?
+            GetNPCByID(DoorOffset-2):openDoor(15); -- Open Door _0rk
+        end
+    elseif (element == 5) then -- lighningday
+        if (GetNPCByID(DoorOffset+2):getAnimation() == 8) then -- lamp lightning open?
+            GetNPCByID(DoorOffset-2):openDoor(15); -- Open Door _0rk
         end
     end
 

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0ry.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0ry.lua
@@ -1,7 +1,7 @@
 -----------------------------------
---    Area: Phomiuna_Aqueducts
---   NPC: Oil Lamp - Ice (East)
--- ID: 16888081  !pos 104 -26 73
+-- Area: Phomiuna_Aqueducts
+-- NPC: Oil Lamp - Ice (East)
+-- !pos 104 -26 73
 -----------------------------------
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0ry.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0ry.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 --    Area: Phomiuna_Aqueducts
--- NPC: Oil Lamp - Darkness (West)
--- ID: 16888071  !pos -63 -26 57
+--   NPC: Oil Lamp - Ice (East)
+-- ID: 16888081  !pos 104 -26 73
 -----------------------------------
 require("scripts/globals/missions");
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");
@@ -14,15 +14,19 @@ function onTrigger(player,npc)
 
     local DoorOffset = npc:getID();
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+7); -- dark lamp
+    player:messageSpecial(ID.text.LAMP_OFFSET+4); -- ice lamp
     npc:openDoor(7); -- lamp animation
 
     local element = VanadielDayElement();
     -- printf("element: %u",element);
 
-    if (element == 6 or element == 7) then -- lightday or darkday
-        if (GetNPCByID(DoorOffset-1):getAnimation() == 8) then -- lamp light open ?
-            GetNPCByID(DoorOffset-6):openDoor(15); -- Open Door _0rk
+    if (element == 0) then -- fireday
+        if (GetNPCByID(DoorOffset+6):getAnimation() == 8) then -- lamp fire open?
+            GetNPCByID(DoorOffset-3):openDoor(15); -- Open Door _0rk
+        end
+    elseif (element == 4) then -- iceday
+        if (GetNPCByID(DoorOffset+5):getAnimation() == 8) then -- lamp wind open?
+            GetNPCByID(DoorOffset-3):openDoor(15); -- Open Door _0rk
         end
     end
 

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0ry.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0ry.lua
@@ -3,37 +3,35 @@
 --   NPC: Oil Lamp - Ice (East)
 -- ID: 16888081  !pos 104 -26 73
 -----------------------------------
-require("scripts/globals/missions");
-local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");
+local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
 
-    local DoorOffset = npc:getID();
+    local DoorOffset = npc:getID()
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+4); -- ice lamp
-    npc:openDoor(7); -- lamp animation
+    player:messageSpecial(ID.text.LAMP_OFFSET+4) -- ice lamp
+    npc:openDoor(7) -- lamp animation
 
-    local element = VanadielDayElement();
-    -- printf("element: %u",element);
+    local element = VanadielDayElement()
 
     if (element == 0) then -- fireday
         if (GetNPCByID(DoorOffset+6):getAnimation() == 8) then -- lamp fire open?
-            GetNPCByID(DoorOffset-3):openDoor(15); -- Open Door _0rk
+            GetNPCByID(DoorOffset-3):openDoor(15) -- Open Door _0rl
         end
     elseif (element == 4) then -- iceday
         if (GetNPCByID(DoorOffset+5):getAnimation() == 8) then -- lamp wind open?
-            GetNPCByID(DoorOffset-3):openDoor(15); -- Open Door _0rk
+            GetNPCByID(DoorOffset-3):openDoor(15) -- Open Door _0rl
         end
     end
 
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-end;
+end

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rz.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rz.lua
@@ -3,37 +3,35 @@
 -- NPC: Oil Lamp - Thunder (East)
 -- ID: 16888082  !pos 104 -26 67
 -----------------------------------
-require("scripts/globals/missions");
-local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");
+local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
 
-    local DoorOffset = npc:getID();
+    local DoorOffset = npc:getID()
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+5); -- lighting lamp
-    npc:openDoor(7); -- lamp animation
+    player:messageSpecial(ID.text.LAMP_OFFSET+5) -- lighting lamp
+    npc:openDoor(7) -- lamp animation
 
-    local element = VanadielDayElement();
-    -- printf("element: %u",element);
+    local element = VanadielDayElement()
 
     if (element == 5) then -- lightningday
         if (GetNPCByID(DoorOffset-2):getAnimation() == 8) then -- lamp water open ?
-            GetNPCByID(DoorOffset-4):openDoor(15); -- Open Door _0rk
+            GetNPCByID(DoorOffset-4):openDoor(15) -- Open Door _0rl
         end
     elseif (element == 1) then -- earthday
         if (GetNPCByID(DoorOffset+2):getAnimation() == 8) then -- lamp earth open ?
-            GetNPCByID(DoorOffset-4):openDoor(15); -- Open Door _0rk
+            GetNPCByID(DoorOffset-4):openDoor(15) -- Open Door _0rl
         end
     end
 
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-end;
+end

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rz.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rz.lua
@@ -1,7 +1,7 @@
 -----------------------------------
---    Area: Phomiuna_Aqueducts
+-- Area: Phomiuna_Aqueducts
 -- NPC: Oil Lamp - Thunder (East)
--- ID: 16888082  !pos 104 -26 67
+-- !pos 104 -26 67
 -----------------------------------
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rz.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rz.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 --    Area: Phomiuna_Aqueducts
--- NPC: Oil Lamp - Darkness (West)
--- ID: 16888071  !pos -63 -26 57
+-- NPC: Oil Lamp - Thunder (East)
+-- ID: 16888082  !pos 104 -26 67
 -----------------------------------
 require("scripts/globals/missions");
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");
@@ -14,15 +14,19 @@ function onTrigger(player,npc)
 
     local DoorOffset = npc:getID();
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+7); -- dark lamp
+    player:messageSpecial(ID.text.LAMP_OFFSET+5); -- lighting lamp
     npc:openDoor(7); -- lamp animation
 
     local element = VanadielDayElement();
     -- printf("element: %u",element);
 
-    if (element == 6 or element == 7) then -- lightday or darkday
-        if (GetNPCByID(DoorOffset-1):getAnimation() == 8) then -- lamp light open ?
-            GetNPCByID(DoorOffset-6):openDoor(15); -- Open Door _0rk
+    if (element == 5) then -- lightningday
+        if (GetNPCByID(DoorOffset-2):getAnimation() == 8) then -- lamp water open ?
+            GetNPCByID(DoorOffset-4):openDoor(15); -- Open Door _0rk
+        end
+    elseif (element == 1) then -- earthday
+        if (GetNPCByID(DoorOffset+2):getAnimation() == 8) then -- lamp earth open ?
+            GetNPCByID(DoorOffset-4):openDoor(15); -- Open Door _0rk
         end
     end
 

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_ir0.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_ir0.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 --    Area: Phomiuna_Aqueducts
--- NPC: Oil Lamp - Darkness (West)
--- ID: 16888071  !pos -63 -26 57
+--  NPC: Oil Lamp - Light (East)
+-- ID: 16888083  !pos 104 -26 63
 -----------------------------------
 require("scripts/globals/missions");
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");
@@ -14,15 +14,15 @@ function onTrigger(player,npc)
 
     local DoorOffset = npc:getID();
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+7); -- dark lamp
+    player:messageSpecial(ID.text.LAMP_OFFSET+6); -- light lamp
     npc:openDoor(7); -- lamp animation
 
     local element = VanadielDayElement();
     -- printf("element: %u",element);
 
     if (element == 6 or element == 7) then -- lightday or darkday
-        if (GetNPCByID(DoorOffset-1):getAnimation() == 8) then -- lamp light open ?
-            GetNPCByID(DoorOffset-6):openDoor(15); -- Open Door _0rk
+        if (GetNPCByID(DoorOffset+1):getAnimation() == 8) then -- lamp dark open?
+            GetNPCByID(DoorOffset-5):openDoor(15); -- Open Door _0rk
         end
     end
 

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_ir0.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_ir0.lua
@@ -1,7 +1,7 @@
 -----------------------------------
---    Area: Phomiuna_Aqueducts
---  NPC: Oil Lamp - Light (East)
--- ID: 16888083  !pos 104 -26 63
+-- Area: Phomiuna_Aqueducts
+-- NPC: Oil Lamp - Light (East)
+-- !pos 104 -26 63
 -----------------------------------
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_ir0.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_ir0.lua
@@ -3,33 +3,31 @@
 --  NPC: Oil Lamp - Light (East)
 -- ID: 16888083  !pos 104 -26 63
 -----------------------------------
-require("scripts/globals/missions");
-local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");
+local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
 
-    local DoorOffset = npc:getID();
+    local DoorOffset = npc:getID()
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+6); -- light lamp
-    npc:openDoor(7); -- lamp animation
+    player:messageSpecial(ID.text.LAMP_OFFSET+6) -- light lamp
+    npc:openDoor(7) -- lamp animation
 
-    local element = VanadielDayElement();
-    -- printf("element: %u",element);
+    local element = VanadielDayElement()
 
     if (element == 6 or element == 7) then -- lightday or darkday
         if (GetNPCByID(DoorOffset+1):getAnimation() == 8) then -- lamp dark open?
-            GetNPCByID(DoorOffset-5):openDoor(15); -- Open Door _0rk
+            GetNPCByID(DoorOffset-5):openDoor(15) -- Open Door _0rl
         end
     end
 
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-end;
+end

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_ir1.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_ir1.lua
@@ -1,7 +1,7 @@
 -----------------------------------
---    Area: Phomiuna_Aqueducts
+-- Area: Phomiuna_Aqueducts
 -- NPC: Oil Lamp - Darkness (East)
--- ID: 16888084  !pos 104 -26 57
+-- !pos 104 -26 57
 -----------------------------------
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_ir1.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_ir1.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 --    Area: Phomiuna_Aqueducts
--- NPC: Oil Lamp - Darkness (West)
--- ID: 16888071  !pos -63 -26 57
+-- NPC: Oil Lamp - Darkness (East)
+-- ID: 16888084  !pos 104 -26 57
 -----------------------------------
 require("scripts/globals/missions");
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_ir1.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_ir1.lua
@@ -3,33 +3,31 @@
 -- NPC: Oil Lamp - Darkness (East)
 -- ID: 16888084  !pos 104 -26 57
 -----------------------------------
-require("scripts/globals/missions");
-local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");
+local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
 
-    local DoorOffset = npc:getID();
+    local DoorOffset = npc:getID()
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+7); -- dark lamp
-    npc:openDoor(7); -- lamp animation
+    player:messageSpecial(ID.text.LAMP_OFFSET+7) -- dark lamp
+    npc:openDoor(7) -- lamp animation
 
-    local element = VanadielDayElement();
-    -- printf("element: %u",element);
+    local element = VanadielDayElement()
 
     if (element == 6 or element == 7) then -- lightday or darkday
         if (GetNPCByID(DoorOffset-1):getAnimation() == 8) then -- lamp light open ?
-            GetNPCByID(DoorOffset-6):openDoor(15); -- Open Door _0rk
+            GetNPCByID(DoorOffset-6):openDoor(15) -- Open Door _0rl
         end
     end
 
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-end;
+end

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_ir2.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_ir2.lua
@@ -3,37 +3,35 @@
 --  NPC: Oil Lamp - Earth (East)
 -- ID: 16888085  !pos 104 -26 53
 -----------------------------------
-require("scripts/globals/missions");
-local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");
+local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
 
-    local DoorOffset = npc:getID();
+    local DoorOffset = npc:getID()
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+1); -- earth lamp
-    npc:openDoor(7); -- lamp animation
+    player:messageSpecial(ID.text.LAMP_OFFSET+1) -- earth lamp
+    npc:openDoor(7) -- lamp animation
 
-    local element = VanadielDayElement();
-    -- printf("element: %u",element);
+    local element = VanadielDayElement()
 
     if (element == 3) then -- wind day
         if (GetNPCByID(DoorOffset+1):getAnimation() == 8) then -- lamp wind open?
-            GetNPCByID(DoorOffset-7):openDoor(15); -- Open Door _0rk
+            GetNPCByID(DoorOffset-7):openDoor(15) -- Open Door _0rl
         end
     elseif (element == 1) then -- earth day
         if (GetNPCByID(DoorOffset-3):getAnimation() == 8) then -- lamp lightning open?
-            GetNPCByID(DoorOffset-7):openDoor(15); -- Open Door _0rk
+            GetNPCByID(DoorOffset-7):openDoor(15) -- Open Door _0rl
         end
     end
 
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-end;
+end

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_ir2.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_ir2.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 --    Area: Phomiuna_Aqueducts
--- NPC: Oil Lamp - Darkness (West)
--- ID: 16888071  !pos -63 -26 57
+--  NPC: Oil Lamp - Earth (East)
+-- ID: 16888085  !pos 104 -26 53
 -----------------------------------
 require("scripts/globals/missions");
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");
@@ -14,15 +14,19 @@ function onTrigger(player,npc)
 
     local DoorOffset = npc:getID();
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+7); -- dark lamp
+    player:messageSpecial(ID.text.LAMP_OFFSET+1); -- earth lamp
     npc:openDoor(7); -- lamp animation
 
     local element = VanadielDayElement();
     -- printf("element: %u",element);
 
-    if (element == 6 or element == 7) then -- lightday or darkday
-        if (GetNPCByID(DoorOffset-1):getAnimation() == 8) then -- lamp light open ?
-            GetNPCByID(DoorOffset-6):openDoor(15); -- Open Door _0rk
+    if (element == 3) then -- wind day
+        if (GetNPCByID(DoorOffset+1):getAnimation() == 8) then -- lamp wind open?
+            GetNPCByID(DoorOffset-7):openDoor(15); -- Open Door _0rk
+        end
+    elseif (element == 1) then -- earth day
+        if (GetNPCByID(DoorOffset-3):getAnimation() == 8) then -- lamp lightning open?
+            GetNPCByID(DoorOffset-7):openDoor(15); -- Open Door _0rk
         end
     end
 

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_ir2.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_ir2.lua
@@ -1,7 +1,7 @@
 -----------------------------------
---    Area: Phomiuna_Aqueducts
---  NPC: Oil Lamp - Earth (East)
--- ID: 16888085  !pos 104 -26 53
+-- Area: Phomiuna_Aqueducts
+-- NPC: Oil Lamp - Earth (East)
+-- !pos 104 -26 53
 -----------------------------------
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_ir3.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_ir3.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 --    Area: Phomiuna_Aqueducts
--- NPC: Oil Lamp - Darkness (West)
--- ID: 16888071  !pos -63 -26 57
+--   NPC: Oil Lamp - Wind (East)
+-- ID: 16888086  !pos 104 -26 47
 -----------------------------------
 require("scripts/globals/missions");
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");
@@ -14,15 +14,19 @@ function onTrigger(player,npc)
 
     local DoorOffset = npc:getID();
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+7); -- dark lamp
+    player:messageSpecial(ID.text.LAMP_OFFSET+3); -- wind lamp
     npc:openDoor(7); -- lamp animation
 
     local element = VanadielDayElement();
     -- printf("element: %u",element);
 
-    if (element == 6 or element == 7) then -- lightday or darkday
-        if (GetNPCByID(DoorOffset-1):getAnimation() == 8) then -- lamp light open ?
-            GetNPCByID(DoorOffset-6):openDoor(15); -- Open Door _0rk
+    if (element == 3) then -- winday
+        if (GetNPCByID(DoorOffset-1):getAnimation() == 8) then -- lamp earth open?
+            GetNPCByID(DoorOffset-8):openDoor(15); -- Open Door _0rk
+        end
+    elseif (element == 4) then -- iceday
+        if (GetNPCByID(DoorOffset-5):getAnimation() == 8) then -- lamp ice open?
+            GetNPCByID(DoorOffset-8):openDoor(15); -- Open Door _0rk
         end
     end
 

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_ir3.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_ir3.lua
@@ -1,7 +1,7 @@
 -----------------------------------
---    Area: Phomiuna_Aqueducts
---   NPC: Oil Lamp - Wind (East)
--- ID: 16888086  !pos 104 -26 47
+-- Area: Phomiuna_Aqueducts
+-- NPC: Oil Lamp - Wind (East)
+-- !pos 104 -26 47
 -----------------------------------
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_ir3.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_ir3.lua
@@ -3,37 +3,35 @@
 --   NPC: Oil Lamp - Wind (East)
 -- ID: 16888086  !pos 104 -26 47
 -----------------------------------
-require("scripts/globals/missions");
-local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");
+local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
 
-    local DoorOffset = npc:getID();
+    local DoorOffset = npc:getID()
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+3); -- wind lamp
-    npc:openDoor(7); -- lamp animation
+    player:messageSpecial(ID.text.LAMP_OFFSET+3) -- wind lamp
+    npc:openDoor(7) -- lamp animation
 
-    local element = VanadielDayElement();
-    -- printf("element: %u",element);
+    local element = VanadielDayElement()
 
     if (element == 3) then -- winday
         if (GetNPCByID(DoorOffset-1):getAnimation() == 8) then -- lamp earth open?
-            GetNPCByID(DoorOffset-8):openDoor(15); -- Open Door _0rk
+            GetNPCByID(DoorOffset-8):openDoor(15) -- Open Door _0rl
         end
     elseif (element == 4) then -- iceday
         if (GetNPCByID(DoorOffset-5):getAnimation() == 8) then -- lamp ice open?
-            GetNPCByID(DoorOffset-8):openDoor(15); -- Open Door _0rk
+            GetNPCByID(DoorOffset-8):openDoor(15) -- Open Door _0rl
         end
     end
 
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-end;
+end

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_ir4.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_ir4.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 --    Area: Phomiuna_Aqueducts
--- NPC: Oil Lamp - Darkness (West)
--- ID: 16888071  !pos -63 -26 57
+--   NPC: Oil Lamp - Fire (East)
+-- ID: 16888087  !pos 104 -26 43
 -----------------------------------
 require("scripts/globals/missions");
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");
@@ -14,15 +14,19 @@ function onTrigger(player,npc)
 
     local DoorOffset = npc:getID();
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+7); -- dark lamp
+    player:messageSpecial(ID.text.LAMP_OFFSET); -- fire lamp
     npc:openDoor(7); -- lamp animation
 
     local element = VanadielDayElement();
     -- printf("element: %u",element);
 
-    if (element == 6 or element == 7) then -- lightday or darkday
-        if (GetNPCByID(DoorOffset-1):getAnimation() == 8) then -- lamp light open ?
-            GetNPCByID(DoorOffset-6):openDoor(15); -- Open Door _0rk
+    if (element == 0) then -- fireday
+        if (GetNPCByID(DoorOffset-6):getAnimation() == 8) then -- ice lamp open?
+            GetNPCByID(DoorOffset-9):openDoor(15); -- Door _0rk
+        end
+    elseif (element == 2) then  -- waterday
+        if (GetNPCByID(DoorOffset-5):getAnimation() == 8) then -- water lamp open?
+            GetNPCByID(DoorOffset-9):openDoor(15); -- Door _0rk
         end
     end
 
@@ -32,4 +36,5 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
+
 end;

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_ir4.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_ir4.lua
@@ -3,38 +3,35 @@
 --   NPC: Oil Lamp - Fire (East)
 -- ID: 16888087  !pos 104 -26 43
 -----------------------------------
-require("scripts/globals/missions");
-local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs");
+local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
 
-    local DoorOffset = npc:getID();
+    local DoorOffset = npc:getID()
 
-    player:messageSpecial(ID.text.LAMP_OFFSET); -- fire lamp
-    npc:openDoor(7); -- lamp animation
+    player:messageSpecial(ID.text.LAMP_OFFSET) -- fire lamp
+    npc:openDoor(7) -- lamp animation
 
-    local element = VanadielDayElement();
-    -- printf("element: %u",element);
+    local element = VanadielDayElement()
 
     if (element == 0) then -- fireday
         if (GetNPCByID(DoorOffset-6):getAnimation() == 8) then -- ice lamp open?
-            GetNPCByID(DoorOffset-9):openDoor(15); -- Door _0rk
+            GetNPCByID(DoorOffset-9):openDoor(15) -- Door _0rl
         end
     elseif (element == 2) then  -- waterday
         if (GetNPCByID(DoorOffset-5):getAnimation() == 8) then -- water lamp open?
-            GetNPCByID(DoorOffset-9):openDoor(15); -- Door _0rk
+            GetNPCByID(DoorOffset-9):openDoor(15) -- Door _0rl
         end
     end
 
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-
-end;
+end

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_ir4.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_ir4.lua
@@ -1,7 +1,7 @@
 -----------------------------------
---    Area: Phomiuna_Aqueducts
---   NPC: Oil Lamp - Fire (East)
--- ID: 16888087  !pos 104 -26 43
+-- Area: Phomiuna_Aqueducts
+-- NPC: Oil Lamp - Fire (East)
+-- !pos 104 -26 43
 -----------------------------------
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_ir5.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_ir5.lua
@@ -1,8 +1,8 @@
 -----------------------------------
--- Area: Phomiuna_Aqueducts
---  NPC: _ir5 (Oil Lamp)
--- Notes: Opens north door at J-9 from inside.
--- !pos 103.703 -26.180 37.000 27
+--    Area: Phomiuna_Aqueducts
+--  NPC: Oil Lamp - South (East)
+-- Opens Door at J-9 from inside.
+--  ID: 16888059 !pos 104 -26 37
 -----------------------------------
 
 function onTrade(player,npc,trade)
@@ -13,7 +13,7 @@ function onTrigger(player,npc)
     local DoorOffset = npc:getID() - 1;
 
     if (GetNPCByID(DoorOffset):getAnimation() == 9) then
-        if (player:getZPos() > 34) then
+        if (player:getZPos() > 35) then
             npc:openDoor(7); -- lamp animation
             GetNPCByID(DoorOffset):openDoor(7); -- _0ri
         end

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_ir5.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_ir5.lua
@@ -6,23 +6,23 @@
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
 
-    local DoorOffset = npc:getID() - 1;
+    local DoorOffset = npc:getID() - 1
 
     if (GetNPCByID(DoorOffset):getAnimation() == 9) then
         if (player:getZPos() > 35) then
-            npc:openDoor(7); -- lamp animation
-            GetNPCByID(DoorOffset):openDoor(7); -- _0ri
+            npc:openDoor(7) -- lamp animation
+            GetNPCByID(DoorOffset):openDoor(7) -- _0ri
         end
     end
 
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-end;
+end

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_ir5.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_ir5.lua
@@ -1,8 +1,8 @@
 -----------------------------------
---    Area: Phomiuna_Aqueducts
---  NPC: Oil Lamp - South (East)
+-- Area: Phomiuna_Aqueducts
+-- NPC: Oil Lamp - South (East)
 -- Opens Door at J-9 from inside.
---  ID: 16888059 !pos 104 -26 37
+-- !pos 104 -26 37
 -----------------------------------
 
 function onTrade(player,npc,trade)


### PR DESCRIPTION
*Entire east side's doors weren't coded
*Updated descriptions to better identify
*Fixed two broken oil lamp animations
*East door now properly opens

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [X] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [X] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

