### PR TITLE
Check if enmity list is empty for unclaimed mobs

### DIFF
--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -104,7 +104,7 @@ bool CMobSkillState::Update(time_point tick)
     if (IsCompleted() && tick > m_finishTime)
     {
         auto PTarget = GetTarget();
-        if (PTarget && PTarget->objtype == TYPE_MOB)
+        if (PTarget && PTarget->objtype == TYPE_MOB && PTarget != m_PEntity && m_PEntity->allegiance == ALLEGIANCE_PLAYER)
         {
             static_cast<CMobEntity*>(PTarget)->PEnmityContainer->UpdateEnmity(m_PEntity, 0, 0, true);
         }

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -26,6 +26,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "../../utils/battleutils.h"
 #include "../../mobskill.h"
 #include "../../status_effect_container.h"
+#include "../../enmity_container.h"
 
 CMobSkillState::CMobSkillState(CMobEntity* PEntity, uint16 targid, uint16 wsid) :
     CState(PEntity, targid),
@@ -102,6 +103,11 @@ bool CMobSkillState::Update(time_point tick)
     }
     if (IsCompleted() && tick > m_finishTime)
     {
+        auto PTarget = GetTarget();
+        if (PTarget && PTarget->objtype == TYPE_MOB)
+        {
+            static_cast<CMobEntity*>(PTarget)->PEnmityContainer->UpdateEnmity(m_PEntity, 0, 0, true);
+        }
         m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_STATE_EXIT", m_PEntity, m_PSkill->getID());
         return true;
     }

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1666,12 +1666,12 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
         {
             attackRound.DeleteAttackSwing();
         }
-        battleutils::ClaimMob(PTarget, this);
         if (list.actionTargets.size() == 8)
         {
             break;
         }
     }
+    battleutils::ClaimMob(PTarget, this);
     PAI->EventHandler.triggerListener("ATTACK", this, PTarget, &action);
     PTarget->PAI->EventHandler.triggerListener("ATTACKED", PTarget, this, &action);
     /////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -633,6 +633,7 @@ void CCharEntity::OnEngage(CAttackState& state)
 
 void CCharEntity::OnDisengage(CAttackState& state)
 {
+    battleutils::RelinquishClaim(this);
     CBattleEntity::OnDisengage(state);
     if (state.HasErrorMsg())
     {

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1323,8 +1323,6 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
             actionTarget.reaction = REACTION_EVADE;
             actionTarget.speceffect = SPECEFFECT_NONE;
             actionTarget.messageID = 354;
-
-            battleutils::ClaimMob(PTarget, this);
             hitCount = i; // end barrage, shot missed
         }
 
@@ -1393,8 +1391,6 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
         actionTarget.messageID = 0;
         actionTarget.reaction = REACTION_EVADE;
         PTarget->loc.zone->PushPacket(PTarget, CHAR_INRANGE_SELF, new CMessageBasicPacket(PTarget, PTarget, 0, shadowsTaken, MSGBASIC_SHADOW_ABSORB));
-
-        battleutils::ClaimMob(PTarget, this);
     }
 
     if (actionTarget.speceffect == SPECEFFECT_HIT && actionTarget.param > 0)
@@ -1413,7 +1409,7 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
 
         StatusEffectContainer->DelStatusEffect(EFFECT_SANGE);
     }
-
+    battleutils::ClaimMob(PTarget, this);
     battleutils::RemoveAmmo(this, ammoConsumed);
     // only remove detectables
     StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DETECTABLE);

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -668,11 +668,6 @@ void CMobEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
             this->PAI->EventHandler.triggerListener("WEAPONSKILL_USE", this, PTarget, PSkill->getID(), state.GetSpentTP(), &action);
             PTarget->PAI->EventHandler.triggerListener("WEAPONSKILL_TAKE", PTarget, this, PSkill->getID(), state.GetSpentTP(), &action);
         }
-        if (PTarget->isDead())
-        {
-            battleutils::ClaimMob(PTarget, this);
-        }
-        battleutils::DirtyExp(PTarget, this);
         if (msg == 0)
         {
             msg = PSkill->getMsg();
@@ -726,11 +721,15 @@ void CMobEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
             }
         }
         PTarget->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DETECTABLE);
+        if (PTarget->isDead())
+        {
+            battleutils::ClaimMob(PTarget, this);
+        }
+        battleutils::DirtyExp(PTarget, this);
     }
     PTarget = static_cast<CBattleEntity*>(state.GetTarget());
     if (PTarget->objtype == TYPE_MOB && (PTarget->isDead() || (objtype == TYPE_PET && static_cast<CPetEntity*>(this)->getPetType() == PETTYPE_AVATAR)))
     {
-        static_cast<CMobEntity*>(PTarget)->PEnmityContainer->UpdateEnmity(this, 0, 0);
         battleutils::ClaimMob(PTarget, this);
     }
     battleutils::DirtyExp(PTarget, this);
@@ -1073,12 +1072,6 @@ bool CMobEntity::OnAttack(CAttackState& state, action_t& action)
     }
     else
     {
-        bool success = CBattleEntity::OnAttack(state, action);
-        if (success && PTarget && PTarget->objtype == TYPE_MOB)
-        {
-            static_cast<CMobEntity*>(PTarget)->PEnmityContainer->UpdateEnmity(this, 0, 0);
-            battleutils::ClaimMob(PTarget, this);
-        }
-        return success;
+        return CBattleEntity::OnAttack(state, action);
     }
 }

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4041,7 +4041,7 @@ namespace battleutils
         return GetCharmChance(PCharmer, PVictim) > tpzrand::GetRandomNumber(100.f);
     }
 
