### PR TITLE
[#490] Fix crash on zone with party

### DIFF
--- a/scripts/globals/spells/recall-jugner.lua
+++ b/scripts/globals/spells/recall-jugner.lua
@@ -12,11 +12,13 @@ function onMagicCastingCheck(caster,target,spell)
 end
 
 function onSpellCast(caster,target,spell)
-    if (target:hasKeyItem(tpz.ki.JUGNER_GATE_CRYSTAL) == true) then
+    if target:getObjType() == tpz.objType.PC then
+        if target:hasKeyItem(tpz.ki.JUGNER_GATE_CRYSTAL) then
             target:addStatusEffectEx(tpz.effect.TELEPORT,0,tpz.teleport.id.JUGNER,0,4.7)
-        spell:setMsg(tpz.msg.basic.MAGIC_TELEPORT)
-    else
-        spell:setMsg(tpz.msg.basic.NO_EFFECT)
+            spell:setMsg(tpz.msg.basic.MAGIC_TELEPORT)
+        else
+            spell:setMsg(tpz.msg.basic.NO_EFFECT)
+        end
     end
     return 0
 end

--- a/scripts/globals/spells/recall-meriph.lua
+++ b/scripts/globals/spells/recall-meriph.lua
@@ -12,11 +12,13 @@ function onMagicCastingCheck(caster,target,spell)
 end
 
 function onSpellCast(caster,target,spell)
-    if (target:hasKeyItem(tpz.ki.MERIPHATAUD_GATE_CRYSTAL) == true) then
+    if target:getObjType() == tpz.objType.PC then
+        if target:hasKeyItem(tpz.ki.MERIPHATAUD_GATE_CRYSTAL) then
             target:addStatusEffectEx(tpz.effect.TELEPORT,0,tpz.teleport.id.MERIPH,0,4.7)
-        spell:setMsg(tpz.msg.basic.MAGIC_TELEPORT)
-    else
-        spell:setMsg(tpz.msg.basic.NO_EFFECT)
+            spell:setMsg(tpz.msg.basic.MAGIC_TELEPORT)
+        else
+            spell:setMsg(tpz.msg.basic.NO_EFFECT)
+        end
     end
     return 0
 end

--- a/scripts/globals/spells/recall-pashh.lua
+++ b/scripts/globals/spells/recall-pashh.lua
@@ -12,11 +12,13 @@ function onMagicCastingCheck(caster,target,spell)
 end
 
 function onSpellCast(caster,target,spell)
-    if (target:hasKeyItem(tpz.ki.PASHHOW_GATE_CRYSTAL) == true) then
+    if target:getObjType() == tpz.objType.PC then
+        if target:hasKeyItem(tpz.ki.PASHHOW_GATE_CRYSTAL) then
             target:addStatusEffectEx(tpz.effect.TELEPORT,0,tpz.teleport.id.PASHH,0,4.7)
-        spell:setMsg(tpz.msg.basic.MAGIC_TELEPORT)
-    else
-        spell:setMsg(tpz.msg.basic.NO_EFFECT)
+            spell:setMsg(tpz.msg.basic.MAGIC_TELEPORT)
+        else
+            spell:setMsg(tpz.msg.basic.NO_EFFECT)
+        end
     end
     return 0
 end

--- a/scripts/globals/spells/teleport-altep.lua
+++ b/scripts/globals/spells/teleport-altep.lua
@@ -12,11 +12,13 @@ function onMagicCastingCheck(caster,target,spell)
 end
 
 function onSpellCast(caster,target,spell)
-    if (target:hasKeyItem(tpz.ki.ALTEPA_GATE_CRYSTAL) == true) then
-        target:addStatusEffectEx(tpz.effect.TELEPORT,0,tpz.teleport.id.ALTEP,0,4.7)
-        spell:setMsg(tpz.msg.basic.MAGIC_TELEPORT)
-    else
-        spell:setMsg(tpz.msg.basic.NO_EFFECT)
+    if target:getObjType() == tpz.objType.PC then
+        if target:hasKeyItem(tpz.ki.ALTEPA_GATE_CRYSTAL) then
+            target:addStatusEffectEx(tpz.effect.TELEPORT,0,tpz.teleport.id.ALTEP,0,4.7)
+            spell:setMsg(tpz.msg.basic.MAGIC_TELEPORT)
+        else
+            spell:setMsg(tpz.msg.basic.NO_EFFECT)
+        end
     end
 
     return 0

--- a/scripts/globals/spells/teleport-dem.lua
+++ b/scripts/globals/spells/teleport-dem.lua
@@ -12,11 +12,13 @@ function onMagicCastingCheck(caster,target,spell)
 end
 
 function onSpellCast(caster,target,spell)
-    if (target:hasKeyItem(tpz.ki.DEM_GATE_CRYSTAL) == true) then
+    if target:getObjType() == tpz.objType.PC then
+        if target:hasKeyItem(tpz.ki.DEM_GATE_CRYSTAL) then
             target:addStatusEffectEx(tpz.effect.TELEPORT,0,tpz.teleport.id.DEM,0,4.7)
-        spell:setMsg(tpz.msg.basic.MAGIC_TELEPORT)
-    else
-        spell:setMsg(tpz.msg.basic.NO_EFFECT)
+            spell:setMsg(tpz.msg.basic.MAGIC_TELEPORT)
+        else
+            spell:setMsg(tpz.msg.basic.NO_EFFECT)
+        end
     end
     return 0
 end

--- a/scripts/globals/spells/teleport-holla.lua
+++ b/scripts/globals/spells/teleport-holla.lua
@@ -12,11 +12,13 @@ function onMagicCastingCheck(caster,target,spell)
 end
 
 function onSpellCast(caster,target,spell)
-    if (target:hasKeyItem(tpz.ki.HOLLA_GATE_CRYSTAL) == true) then
+    if target:getObjType() == tpz.objType.PC then
+        if target:hasKeyItem(tpz.ki.HOLLA_GATE_CRYSTAL) then
             target:addStatusEffectEx(tpz.effect.TELEPORT,0,tpz.teleport.id.HOLLA,0,4.7)
-        spell:setMsg(tpz.msg.basic.MAGIC_TELEPORT)
-    else
-        spell:setMsg(tpz.msg.basic.NO_EFFECT)
+            spell:setMsg(tpz.msg.basic.MAGIC_TELEPORT)
+        else
+            spell:setMsg(tpz.msg.basic.NO_EFFECT)
+        end
     end
     return 0
 end

--- a/scripts/globals/spells/teleport-mea.lua
+++ b/scripts/globals/spells/teleport-mea.lua
@@ -12,11 +12,13 @@ function onMagicCastingCheck(caster,target,spell)
 end
 
 function onSpellCast(caster,target,spell)
-    if (target:hasKeyItem(tpz.ki.MEA_GATE_CRYSTAL) == true) then
+    if target:getObjType() == tpz.objType.PC then
+        if target:hasKeyItem(tpz.ki.MEA_GATE_CRYSTAL) then
             target:addStatusEffectEx(tpz.effect.TELEPORT,0,tpz.teleport.id.MEA,0,4.7)
-        spell:setMsg(tpz.msg.basic.MAGIC_TELEPORT)
-    else
-        spell:setMsg(tpz.msg.basic.NO_EFFECT)
+            spell:setMsg(tpz.msg.basic.MAGIC_TELEPORT)
+        else
+            spell:setMsg(tpz.msg.basic.NO_EFFECT)
+        end
     end
     return 0
 end

--- a/scripts/globals/spells/teleport-vahzl.lua
+++ b/scripts/globals/spells/teleport-vahzl.lua
@@ -12,11 +12,13 @@ function onMagicCastingCheck(caster,target,spell)
 end
 
 function onSpellCast(caster,target,spell)
-    if (target:hasKeyItem(tpz.ki.VAHZL_GATE_CRYSTAL) == true) then
+    if target:getObjType() == tpz.objType.PC then
+        if target:hasKeyItem(tpz.ki.VAHZL_GATE_CRYSTAL) then
             target:addStatusEffectEx(tpz.effect.TELEPORT,0,tpz.teleport.id.VAHZL,0,4.7)
-        spell:setMsg(tpz.msg.basic.MAGIC_TELEPORT)
-    else
-        spell:setMsg(tpz.msg.basic.NO_EFFECT)
+            spell:setMsg(tpz.msg.basic.MAGIC_TELEPORT)
+        else
+            spell:setMsg(tpz.msg.basic.NO_EFFECT)
+        end
     end
     return 0
 end

--- a/scripts/globals/spells/teleport-yhoat.lua
+++ b/scripts/globals/spells/teleport-yhoat.lua
@@ -12,11 +12,13 @@ function onMagicCastingCheck(caster,target,spell)
 end
 
 function onSpellCast(caster,target,spell)
-    if (target:hasKeyItem(tpz.ki.YHOATOR_GATE_CRYSTAL) == true) then
+    if target:getObjType() == tpz.objType.PC then
+        if target:hasKeyItem(tpz.ki.YHOATOR_GATE_CRYSTAL) then
             target:addStatusEffectEx(tpz.effect.TELEPORT,0,tpz.teleport.id.YHOAT,0,4.7)
-        spell:setMsg(tpz.msg.basic.MAGIC_TELEPORT)
-    else
-        spell:setMsg(tpz.msg.basic.NO_EFFECT)
+            spell:setMsg(tpz.msg.basic.MAGIC_TELEPORT)
+        else
+            spell:setMsg(tpz.msg.basic.NO_EFFECT)
+        end
     end
     return 0
 end

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -6694,7 +6694,7 @@ inline int32 CLuaBaseEntity::addKeyItem(lua_State *L)
 inline int32 CLuaBaseEntity::hasKeyItem(lua_State *L)
 {
     TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
-    TPZ_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC && m_PBaseEntity->objtype != TYPE_TRUST);
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
 
     TPZ_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isnumber(L, 1));
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -6694,7 +6694,7 @@ inline int32 CLuaBaseEntity::addKeyItem(lua_State *L)
 inline int32 CLuaBaseEntity::hasKeyItem(lua_State *L)
 {
     TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
-    TPZ_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC && m_PBaseEntity->objtype != TYPE_TRUST);
 
     TPZ_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isnumber(L, 1));
 

