### PR TITLE
Fix CS priority + remove "set homepoint?" events (to match retail)

### DIFF
--- a/scripts/zones/Bastok_Markets/Zone.lua
+++ b/scripts/zones/Bastok_Markets/Zone.lua
@@ -17,8 +17,15 @@ end
 function onZoneIn(player, prevZone)
     local cs = -1
 
+    -- FIRST LOGIN (START CS)
+    if player:getPlaytime(false) == 0 then
+        if NEW_CHARACTER_CUTSCENE == 1 then
+            cs = 0
+        end
+        player:setPos(-280, -12, -91, 15)
+        player:setHomePoint()
     -- SOA 1-1 Optional CS
-    if
+    elseif
         ENABLE_SOA and
         player:getCurrentMission(SOA) == tpz.mission.id.soa.RUMORS_FROM_THE_WEST and
         player:getCharVar("SOA_1_CS2") == 0
@@ -26,23 +33,10 @@ function onZoneIn(player, prevZone)
         cs = 22
     end
 
-    -- FIRST LOGIN (START CS)
-    if player:getPlaytime(false) == 0 then
-        if NEW_CHARACTER_CUTSCENE == 1 then
-            --cs = 0
-        end
-        player:setPos(-280, -12, -91, 15)
-        player:setHomePoint()
-    end
-
     -- MOG HOUSE EXIT
     if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
         position = math.random(1, 5) - 33
         player:setPos(-177, -8, position, 127)
-        if player:getMainJob() ~= player:getCharVar("PlayerMainJob") and player:getGMLevel() == 0 then
-            cs = 30004
-        end
-        player:setCharVar("PlayerMainJob", 0)
     end
 
     return cs
@@ -70,9 +64,6 @@ function onEventFinish(player, csid, option)
 
     if csid == 0 then
         player:messageSpecial(ID.text.ITEM_OBTAINED, 536)
-    elseif csid == 30004 and option == 0 then
-        player:setHomePoint()
-        player:messageSpecial(ID.text.HOMEPOINT_SET)
     elseif csid == 22 then
         player:setCharVar("SOA_1_CS2",  1)
     end

--- a/scripts/zones/Bastok_Markets/Zone.lua
+++ b/scripts/zones/Bastok_Markets/Zone.lua
@@ -26,7 +26,7 @@ function onZoneIn(player, prevZone)
         player:setHomePoint()
     -- SOA 1-1 Optional CS
     elseif
-        ENABLE_SOA and
+        ENABLE_SOA == 1 and
         player:getCurrentMission(SOA) == tpz.mission.id.soa.RUMORS_FROM_THE_WEST and
         player:getCharVar("SOA_1_CS2") == 0
     then
@@ -35,7 +35,7 @@ function onZoneIn(player, prevZone)
 
     -- MOG HOUSE EXIT
     if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
-        position = math.random(1, 5) - 33
+        local position = math.random(1, 5) - 33
         player:setPos(-177, -8, position, 127)
     end
 

--- a/scripts/zones/Bastok_Markets_[S]/Zone.lua
+++ b/scripts/zones/Bastok_Markets_[S]/Zone.lua
@@ -15,7 +15,7 @@ function onZoneIn(player, prevZone)
     local cs = -1
     -- MOG HOUSE EXIT
     if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
-        position = math.random(1, 5) - 33
+        local position = math.random(1, 5) - 33
         player:setPos(-177, -8, position, 127)
     end
     return cs

--- a/scripts/zones/Bastok_Markets_[S]/Zone.lua
+++ b/scripts/zones/Bastok_Markets_[S]/Zone.lua
@@ -17,10 +17,6 @@ function onZoneIn(player, prevZone)
     if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
         position = math.random(1, 5) - 33
         player:setPos(-177, -8, position, 127)
-        if player:getMainJob() ~= player:getCharVar("PlayerMainJob") and player:getGMLevel() == 0 then
-            cs = 30004
-        end
-        player:setCharVar("PlayerMainJob", 0)
     end
     return cs
 end

--- a/scripts/zones/Bastok_Mines/Zone.lua
+++ b/scripts/zones/Bastok_Mines/Zone.lua
@@ -29,21 +29,15 @@ function onZoneIn(player, prevZone)
         end
         player:setPos(-45, -0, 26, 213)
         player:setHomePoint()
