### PR TITLE
Remove food from the list of drainable effects for Thinker Tap moves

### DIFF
--- a/scripts/globals/mobskills/binary_tap.lua
+++ b/scripts/globals/mobskills/binary_tap.lua
@@ -19,8 +19,8 @@ end
 function onMobWeaponSkill(target, mob, skill)
 
     -- try to drain buff
-    local effectFirst = mob:stealStatusEffect(target, tpz.effectFlag.DISPELABLE+tpz.effectFlag.FOOD)
-    local effectSecond = mob:stealStatusEffect(target, tpz.effectFlag.DISPELABLE+tpz.effectFlag.FOOD)
+    local effectFirst = mob:stealStatusEffect(target, tpz.effectFlag.DISPELABLE)
+    local effectSecond = mob:stealStatusEffect(target, tpz.effectFlag.DISPELABLE)
     local dmg = 0
 
     if (effectFirst ~= 0) then

--- a/scripts/globals/mobskills/spirit_tap.lua
+++ b/scripts/globals/mobskills/spirit_tap.lua
@@ -22,7 +22,7 @@ end
 function onMobWeaponSkill(target, mob, skill)
 
     -- try to drain buff
-    local effect = mob:stealStatusEffect(target, tpz.effectFlag.DISPELABLE+tpz.effectFlag.FOOD)
+    local effect = mob:stealStatusEffect(target, tpz.effectFlag.DISPELABLE)
     local dmg = 0
 
     if (effect ~= 0) then

--- a/scripts/globals/mobskills/trinary_tap.lua
+++ b/scripts/globals/mobskills/trinary_tap.lua
@@ -22,9 +22,9 @@ end
 function onMobWeaponSkill(target, mob, skill)
 
     -- try to drain buff
-    local effect1 = mob:stealStatusEffect(target, tpz.effectFlag.DISPELABLE+tpz.effectFlag.FOOD)
-    local effect2 = mob:stealStatusEffect(target, tpz.effectFlag.DISPELABLE+tpz.effectFlag.FOOD)
-    local effect3 = mob:stealStatusEffect(target, tpz.effectFlag.DISPELABLE+tpz.effectFlag.FOOD)
+    local effect1 = mob:stealStatusEffect(target, tpz.effectFlag.DISPELABLE)
+    local effect2 = mob:stealStatusEffect(target, tpz.effectFlag.DISPELABLE)
+    local effect3 = mob:stealStatusEffect(target, tpz.effectFlag.DISPELABLE)
     local dmg = 0
 
     if (effect1 ~= 0) then


### PR DESCRIPTION
Contrary to what wikis claim, food is not a buff that can be stolen by these moves. This is been confirmed on retail.

See the following capture on the FFXI Captures Discord server:
- NM[Brooder] [Ruminator] (Abyssea - La Theine) [+] Food Absorb Test

"Fixes" #149 . The status container still needs work, and checks for cancel-able buffs need to happen (in general, not just for buff theft), but Tap moves are currently the only abilities that caused crashing in this manner (that I'm aware of, at least).

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [🤞] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