--- a/src/map/packets/party_define.cpp
+++ b/src/map/packets/party_define.cpp
@@ -65,26 +65,17 @@ CPartyDefinePacket::CPartyDefinePacket(CParty* PParty, bool loadTrust)
 
         if (loadTrust)
         {
-            ret = Sql_Query(SqlHandle, msg, allianceid, PParty->GetPartyID(), PARTY_SECOND | PARTY_THIRD);
+            CCharEntity* PLeader = (CCharEntity*)PParty->GetLeader();
 
-            if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) > 0)
+            if (PLeader != nullptr)
             {
-                while (Sql_NextRow(SqlHandle) == SQL_SUCCESS)
+                for (auto PTrust : PLeader->PTrusts)
                 {
-                    CCharEntity* PChar = zoneutils::GetChar(Sql_GetUIntData(SqlHandle, 0));
-                    CCharEntity* PLeader = (CCharEntity*)PParty->GetLeader();
-
-                    if (PLeader != nullptr)
-                    {
-                        for (auto PTrust : PLeader->PTrusts)
-                        {
-                            ref<uint32>(12 * i + (0x08)) = PTrust->id;
-                            ref<uint16>(12 * i + (0x0C)) = PTrust->targid;
-                            ref<uint16>(12 * i + (0x0E)) = 0;
-                            ref<uint16>(12 * i + (0x10)) = PTrust->getZone();
-                            i++;
-                        }
-                    }
+                    ref<uint32>(12 * i + (0x08)) = PTrust->id;
+                    ref<uint16>(12 * i + (0x0C)) = PTrust->targid;
+                    ref<uint16>(12 * i + (0x0E)) = 0;
+                    ref<uint16>(12 * i + (0x10)) = PTrust->getZone();
+                    i++;
                 }
             }
         }