+    -- ENTER THE TALEKEEPER
+    elseif prevZone == tpz.zone.ZERUHN_MINES and player:getCurrentMission(BASTOK) == tpz.mission.id.bastok.ENTER_THE_TALEKEEPER and player:getCharVar("MissionStatus") == 5 then
+        cs = 176
     end
 
     -- MOG HOUSE EXIT
     if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
         position = math.random(1, 5) - 75
         player:setPos(116, 0.99, position, 127)
-        if player:getMainJob() ~= player:getCharVar("PlayerMainJob") and player:getGMLevel() == 0 then
-            cs = 30004
-        end
-        player:setCharVar("PlayerMainJob", 0)
-    end
-
-    -- ENTER THE TALEKEEPER
-    if prevZone == tpz.zone.ZERUHN_MINES and player:getCurrentMission(BASTOK) == tpz.mission.id.bastok.ENTER_THE_TALEKEEPER and player:getCharVar("MissionStatus") == 5 then
-        cs = 176
     end
 
     return cs
@@ -62,9 +56,6 @@ end
 function onEventFinish(player, csid, option)
     if csid == 1 then
         player:messageSpecial(ID.text.ITEM_OBTAINED, 536) -- adventurer coupon
-    elseif csid == 30004 and option == 0 then
-        player:setHomePoint()
-        player:messageSpecial(ID.text.HOMEPOINT_SET)
     elseif csid == 176 then
         finishMissionTimeline(player, 1, csid, option)
     end

--- a/scripts/zones/Bastok_Mines/Zone.lua
+++ b/scripts/zones/Bastok_Mines/Zone.lua
@@ -36,7 +36,7 @@ function onZoneIn(player, prevZone)
 
     -- MOG HOUSE EXIT
     if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
-        position = math.random(1, 5) - 75
+        local position = math.random(1, 5) - 75
         player:setPos(116, 0.99, position, 127)
     end
 

--- a/scripts/zones/Lower_Jeuno/Zone.lua
+++ b/scripts/zones/Lower_Jeuno/Zone.lua
@@ -31,18 +31,16 @@ function onZoneIn(player, prevZone)
         -- No need for an 'else' to change it back outside these dates as a re-zone will handle that.
     end
 
-    -- MOG HOUSE EXIT
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
-        player:setPos(41.2, -5, 84, 85)
-        if player:getMainJob() ~= player:getCharVar("PlayerMainJob") and player:getGMLevel() == 0 then
-            cs = 30004
-        end
-        player:setCharVar("PlayerMainJob", 0)
-    elseif player:getCurrentMission(COP) == tpz.mission.id.cop.TENDING_AGED_WOUNDS and player:getCharVar("PromathiaStatus") == 0 then
+    if player:getCurrentMission(COP) == tpz.mission.id.cop.TENDING_AGED_WOUNDS and player:getCharVar("PromathiaStatus") == 0 then
         player:setCharVar("PromathiaStatus", 1)
         cs = 70
     elseif ENABLE_ACP == 1 and player:getCurrentMission(ACP) == tpz.mission.id.acp.A_CRYSTALLINE_PROPHECY and player:getMainLvl() >=10 then
         cs = 10094
+    end
+
+    -- MOG HOUSE EXIT
+    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+        player:setPos(41.2, -5, 84, 85)
     end
 
     return cs
@@ -111,10 +109,7 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-    if csid == 30004 and option == 0 then
-        player:setHomePoint()
-        player:messageSpecial(ID.text.HOMEPOINT_SET)
-    elseif csid == 20 then
+    if csid == 20 then
         player:addCharVar("ZilartStatus", 2)
     elseif csid == 10094 then
         player:completeMission(ACP, tpz.mission.id.acp.A_CRYSTALLINE_PROPHECY)

--- a/scripts/zones/Northern_San_dOria/Zone.lua
+++ b/scripts/zones/Northern_San_dOria/Zone.lua
@@ -28,15 +28,6 @@ function onZoneIn(player, prevZone)
     local MissionStatus = player:getCharVar("MissionStatus")
     local cs = -1
 
