### PR TITLE
Fix claim base enmity from blocking tame

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4061,7 +4061,7 @@ namespace battleutils
             CMobEntity* mob = static_cast<CMobEntity*>(PDefender);
             if (!passing)
             {
-                mob->PEnmityContainer->UpdateEnmity(original, 0, 0, true);
+                mob->PEnmityContainer->UpdateEnmity(original, 0, 0, true, true);
             }
             if (PAttacker)
             {


### PR DESCRIPTION
Claim itself shouldn't be setting a mob to be untameable. Fixes a failed charm attempt from blocking tame.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

