### PR TITLE
Change auto add master on UpdateEnmity

### DIFF
--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -106,7 +106,7 @@ bool CMobSkillState::Update(time_point tick)
         auto PTarget = GetTarget();
         if (PTarget && PTarget->objtype == TYPE_MOB && PTarget != m_PEntity && m_PEntity->allegiance == ALLEGIANCE_PLAYER)
         {
-            static_cast<CMobEntity*>(PTarget)->PEnmityContainer->UpdateEnmity(m_PEntity, 0, 0, true);
+            static_cast<CMobEntity*>(PTarget)->PEnmityContainer->UpdateEnmity(m_PEntity, 0, 0);
         }
         m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_STATE_EXIT", m_PEntity, m_PSkill->getID());
         return true;

--- a/src/map/enmity_container.h
+++ b/src/map/enmity_container.h
@@ -54,7 +54,7 @@ public:
     void    Clear(uint32 EntityID = 0);         // Removes Entries from list
     void    LogoutReset(uint32 EntityID);       // Sets entry to inactive
     void    AddBaseEnmity(CBattleEntity* PEntity);
-    void    UpdateEnmity(CBattleEntity* PEntity, int32 CE, int32 VE, bool withMaster = true, bool tameable = false);
+    void    UpdateEnmity(CBattleEntity* PEntity, int32 CE, int32 VE, bool withMaster = false, bool tameable = false);
     void    UpdateEnmityFromDamage(CBattleEntity* PEntity, int32 Damage);
     void    UpdateEnmityFromCure(CBattleEntity* PEntity, uint8 level, int32 CureAmount, bool isCureV);
     void    UpdateEnmityFromAttack(CBattleEntity* PEntity, int32 Damage);


### PR DESCRIPTION
Stop adding master by default when a pet calls `UpdateEnmity`. `ClaimMob` should handle this now when an actual claiming action is performed, and actions that don't claim (for example Automaton mobskills and spells) will only add the pet.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