-    -- SOA 1-1 Optional CS
-    if
-        ENABLE_SOA and
-        player:getCurrentMission(SOA) == tpz.mission.id.soa.RUMORS_FROM_THE_WEST and
-        player:getCharVar("SOA_1_CS1") == 0
-    then
-        cs = 878
-    end
-
     -- FIRST LOGIN (START CS)
     if player:getPlaytime(false) == 0 then
         if NEW_CHARACTER_CUTSCENE == 1 then
@@ -44,17 +35,15 @@ function onZoneIn(player, prevZone)
         end
         player:setPos(0, 0, -11, 191)
         player:setHomePoint()
-    end
-    -- MOG HOUSE EXIT
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
-        player:setPos(130, -0.2, -3, 160)
-        if player:getMainJob() ~= player:getCharVar("PlayerMainJob") and player:getGMLevel() == 0 then
-            cs = 30004
-        end
-        player:setCharVar("PlayerMainJob", 0)
-    end
+    -- SOA 1-1 Optional CS
+    elseif
+        ENABLE_SOA and
+        player:getCurrentMission(SOA) == tpz.mission.id.soa.RUMORS_FROM_THE_WEST and
+        player:getCharVar("SOA_1_CS1") == 0
+    then
+        cs = 878
     -- RDM AF3 CS
-    if player:getCharVar("peaceForTheSpiritCS") == 5 and player:getFreeSlotsCount() >= 1 then
+    elseif player:getCharVar("peaceForTheSpiritCS") == 5 and player:getFreeSlotsCount() >= 1 then
         cs = 49
     elseif player:getCurrentMission(COP) == tpz.mission.id.cop.THE_ROAD_FORKS and player:getCharVar("EMERALD_WATERS_Status") == 1 then --EMERALD_WATERS-- COP 3-3A: San d'Oria Route
         player:setCharVar("EMERALD_WATERS_Status", 2)
@@ -66,6 +55,12 @@ function onZoneIn(player, prevZone)
     elseif player:hasCompletedMission(SANDORIA, tpz.mission.id.sandoria.COMING_OF_AGE) and tonumber(os.date("%j")) == player:getCharVar("Wait1DayM8-1_date") then
         cs = 16
     end
+
+    -- MOG HOUSE EXIT
+    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+        player:setPos(130, -0.2, -3, 160)
+    end
+
     return cs
 end
 
@@ -101,9 +96,6 @@ function onEventFinish(player, csid, option)
         player:setCharVar("MissionStatus", 1)
     elseif csid == 0 then
         player:setCharVar("MissionStatus", 5)
-    elseif csid == 30004 and option == 0 then
-        player:setHomePoint()
-        player:messageSpecial(ID.text.HOMEPOINT_SET)
     elseif csid == 569 then
         player:setPos(0, 0, -13, 192, 233)
     elseif csid == 49 and npcUtil.completeQuest(player, SANDORIA, tpz.quest.id.sandoria.PEACE_FOR_THE_SPIRIT, {item = 12513, fame = 60, title = tpz.title.PARAGON_OF_RED_MAGE_EXCELLENCE}) then

--- a/scripts/zones/Northern_San_dOria/Zone.lua
+++ b/scripts/zones/Northern_San_dOria/Zone.lua
@@ -37,7 +37,7 @@ function onZoneIn(player, prevZone)
         player:setHomePoint()
     -- SOA 1-1 Optional CS
     elseif
-        ENABLE_SOA and
+        ENABLE_SOA == 1 and
         player:getCurrentMission(SOA) == tpz.mission.id.soa.RUMORS_FROM_THE_WEST and
         player:getCharVar("SOA_1_CS1") == 0
     then

--- a/scripts/zones/Port_Bastok/Zone.lua
+++ b/scripts/zones/Port_Bastok/Zone.lua
@@ -22,8 +22,8 @@ end;
 function onZoneIn(player,prevZone)
     local cs = -1;
     -- FIRST LOGIN (START CS)
-    if (player:getPlaytime(false) == 0) then
-        if (NEW_CHARACTER_CUTSCENE == 1) then
+    if player:getPlaytime(false) == 0 then
+        if NEW_CHARACTER_CUTSCENE == 1 then
             cs = 1;
         end
         player:setPos(132,-8.5,-13,179);