--- a/src/map/packets/party_define.cpp
+++ b/src/map/packets/party_define.cpp
@@ -31,40 +31,6 @@ const char* msg = "SELECT chars.charid, partyflag, pos_zone, pos_prevzone FROM a
                                         LEFT JOIN chars ON accounts_parties.charid = chars.charid WHERE \
                                         IF (allianceid <> 0, allianceid = %d, partyid = %d) ORDER BY partyflag & %u, timestamp;";
 
-CPartyDefinePacket::CPartyDefinePacket(CParty* PParty)
-{
-    this->type = 0xC8;
-    this->size = 0x7C;
-
-    if (PParty)
-    {
-        uint32 allianceid = 0;
-        if (PParty->m_PAlliance)
-        {
-            allianceid = PParty->m_PAlliance->m_AllianceID;
-        }
-
-        uint8 i = 0;
-
-        int ret = Sql_Query(SqlHandle, msg, allianceid, PParty->GetPartyID(), PARTY_SECOND | PARTY_THIRD);
-
-        if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) > 0)
-        {
-            while (Sql_NextRow(SqlHandle) == SQL_SUCCESS)
-            {
-                uint16 targid = 0;
-                CCharEntity* PChar = zoneutils::GetChar(Sql_GetUIntData(SqlHandle, 0));
-                if (PChar) targid = PChar->targid;
-                ref<uint32>(12 * i + 0x08) = Sql_GetUIntData(SqlHandle, 0);
-                ref<uint16>(12 * i + 0x0C) = targid;
-                ref<uint16>(12 * i + 0x0E) = Sql_GetUIntData(SqlHandle, 1);
-                ref<uint16>(12 * i + 0x10) = Sql_GetUIntData(SqlHandle, 2) ? Sql_GetUIntData(SqlHandle, 2) : Sql_GetUIntData(SqlHandle, 3);
-                i++;
-            }
-        }
-    }
-}
-
 CPartyDefinePacket::CPartyDefinePacket(CParty* PParty, bool loadTrust)
 {
     this->type = 0xC8;
@@ -97,24 +63,27 @@ CPartyDefinePacket::CPartyDefinePacket(CParty* PParty, bool loadTrust)
             }
         }
 
