### PR TITLE
Fixes Thuban and Herensegue's WS.

### DIFF
--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -1066,7 +1066,7 @@ INSERT INTO `mob_skill_lists` VALUES ('Structure',236,999);
 INSERT INTO `mob_skill_lists` VALUES ('Structure',236,1000);
 INSERT INTO `mob_skill_lists` VALUES ('Structure',236,1001);
 -- 235 to 238: assigned to many random mobs
-INSERT INTO `mob_skill_lists` VALUES ('Thunderclaw_Thuban',239,629); -- thunderbolt
+INSERT INTO `mob_skill_lists` VALUES ('Thunderclaw_Thuban',239,378); -- thunderbolt
 INSERT INTO `mob_skill_lists` VALUES ('Tauri',240,498);
 INSERT INTO `mob_skill_lists` VALUES ('Tauri',240,499);
 INSERT INTO `mob_skill_lists` VALUES ('Tauri',240,500);


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Thuban and Heren's current WS is set to Behemoth's Thunderbolt, they need to have the raptor version thunderbolt_breath to avoid having a spasm when using their WS.