--- a/scripts/zones/Port_Bastok/Zone.lua
+++ b/scripts/zones/Port_Bastok/Zone.lua
@@ -28,6 +28,8 @@ function onZoneIn(player,prevZone)
         end
         player:setPos(132,-8.5,-13,179);
         player:setHomePoint();
+    elseif (player:getCurrentMission(COP) == tpz.mission.id.cop.THE_ENDURING_TUMULT_OF_WAR and player:getCharVar("PromathiaStatus") == 0) then
+        cs = 306;
     end
 
     if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
@@ -37,15 +39,7 @@ function onZoneIn(player,prevZone)
         else
             local position = math.random(1,5) + 57;
             player:setPos(position,8.5,-239,192);
-            if player:getMainJob() ~= player:getCharVar("PlayerMainJob") and player:getGMLevel() == 0 then
-                cs = 30004;
-            end
-            player:setCharVar("PlayerMainJob",0);
         end
-    end
-
-    if (player:getCurrentMission(COP) == tpz.mission.id.cop.THE_ENDURING_TUMULT_OF_WAR and player:getCharVar("PromathiaStatus") == 0) then
-        cs = 306;
     end
 
     return cs;
@@ -74,9 +68,6 @@ function onEventFinish(player,csid,option)
         player:messageSpecial(ID.text.ITEM_OBTAINED,536);
     elseif (csid == 71) then
         player:setPos(0,0,0,0,224);
-    elseif (csid == 30004 and option == 0) then
-        player:setHomePoint();
-        player:messageSpecial(ID.text.HOMEPOINT_SET);
     elseif (csid == 305) then
         player:setCharVar("PromathiaStatus",1);
     elseif (csid == 306) then

--- a/scripts/zones/Port_Jeuno/Zone.lua
+++ b/scripts/zones/Port_Jeuno/Zone.lua
@@ -26,6 +26,13 @@ function onZoneIn(player,prevZone)
         -- No need for an 'else' to change it back outside these dates as a re-zone will handle that.
     end
 
+    if
+        ENABLE_ABYSSEA == 1 and player:getMainLvl() >= 30
+        and player:getQuestStatus(ABYSSEA, tpz.quest.id.abyssea.A_JOURNEY_BEGINS) == QUEST_AVAILABLE
+    then
+        cs = 324;
+    end
+
     if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
         if (prevZone == tpz.zone.SAN_DORIA_JEUNO_AIRSHIP) then
             cs = 10018;
@@ -42,14 +49,7 @@ function onZoneIn(player,prevZone)
         else
             local position = math.random(1,3) - 2;
             player:setPos(-192.5 ,-5,position,0);
-            if player:getMainJob() ~= player:getCharVar("PlayerMainJob") and player:getGMLevel() == 0 then
-                cs = 30004;
-            end
-            player:setCharVar("PlayerMainJob",0);
         end
-    elseif (ENABLE_ABYSSEA == 1 and player:getMainLvl() >= 30
-    and player:getQuestStatus(ABYSSEA, tpz.quest.id.abyssea.A_JOURNEY_BEGINS) == QUEST_AVAILABLE) then
-        cs = 324;
     end
 
     return cs
@@ -83,9 +83,6 @@ function onEventFinish(player,csid,option)
         player:setPos(0,0,0,0,224);
     elseif (csid == 10013) then
         player:setPos(0,0,0,0,226);
-    elseif (csid == 30004 and option == 0) then
-        player:setHomePoint();
-        player:messageSpecial(ID.text.HOMEPOINT_SET);
     elseif (csid == 324) then
         player:addQuest(ABYSSEA, tpz.quest.id.abyssea.A_JOURNEY_BEGINS);
     end

--- a/scripts/zones/Port_San_dOria/Zone.lua
+++ b/scripts/zones/Port_San_dOria/Zone.lua
@@ -22,6 +22,8 @@ function onZoneIn(player,prevZone)
         end
         player:setPos(-104, -8, -128, 227);
         player:setHomePoint();
+    elseif (player:getCurrentMission(COP) == tpz.mission.id.cop.THREE_PATHS and player:getCharVar("COP_Ulmia_s_Path") == 1) then
+        cs = 4;
     end
 
     if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
@@ -30,15 +32,7 @@ function onZoneIn(player,prevZone)
             player:setPos(-1.000, 0.000, 44.000, 0);
         else
             player:setPos(80,-16,-135,165);
