### PR TITLE
Add noKiller to onMobDeath

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -2911,8 +2911,9 @@ namespace luautils
             Lunar<CLuaBaseEntity>::push(LuaHandle, &LuaMobEntity);
             lua_pushnil(LuaHandle);
             lua_pushnil(LuaHandle);
+            lua_pushboolean(LuaHandle, true);
 
-            if (lua_pcall(LuaHandle, 3, 0, 0))
+            if (lua_pcall(LuaHandle, 4, 0, 0))
             {
                 ShowError("luautils::onMobDeath: %s\n", lua_tostring(LuaHandle, -1));
                 lua_pop(LuaHandle, 1);


### PR DESCRIPTION
Usage of noKiller is similar to isKiller, but is only true when a mob dies
unclaimed. Useful for executing lua on mob death when something needs to
happen only once and a player object isn't required.

Example usage:
```lua
function onMobDeath(mob, player, isKiller, noKiller)
    if isKiller or noKiller then
        -- open a door, spawn a chest, show some death dialogue, etc
        -- do not use player with noKiller
    end
end
```
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

