### PR TITLE
Add range check to wyvern's Healing Breath

### DIFF
--- a/scripts/globals/pets/wyvern.lua
+++ b/scripts/globals/pets/wyvern.lua
@@ -34,12 +34,17 @@ local wyvernTypes = {
 }
 
 function doHealingBreath(player, threshold, breath)
-    if player:getHPP() < threshold then
+    local breath_heal_range = 13
+    local function inBreathRange(target)
+        return player:getPet():getZoneID() == target:getZoneID() and player:getPet():checkDistance(target) <= breath_heal_range
+    end
+
+    if player:getHPP() < threshold and inBreathRange(player) then
         player:getPet():useJobAbility(breath, player)
     else
         local party = player:getParty()
         for _,member in ipairs(party) do
-            if member:getHPP() < threshold then
+            if member:getHPP() < threshold and inBreathRange(member) then
                 player:getPet():useJobAbility(breath, member)
                 break
             end


### PR DESCRIPTION
Does what it says on the tin. Previously the Wyvern would ignorantly try using healing breath even when members were on another map or way out of range.

Used the Wiki value of 13 for being 'in-range' for healing breath.

Fixes #523

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