-            if player:getMainJob() ~= player:getCharVar("PlayerMainJob") and player:getGMLevel() == 0 then
-                cs = 30004;
-            end
-            player:setCharVar("PlayerMainJob",0);
         end
-    end
-
-    if (player:getCurrentMission(COP) == tpz.mission.id.cop.THREE_PATHS and player:getCharVar("COP_Ulmia_s_Path") == 1) then
-        cs =4;
     end
 
     return cs;
@@ -60,9 +54,6 @@ function onEventFinish(player,csid,option)
         player:messageSpecial(ID.text.ITEM_OBTAINED,536);
     elseif (csid == 700) then
         player:setPos(0,0,0,0,223);
-    elseif (csid == 30004 and option == 0) then
-        player:setHomePoint();
-        player:messageSpecial(ID.text.HOMEPOINT_SET);
     elseif (csid == 4) then
         player:setCharVar("COP_Ulmia_s_Path",2);
     end

--- a/scripts/zones/Port_San_dOria/Zone.lua
+++ b/scripts/zones/Port_San_dOria/Zone.lua
@@ -16,8 +16,8 @@ end;
 function onZoneIn(player,prevZone)
     local cs = -1;
     -- FIRST LOGIN (START CS)
-    if (player:getPlaytime(false) == 0) then
-        if (NEW_CHARACTER_CUTSCENE == 1) then
+    if player:getPlaytime(false) == 0 then
+        if NEW_CHARACTER_CUTSCENE == 1 then
             cs = 500;
         end
         player:setPos(-104, -8, -128, 227);

--- a/scripts/zones/Port_Windurst/Zone.lua
+++ b/scripts/zones/Port_Windurst/Zone.lua
@@ -30,10 +30,6 @@ function onZoneIn(player,prevZone)
         else
             position = math.random(1,5) + 195;
             player:setPos(position,-15.56,258,65);
-            if player:getMainJob() ~= player:getCharVar("PlayerMainJob") and player:getGMLevel() == 0 then
-                cs = 30004;
-            end
-            player:setCharVar("PlayerMainJob",0);
         end
     end
     return cs;
@@ -55,8 +51,5 @@ function onEventFinish(player,csid,option)
         player:messageSpecial(ID.text.ITEM_OBTAINED,536);
     elseif (csid == 10002) then
         player:setPos(0,0,0,0,225);
-    elseif (csid == 30004 and option == 0) then
-        player:setHomePoint();
-        player:messageSpecial(ID.text.HOMEPOINT_SET);
     end
 end;

--- a/scripts/zones/Port_Windurst/Zone.lua
+++ b/scripts/zones/Port_Windurst/Zone.lua
@@ -16,8 +16,8 @@ end;
 function onZoneIn(player,prevZone)
     local cs = -1;
     -- FIRST LOGIN (START CS)
-    if (player:getPlaytime(false) == 0) then
-        if (NEW_CHARACTER_CUTSCENE == 1) then
+    if player:getPlaytime(false) == 0 then
+        if NEW_CHARACTER_CUTSCENE == 1 then
             cs = 305;
         end
         player:setPos(-120,-5.5,175,48);
@@ -28,7 +28,7 @@ function onZoneIn(player,prevZone)
             cs = 10004;
             player:setPos(228.000, -3.000, 76.000, 160);
         else
-            position = math.random(1,5) + 195;
+            local position = math.random(1,5) + 195;
             player:setPos(position,-15.56,258,65);
         end
     end

--- a/scripts/zones/Residential_Area/Zone.lua
+++ b/scripts/zones/Residential_Area/Zone.lua
@@ -12,7 +12,6 @@ end;
 function onZoneIn(player,prevZone)
     local cs = -1;
 
-    player:setCharVar("PlayerMainJob",player:getMainJob());
     player:eraseStatusEffect(true);
     player:setPos(0,0,0,192);
 

--- a/scripts/zones/RuLude_Gardens/Zone.lua
+++ b/scripts/zones/RuLude_Gardens/Zone.lua
@@ -15,18 +15,15 @@ end
 
 function onZoneIn(player, prevZone)
     local cs = -1
