### PR TITLE
Stop tame applying enmity on success

### DIFF
--- a/scripts/globals/abilities/tame.lua
+++ b/scripts/globals/abilities/tame.lua
@@ -16,15 +16,18 @@ end
 function onUseAbility(player,target,ability)
     if player:getPet() ~= nil then
         ability:setMsg(tpz.msg.basic.JA_NO_EFFECT)
+        target:addEnmity(player, 1, 0)
         return 0
     end
     if target:getMobMod(tpz.mobMod.CHARMABLE) == 0 then
         ability:setMsg(tpz.msg.basic.JA_NO_EFFECT)
+        target:addEnmity(player, 1, 0)
         return 0
     end
     local resist = applyResistanceAbility(player, target, tpz.magic.ele.NONE, tpz.skill.NONE, player:getStat(tpz.mod.INT) - target:getStat(tpz.mod.INT))
     if resist <= 0.25 then
         ability:setMsg(tpz.msg.basic.JA_MISS_2)
+        target:addEnmity(player, 1, 0)
         return 0
     else
         if target:isEngaged() then
@@ -32,10 +35,12 @@ function onUseAbility(player,target,ability)
             for _,enmity in ipairs(enmitylist) do
                 if enmity.active and enmity.entity:getID() ~= player:getID() then
                     ability:setMsg(tpz.msg.basic.JA_NO_EFFECT)
+                    target:addEnmity(player, 1, 0)
                     return 0
                 elseif enmity.entity:getID() == player:getID() then
                     if not enmity.tameable then
                         ability:setMsg(tpz.msg.basic.JA_NO_EFFECT)
+                        target:addEnmity(player, 1, 0)
                         return 0
                     end
                 end

--- a/sql/abilities.sql
+++ b/sql/abilities.sql
@@ -76,7 +76,7 @@ INSERT INTO `abilities` VALUES (34,'arcane_circle',8,5,1,600,86,0,0,30,2000,0,6,
 INSERT INTO `abilities` VALUES (35,'last_resort',8,15,1,300,87,0,0,12,2000,0,6,20.0,0,1,1300,836,0,NULL);
 INSERT INTO `abilities` VALUES (36,'charm',9,1,4,15,97,0,0,13,2000,0,6,18.0,0,320,0,0,0,NULL);
 INSERT INTO `abilities` VALUES (37,'gauge',9,10,4,30,98,0,0,14,2000,0,6,23.0,0,0,0,0,0,NULL);
-INSERT INTO `abilities` VALUES (38,'tame',9,30,4,600,99,0,0,15,2000,0,6,18.0,0,1,0,904,0,NULL);
+INSERT INTO `abilities` VALUES (38,'tame',9,30,4,600,99,0,0,15,2000,0,6,18.0,0,0,0,904,0,NULL);
 INSERT INTO `abilities` VALUES (39,'pet_commands',9,1,1,0,0,0,0,0,2000,0,6,18.0,0,0,0,0,0,NULL);
 INSERT INTO `abilities` VALUES (40,'scavenge',11,10,1,180,121,0,0,21,2000,0,6,20.0,0,1,80,1024,0,NULL);
 INSERT INTO `abilities` VALUES (41,'shadowbind',11,40,4,300,122,0,0,188,2000,0,3,18.0,0,1,800,0,0,NULL);


### PR DESCRIPTION
Tame should only apply enmity on fail.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