-        ret = Sql_Query(SqlHandle, msg, allianceid, PParty->GetPartyID(), PARTY_SECOND | PARTY_THIRD);
-
-        if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) > 0)
+        if (loadTrust)
         {
-            while (Sql_NextRow(SqlHandle) == SQL_SUCCESS)
-            {
-                CCharEntity* PChar = zoneutils::GetChar(Sql_GetUIntData(SqlHandle, 0));
-                CCharEntity* PLeader = (CCharEntity*)PParty->GetLeader();
+            ret = Sql_Query(SqlHandle, msg, allianceid, PParty->GetPartyID(), PARTY_SECOND | PARTY_THIRD);
 
-                if (PParty->GetLeader() != nullptr && PParty->GetLeader()->objtype == TYPE_PC)
+            if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) > 0)
+            {
+                while (Sql_NextRow(SqlHandle) == SQL_SUCCESS)
                 {
-                    for (auto PTrust : PLeader->PTrusts)
+                    CCharEntity* PChar = zoneutils::GetChar(Sql_GetUIntData(SqlHandle, 0));
+                    CCharEntity* PLeader = (CCharEntity*)PParty->GetLeader();
+
+                    if (PLeader != nullptr)
                     {
-                        ref<uint32>(12 * i + (0x08)) = PTrust->id;
-                        ref<uint16>(12 * i + (0x0C)) = PTrust->targid;
-                        ref<uint16>(12 * i + (0x0E)) = 0;
-                        ref<uint16>(12 * i + (0x10)) = PTrust->getZone();
-                        i++;
+                        for (auto PTrust : PLeader->PTrusts)
+                        {
+                            ref<uint32>(12 * i + (0x08)) = PTrust->id;
+                            ref<uint16>(12 * i + (0x0C)) = PTrust->targid;
+                            ref<uint16>(12 * i + (0x0E)) = 0;
+                            ref<uint16>(12 * i + (0x10)) = PTrust->getZone();
+                            i++;
+                        }
                     }
                 }
             }

--- a/src/map/packets/party_define.h
+++ b/src/map/packets/party_define.h
@@ -37,9 +37,7 @@ class CParty;
 class CPartyDefinePacket : public CBasicPacket
 {
 public:
-
-    CPartyDefinePacket(CParty* PParty);
-    CPartyDefinePacket(CParty* PParty, bool loadTrust);
+    CPartyDefinePacket(CParty* PParty, bool loadTrust = false);
 };
 
 #endif

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -752,7 +752,7 @@ void CParty::ReloadParty()
             PChar->PLatentEffectContainer->CheckLatentsPartyMembers(members.size());
             PChar->PLatentEffectContainer->CheckLatentsPartyAvatar();
             PChar->ReloadPartyDec();
-            if (PChar->loc.zone->GetID() == PLeader->loc.zone->GetID())
+            if (PChar->getZone() == PLeader->getZone())
             {
                 PChar->pushPacket(new CPartyDefinePacket(this, true));
             }

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -752,13 +752,9 @@ void CParty::ReloadParty()
             PChar->PLatentEffectContainer->CheckLatentsPartyMembers(members.size());
             PChar->PLatentEffectContainer->CheckLatentsPartyAvatar();
             PChar->ReloadPartyDec();
-            if (PChar->getZone() == PLeader->getZone())
+            if (PLeader)
             {
-                PChar->pushPacket(new CPartyDefinePacket(this, true));
-            }
-            else
-            {
-                PChar->pushPacket(new CPartyDefinePacket(this));
+                PChar->pushPacket(new CPartyDefinePacket(this, PChar->getZone() == PLeader->getZone()));
             }
             //auto effects = std::make_unique<CPartyEffectsPacket>();
             uint8 j = 0;


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Fixes #490 

Not yet tested, but given @Kreidos did some digging and it looks like this check will guard against looking at `loc.zone` while it's `nullptr`. Will try and get set up to do some testing later, unless someone else gets to it first.

The existing guarding getter:
```
uint16 CBaseEntity::getZone()
{
    return loc.zone != nullptr ? loc.zone->GetID() : loc.destination;
}
```