### PR TITLE
Fix AH 7-item limit not being enforced correctly

### DIFF
--- a/conf/default/map.conf
+++ b/conf/default/map.conf
@@ -66,6 +66,10 @@ ah_tax_rate_single: 1.0
 ah_tax_rate_stacks: 0.5
 ah_max_fee: 10000
 
+# Max open listings per player, 0 = no limit. (Default 7)
+# Note: Settings over 7 may need client-side plugin to work under all circumstances.
+ah_list_limit: 7
+
 #Misc EXP related settings
 exp_rate: 1.0
 exp_loss_rate: 1.0

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -951,6 +951,7 @@ int32 map_config_default()
     map_config.ah_tax_rate_single = 1.0;
     map_config.ah_tax_rate_stacks = 0.5;
     map_config.ah_max_fee = 10000;
+    map_config.ah_list_limit = 7;
     map_config.exp_rate = 1.0f;
     map_config.exp_loss_rate = 1.0f;
     map_config.exp_retain = 0.0f;
@@ -1102,6 +1103,10 @@ int32 map_config_read(const int8* cfgName)
         else if (strcmp(w1, "ah_max_fee") == 0)
         {
             map_config.ah_max_fee = atoi(w2);
+        }
+        else if (strcmp(w1, "ah_list_limit") == 0)
+        {
+            map_config.ah_list_limit = atoi(w2);
         }
         else if (strcmp(w1, "exp_rate") == 0)
         {

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -79,6 +79,7 @@ struct map_config_t
     float  ah_tax_rate_single;        // Percent of listing price to tax single items
     float  ah_tax_rate_stacks;        // Percent of listing price to tax stacks
     uint32 ah_max_fee;                // Maximum total AH fees/taxes
+    uint32 ah_list_limit;             // Maximum open AH listings per player
 
     float  exp_rate;                  // множитель получаемого опыта
     float  exp_loss_rate;             // same as exp rate but applies when player dies

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -2350,18 +2350,18 @@ void SmallPacket0x04E(map_session_data_t* session, CCharEntity* PChar, CBasicPac
             const char* Query = "SELECT COUNT(*) FROM auction_house WHERE seller = %u AND sale=0;";
 
             int32 ret = Sql_Query(SqlHandle, Query, PChar->id);
-            uint8 ah_listings = 0;
+            uint32 ah_listings = 0;
 
             if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0)
             {
                 Sql_NextRow(SqlHandle);
-                ah_listings = (int32)Sql_GetIntData(SqlHandle, 0);
+                ah_listings = (uint32)Sql_GetIntData(SqlHandle, 0);
                 // ShowDebug(CL_CYAN"%s has %d outstanding listings before placing this one." CL_RESET, PChar->GetName(), ah_listings);
             }
 
-            if (ah_listings >= 7)
+            if (map_config.ah_list_limit && ah_listings >= map_config.ah_list_limit)
             {
-                // ShowDebug(CL_CYAN"%s already has 7 items on the AH\n" CL_RESET,PChar->GetName());
+                // ShowDebug(CL_CYAN"%s already has %d items on the AH\n" CL_RESET,PChar->GetName(), ah_listings);
                 PChar->pushPacket(new CAuctionHousePacket(action, 197, 0, 0)); // Failed to place up
                 return;
             }
@@ -2385,7 +2385,7 @@ void SmallPacket0x04E(map_session_data_t* session, CCharEntity* PChar, CBasicPac
             charutils::UpdateItem(PChar, LOC_INVENTORY, 0, -(int32)auctionFee); // Deduct AH fee
 
             PChar->pushPacket(new CAuctionHousePacket(action, 1, 0, 0)); // Merchandise put up on auction msg
-            PChar->pushPacket(new CAuctionHousePacket(0x0C, ah_listings, PChar)); // Inform history of slot
+            PChar->pushPacket(new CAuctionHousePacket(0x0C, (uint8)ah_listings, PChar)); // Inform history of slot
         }
     }
     break;

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -2346,7 +2346,20 @@ void SmallPacket0x04E(map_session_data_t* session, CCharEntity* PChar, CBasicPac
                 return;
             }
 
-            if (PChar->m_ah_history.size() >= 7)
+            // Get the current number of items the player has for sale
+            const char* Query = "SELECT COUNT(*) FROM auction_house WHERE seller = %u AND sale=0;";
+
+            int32 ret = Sql_Query(SqlHandle, Query, PChar->id);
+            uint8 ah_listings = 0;
+
+            if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0)
+            {
+                Sql_NextRow(SqlHandle);
+                ah_listings = (int32)Sql_GetIntData(SqlHandle, 0);
+                // ShowDebug(CL_CYAN"%s has %d outstanding listings before placing this one." CL_RESET, PChar->GetName(), ah_listings);
+            }
+
+            if (ah_listings >= 7)
             {
                 // ShowDebug(CL_CYAN"%s already has 7 items on the AH\n" CL_RESET,PChar->GetName());
                 PChar->pushPacket(new CAuctionHousePacket(action, 197, 0, 0)); // Failed to place up
@@ -2372,7 +2385,7 @@ void SmallPacket0x04E(map_session_data_t* session, CCharEntity* PChar, CBasicPac
             charutils::UpdateItem(PChar, LOC_INVENTORY, 0, -(int32)auctionFee); // Deduct AH fee
 
             PChar->pushPacket(new CAuctionHousePacket(action, 1, 0, 0)); // Merchandise put up on auction msg
-            PChar->pushPacket(new CAuctionHousePacket(0x0C, (uint8)PChar->m_ah_history.size(), PChar)); // Inform history of slot
+            PChar->pushPacket(new CAuctionHousePacket(0x0C, ah_listings, PChar)); // Inform history of slot
         }
     }
     break;


### PR DESCRIPTION
AH listing count is now checked at every sale,
and not just the cached value from the last time
player viewed their Sale History.

Fixes #86

As previously discussed, the limit is enforced on the client so there's no reason to make it a configurable value.
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

