### PR TITLE
Apply Tonberry and Fomor hate to alliance members in zone

### DIFF
--- a/scripts/mixins/families/tonberry.lua
+++ b/scripts/mixins/families/tonberry.lua
@@ -6,9 +6,13 @@ g_mixins.families = g_mixins.families or {}
 g_mixins.families.tonberry = function(mob)
     mob:addListener("DEATH", "TONBERRY_DEATH", function(mob, player)
         if player then
-            local kills = player:getCharVar("EVERYONES_GRUDGE_KILLS")
-            if (kills < 480) then
-                player:setCharVar("EVERYONES_GRUDGE_KILLS", kills + 1)
+            for _, member in pairs(player:getAlliance()) do
+                if member:getZoneID() == player:getZoneID() then
+                    local kills = member:getCharVar("EVERYONES_GRUDGE_KILLS")
+                    if kills < 480 then
+                        member:setCharVar("EVERYONES_GRUDGE_KILLS", kills + 1)
+                    end
+                end
             end
         end
     end)

--- a/scripts/mixins/fomor_hate.lua
+++ b/scripts/mixins/fomor_hate.lua
@@ -6,10 +6,16 @@ g_mixins = g_mixins or {}
 g_mixins.fomor_hate = function(mob)
     mob:addListener("DEATH", "FOMOR_HATE_DEATH", function(mob, player)
         if player then
-            local hate = player:getCharVar("FOMOR_HATE")
-            local adj = mob:getLocalVar("fomorHateAdj")
-            if (adj == 0) then adj = 2 end -- most fomor add 2 hate
-            player:setCharVar("FOMOR_HATE", utils.clamp(hate + adj, 0, 60))
+            for _, member in pairs(player:getAlliance()) do
+                if member:getZoneID() == player:getZoneID() then
+                    local hate = member:getCharVar("FOMOR_HATE")
+                    local adj = mob:getLocalVar("fomorHateAdj")
+                    if adj == 0 then
+                        adj = 2 -- default: most fomor add 2 hate
+                    end
+                    member:setCharVar("FOMOR_HATE", utils.clamp(hate + adj, 0, 60))
+                end
+            end
         end
     end)
 end


### PR DESCRIPTION
Fomor and Tonberry mixins were only adding hate to the mob's current target at ToD.  Now, it will apply to all alliance members ~within EXP range~ in zone, even if outside of XP range.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

