### PR TITLE
Make ENABLE_TRUST_QUESTS use obvious

### DIFF
--- a/scripts/zones/Port_Bastok/npcs/Clarion_Star.lua
+++ b/scripts/zones/Port_Bastok/npcs/Clarion_Star.lua
@@ -28,7 +28,7 @@ function onTrigger(player,npc)
     local TrustBastok   = player:getQuestStatus(BASTOK, tpz.quest.id.bastok.TRUST_BASTOK)
     local TrustWindurst = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.TRUST_WINDURST)
 
-    if player:getMainLvl() >= 5 and ENABLE_TRUST_QUESTS then
+    if player:getMainLvl() >= 5 and ENABLE_TRUST_QUESTS == 1 then
         if TrustBastok == QUEST_AVAILABLE and (TrustWindurst == QUEST_COMPLETED or TrustSandoria == QUEST_COMPLETED) then
             player:startEvent(438)
         elseif TrustBastok == QUEST_AVAILABLE and TrustWindurst == QUEST_AVAILABLE and TrustSandoria == QUEST_AVAILABLE then

--- a/scripts/zones/Southern_San_dOria/npcs/Gondebaud.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Gondebaud.lua
@@ -28,7 +28,7 @@ function onTrigger(player,npc)
     local TrustBastok   = player:getQuestStatus(BASTOK, tpz.quest.id.bastok.TRUST_BASTOK)
     local TrustWindurst = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.TRUST_WINDURST)
 
-    if player:getMainLvl() >= 5 and ENABLE_TRUST_QUESTS then
+    if player:getMainLvl() >= 5 and ENABLE_TRUST_QUESTS == 1 then
         if TrustSandoria == QUEST_AVAILABLE and (TrustWindurst == QUEST_COMPLETED or TrustBastok == QUEST_COMPLETED) then
             player:startEvent(3504)
         elseif TrustSandoria == QUEST_AVAILABLE and TrustWindurst == QUEST_AVAILABLE and TrustBastok == QUEST_AVAILABLE then

--- a/scripts/zones/Windurst_Woods/npcs/Wetata.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Wetata.lua
@@ -28,7 +28,7 @@ function onTrigger(player,npc)
     local TrustBastok   = player:getQuestStatus(BASTOK, tpz.quest.id.bastok.TRUST_BASTOK)
     local TrustWindurst = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.TRUST_WINDURST)
 
-    if player:getMainLvl() >= 5 and ENABLE_TRUST_QUESTS then
+    if player:getMainLvl() >= 5 and ENABLE_TRUST_QUESTS == 1 then
         if TrustWindurst == QUEST_AVAILABLE and (TrustBastok == QUEST_COMPLETED or TrustSandoria == QUEST_COMPLETED) then
             player:startEvent(867)
         elseif TrustWindurst == QUEST_AVAILABLE and TrustBastok == QUEST_AVAILABLE and TrustSandoria == QUEST_AVAILABLE then


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Make the checks obvious/correct