+
+    if player:getCurrentMission(COP) == tpz.mission.id.cop.FOR_WHOM_THE_VERSE_IS_SUNG  and  player:getCharVar("PromathiaStatus") == 2 then
+        cs = 10047
+    end
+
     -- MOG HOUSE EXIT
     if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
         position = math.random(1, 5) + 45
         player:setPos(position, 10, -73, 192)
-        if player:getMainJob() ~= player:getCharVar("PlayerMainJob") and player:getGMLevel() == 0 then
-            cs = 30004
-        end
-        player:setCharVar("PlayerMainJob", 0)
-    end
-
-    if player:getCurrentMission(COP) == tpz.mission.id.cop.FOR_WHOM_THE_VERSE_IS_SUNG  and  player:getCharVar("PromathiaStatus") == 2 then
-        cs = 10047
     end
 
     return cs
@@ -82,9 +79,6 @@ function onEventFinish(player, csid, option)
         -- progress are recorded in the following two variables
         player:setCharVar("MEMORIES_OF_A_MAIDEN_Status", 1) -- MEMORIES_OF_A_MAIDEN--3-3B: Windurst Road
         player:setCharVar("EMERALD_WATERS_Status", 1) -- EMERALD_WATERS-- 3-3A: San d'Oria Road
-    elseif csid == 30004 and option == 0 then
-        player:setHomePoint()
-        player:messageSpecial(ID.text.HOMEPOINT_SET)
     elseif csid == 10047 then
         player:setCharVar("PromathiaStatus", 0)
         player:completeMission(COP, tpz.mission.id.cop.FOR_WHOM_THE_VERSE_IS_SUNG)

--- a/scripts/zones/Southern_San_dOria/Zone.lua
+++ b/scripts/zones/Southern_San_dOria/Zone.lua
@@ -27,14 +27,12 @@ function onZoneIn(player, prevZone)
         player:setPos(-96, 1, -40, 224)
         player:setHomePoint()
     end
+
     -- MOG HOUSE EXIT
     if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
         player:setPos(161, -2, 161, 94)
-        if player:getMainJob() ~= player:getCharVar("PlayerMainJob") and player:getGMLevel() == 0 then
-            cs = 30004
-        end
-        player:setCharVar("PlayerMainJob", 0)
     end
+
     return cs
 end
 
@@ -58,9 +56,6 @@ end
 function onEventFinish(player, csid, option)
     if csid == 503 then
         player:messageSpecial(ID.text.ITEM_OBTAINED, 536)
-    elseif csid == 30004 and option == 0 then
-        player:setHomePoint()
-        player:messageSpecial(ID.text.HOMEPOINT_SET)
     elseif csid == 758 then
         player:setCharVar("COP_louverance_story", 3)
     end

--- a/scripts/zones/Southern_San_dOria_[S]/Zone.lua
+++ b/scripts/zones/Southern_San_dOria_[S]/Zone.lua
@@ -32,10 +32,6 @@ function onZoneIn(player, prevZone)
     -- MOG HOUSE EXIT
     if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
         player:setPos(161, -2, 161, 94)
-        if player:getMainJob() ~= player:getCharVar("PlayerMainJob") and player:getGMLevel() == 0 then
-            cs = 30004
-        end
-        player:setCharVar("PlayerMainJob", 0)
     end
     return cs
 end

--- a/scripts/zones/Upper_Jeuno/Zone.lua
+++ b/scripts/zones/Upper_Jeuno/Zone.lua
@@ -27,13 +27,11 @@ function onZoneIn(player, prevZone)
     -- COP mission 1-1
     if player:getCurrentMission(COP) == tpz.mission.id.cop.THE_RITES_OF_LIFE and player:getCharVar("PromathiaStatus") == 0 then
         cs = 2
+    end
+
     -- MOG HOUSE EXIT
-    elseif player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
         player:setPos(46.2, -5, -78, 172)
-        if player:getMainJob() ~= player:getCharVar("PlayerMainJob") and player:getGMLevel() == 0 then
-            cs = 30004
-        end
-        player:setCharVar("PlayerMainJob", 0)
     end
 
     return cs
@@ -50,10 +48,7 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-    if csid == 30004 and option == 0 then
-        player:setHomePoint()
-        player:messageSpecial(ID.text.HOMEPOINT_SET)
-    elseif csid == 2 then
+    if csid == 2 then
         player:setCharVar("PromathiaStatus", 1)
     end
 end