-    void ClaimMob(CBattleEntity* PDefender, CBattleEntity* PAttacker)
+    void ClaimMob(CBattleEntity* PDefender, CBattleEntity* PAttacker, bool passing)
     {
         if (PDefender->objtype == TYPE_MOB)
         {
@@ -4059,11 +4059,17 @@ namespace battleutils
             }
             CBattleEntity* battleTarget = original->GetBattleTarget();
             CMobEntity* mob = static_cast<CMobEntity*>(PDefender);
-            mob->PEnmityContainer->UpdateEnmity(original, 0, 0, true);
+            if (!passing)
+            {
+                mob->PEnmityContainer->UpdateEnmity(original, 0, 0, true);
+            }
             if (PAttacker)
             {
                 CCharEntity* attacker = static_cast<CCharEntity*>(PAttacker);
-                battleutils::DirtyExp(PDefender, PAttacker);
+                if (!passing)
+                {
+                    battleutils::DirtyExp(PDefender, PAttacker);
+                }
                 if (!battleTarget || battleTarget == PDefender || battleTarget != attacker->PClaimedMob || PDefender->isDead())
                 {
                     if (PDefender->isAlive() && attacker->PClaimedMob && attacker->PClaimedMob != PDefender
@@ -4156,7 +4162,7 @@ namespace battleutils
                 if (member != PChar && !found && member->getZone() == PChar->getZone() && member->isAlive() && (!member->PClaimedMob || member->PClaimedMob == mob))
                 { // check if we can pass claim to someone else
                     found = true;
-                    battleutils::ClaimMob(mob, PMember);
+                    battleutils::ClaimMob(mob, PMember, true);
                 }
             });
             if (!found)

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2039,7 +2039,10 @@ namespace battleutils
         if (damage < 0)
             damage = -corrected;
 
-        battleutils::ClaimMob(PDefender, PAttacker);
+        if (PAttacker->objtype == TYPE_PC)
+        {
+            battleutils::ClaimMob(PDefender, PAttacker);
+        }
 
         int16 standbyTp = 0;
 
@@ -4042,8 +4045,7 @@ namespace battleutils
     {
         if (PDefender->objtype == TYPE_MOB)
         {
-            CBattleEntity* battleTarget = PAttacker->GetBattleTarget();
-            CMobEntity* mob = static_cast<CMobEntity*>(PDefender);
+            CBattleEntity* original = PAttacker;
             if (PAttacker->objtype != TYPE_PC)
             {
                 if (PAttacker->PMaster && PAttacker->PMaster->objtype == TYPE_PC)
@@ -4052,9 +4054,12 @@ namespace battleutils
                 }
                 else
                 {
-                    PAttacker = nullptr;
+                    return;
                 }
             }
+            CBattleEntity* battleTarget = original->GetBattleTarget();
+            CMobEntity* mob = static_cast<CMobEntity*>(PDefender);
+            mob->PEnmityContainer->UpdateEnmity(original, 0, 0, true);
             if (PAttacker)
             {
                 CCharEntity* attacker = static_cast<CCharEntity*>(PAttacker);

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4082,8 +4082,9 @@ namespace battleutils
                         }
                         else
                         { // mob is unclaimed
-                            PAttacker->ForAlliance([&PAttacker, &PDefender, &mob, &attacker](CBattleEntity* PMember){
-                                if (mob->PEnmityContainer->GetHighestEnmity() == PMember || mob->PEnmityContainer->GetHighestEnmity() == PMember->PPet)
+                            CBattleEntity* highestClaim = mob->PEnmityContainer->GetHighestEnmity();
+                            PAttacker->ForAlliance([&](CBattleEntity* PMember){
+                                if (!highestClaim || highestClaim == PMember || highestClaim == PMember->PPet)
                                 { // someone in your alliance is top of hate list, claim for your alliance
                                     mob->m_OwnerID.id = PAttacker->id;
                                     mob->m_OwnerID.targid = PAttacker->targid;

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -193,7 +193,7 @@ namespace battleutils
     uint8               getBarrageShotCount(CCharEntity* PChar);
     uint8               getStoreTPbonusFromMerit(CBattleEntity* PEntity);
 
-    void                ClaimMob(CBattleEntity* PDefender, CBattleEntity* PAttacker);
+    void                ClaimMob(CBattleEntity* PDefender, CBattleEntity* PAttacker, bool passing = false);
     void                DirtyExp(CBattleEntity* PDefender, CBattleEntity* PAttacker);
     void                RelinquishClaim(CCharEntity* PDefender);
 


### PR DESCRIPTION
Prior to the recent changes the attack round would simply set the owner instead of checking enmity since without unclaiming mechanics it didn't really matter. Attack enmity is set in takePhysicalDamage, so missed attacks and 0 damage attacks didn't generate any enmity, BUT since the owner was getting set either way, during the mob roam tick it checks if it has anyone on their enmity list, and if it doesn't but it does have an owner, it adds base enmity there. This fixes an oversight in the claim code for when claim is attempted with an empty enmity list.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