--- a/scripts/zones/Windurst_Walls/Zone.lua
+++ b/scripts/zones/Windurst_Walls/Zone.lua
@@ -18,19 +18,18 @@ end
 
 function onZoneIn(player, prevZone)
     local cs = -1
-    -- MOG HOUSE EXIT
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
-        position = math.random(1, 5) - 123
-        player:setPos(-257.5, -5.05, position, 0)
-        if player:getMainJob() ~= player:getCharVar("PlayerMainJob") and player:getGMLevel() == 0 then
-            cs = 30004
-        end
-        player:setCharVar("PlayerMainJob", 0)
-    elseif ENABLE_ASA == 1 and player:getCurrentMission(ASA) == tpz.mission.id.asa.A_SHANTOTTO_ASCENSION
+
+    if ENABLE_ASA == 1 and player:getCurrentMission(ASA) == tpz.mission.id.asa.A_SHANTOTTO_ASCENSION
         and (prevZone == tpz.zone.WINDURST_WATERS or prevZone == tpz.zone.WINDURST_WOODS) and player:getMainLvl()>=10 then
         cs = 510
     elseif player:getCurrentMission(WINDURST) == tpz.mission.id.windurst.MOON_READING and player:getCharVar("MissionStatus") == 4 then
         cs = 443
+    end
+
+    -- MOG HOUSE EXIT
+    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+        position = math.random(1, 5) - 123
+        player:setPos(-257.5, -5.05, position, 0)
     end
 
     return cs
@@ -58,9 +57,6 @@ end
 function onEventFinish(player, csid, option)
     if csid == 86 then
         player:setPos(0, 0, -22.40, 192, 242)
-    elseif csid == 30004 and option == 0 then
-        player:setHomePoint()
-        player:messageSpecial(ID.text.HOMEPOINT_SET)
     elseif csid == 510 then
         player:startEvent(514)
     elseif csid == 514 then

--- a/scripts/zones/Windurst_Walls/Zone.lua
+++ b/scripts/zones/Windurst_Walls/Zone.lua
@@ -28,7 +28,7 @@ function onZoneIn(player, prevZone)
 
     -- MOG HOUSE EXIT
     if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
-        position = math.random(1, 5) - 123
+        local position = math.random(1, 5) - 123
         player:setPos(-257.5, -5.05, position, 0)
     end
 

--- a/scripts/zones/Windurst_Waters/Zone.lua
+++ b/scripts/zones/Windurst_Waters/Zone.lua
@@ -28,21 +28,15 @@ function onZoneIn(player, prevZone)
         end
         player:setPos(-40, -5, 80, 64)
         player:setHomePoint()
+    elseif player:getCurrentMission(COP) == tpz.mission.id.cop.THE_ROAD_FORKS and player:getCharVar("MEMORIES_OF_A_MAIDEN_Status") == 1 then -- COP MEMORIES_OF_A_MAIDEN--3-3B: Windurst Route
+        player:setCharVar("MEMORIES_OF_A_MAIDEN_Status", 2)
+        cs = 871
     end
 
     -- MOG HOUSE EXIT
     if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
         position = math.random(1, 5) + 157
         player:setPos(position, -5, -62, 192)
-        if player:getMainJob() ~= player:getCharVar("PlayerMainJob") and player:getGMLevel() == 0 then
-            cs = 30004
-        end
-        player:setCharVar("PlayerMainJob", 0)
-    end
-
-    if player:getCurrentMission(COP) == tpz.mission.id.cop.THE_ROAD_FORKS and player:getCharVar("MEMORIES_OF_A_MAIDEN_Status") == 1 then -- COP MEMORIES_OF_A_MAIDEN--3-3B: Windurst Route
-        player:setCharVar("MEMORIES_OF_A_MAIDEN_Status", 2)
-        cs = 871
     end
 
     return cs
@@ -72,9 +66,6 @@ end
 function onEventFinish(player, csid, option)
     if csid == 531 then
         player:messageSpecial(ID.text.ITEM_OBTAINED, 536)
-    elseif csid == 30004 and option == 0 then
-        player:setHomePoint()
-        player:messageSpecial(ID.text.HOMEPOINT_SET)
     elseif csid == 146 then -- Returned from Giddeus, Windurst 1-3
         player:setCharVar("MissionStatus", 3)
         player:setCharVar("ghoo_talk", 0)

--- a/scripts/zones/Windurst_Waters/Zone.lua
+++ b/scripts/zones/Windurst_Waters/Zone.lua
@@ -35,7 +35,7 @@ function onZoneIn(player, prevZone)
 
     -- MOG HOUSE EXIT
     if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
-        position = math.random(1, 5) + 157
+        local position = math.random(1, 5) + 157
         player:setPos(position, -5, -62, 192)
     end
 

--- a/scripts/zones/Windurst_Waters_[S]/Zone.lua
+++ b/scripts/zones/Windurst_Waters_[S]/Zone.lua
@@ -17,10 +17,6 @@ function onZoneIn(player, prevZone)
     -- MOG HOUSE EXIT
     if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
         player:setPos(157 + math.random(1, 5), -5, -62, 192)
-        if player:getMainJob() ~= player:getCharVar("PlayerMainJob") and player:getGMLevel() == 0 then
-            cs = 30004
-        end
-        player:setCharVar("PlayerMainJob", 0)
     end
 
     return cs

--- a/scripts/zones/Windurst_Woods/Zone.lua
+++ b/scripts/zones/Windurst_Woods/Zone.lua
@@ -28,7 +28,7 @@ function onZoneIn(player, prevZone)
         player:setHomePoint()
     -- SOA 1-1 Optional CS
     elseif
-        ENABLE_SOA and
+        ENABLE_SOA == 1 and
         player:getCurrentMission(SOA) == tpz.mission.id.soa.RUMORS_FROM_THE_WEST and
         player:getCharVar("SOA_1_CS3") == 0
     then
@@ -37,7 +37,7 @@ function onZoneIn(player, prevZone)
 
     -- MOG HOUSE EXIT
     if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
-        position = math.random(1, 5) + 37
+        local position = math.random(1, 5) + 37
         player:setPos(-138, -10, position, 0)
     end
 

--- a/scripts/zones/Windurst_Woods/Zone.lua
+++ b/scripts/zones/Windurst_Woods/Zone.lua
@@ -19,15 +19,6 @@ end
 function onZoneIn(player, prevZone)
     local cs = -1
 
-    -- SOA 1-1 Optional CS
-    if
-        ENABLE_SOA and
-        player:getCurrentMission(SOA) == tpz.mission.id.soa.RUMORS_FROM_THE_WEST and
-        player:getCharVar("SOA_1_CS3") == 0
-    then
-        cs = 839
-    end
-
     -- FIRST LOGIN (START CS)
     if player:getPlaytime(false) == 0 then
         if NEW_CHARACTER_CUTSCENE == 1 then
@@ -35,16 +26,19 @@ function onZoneIn(player, prevZone)
         end
         player:setPos(0, 0, -50, 0)
         player:setHomePoint()
+    -- SOA 1-1 Optional CS
+    elseif
+        ENABLE_SOA and
+        player:getCurrentMission(SOA) == tpz.mission.id.soa.RUMORS_FROM_THE_WEST and
+        player:getCharVar("SOA_1_CS3") == 0
+    then
+        cs = 839
     end
 
     -- MOG HOUSE EXIT
     if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
         position = math.random(1, 5) + 37
         player:setPos(-138, -10, position, 0)
-        if player:getMainJob() ~= player:getCharVar("PlayerMainJob") and player:getGMLevel() == 0 then
-            cs = 30004
-        end
-        player:setCharVar("PlayerMainJob", 0)
     end
 
     return cs
@@ -63,9 +57,6 @@ end
 function onEventFinish(player, csid, option)
     if csid == 367 then
         player:messageSpecial(ID.text.ITEM_OBTAINED, 536)
-    elseif csid == 30004 and option == 0 then
-        player:setHomePoint()
-        player:messageSpecial(ID.text.HOMEPOINT_SET)
     elseif csid == 839 then
         player:setCharVar("SOA_1_CS3", 1)
     end


### PR DESCRIPTION
I _assume_ this will also let GMs escape their moghouses. But for all I know @zach2good might just have an overly attached Moogle.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

