### PR TITLE
Casket fix

### DIFF
--- a/scripts/globals/caskets.lua
+++ b/scripts/globals/caskets.lua
@@ -102,7 +102,7 @@ local function timeElapsedCheck(npc)
         return false
     end
 
-    if npc:getLocalVar("[caskets]SPAWNTIME") > 0 then
+    if npc:getLocalVar("[caskets]SPAWNTIME") then
         spawnTime = npc:getLocalVar("[caskets]SPAWNTIME")
     end
     
@@ -127,7 +127,7 @@ local function getCasketID(mob)
     for i = baseChestId, baseChestId + 15 do
         if timeElapsedCheck(GetNPCByID(i)) then
             if GetNPCByID(i):getLocalVar("[caskets]SPAWNSTATUS") == casketInfo.spawnStatus.DESPAWNED or
-                GetNPCByID(i):getLocalVar("[caskets]SPAWNSTATUS") == nil then
+                GetNPCByID(i):getLocalVar("[caskets]SPAWNSTATUS") == 0 then
                 chestId = i
                 break
             end
@@ -165,7 +165,6 @@ local function dropChance(player)
     end
 
     local rand = math.random()
-
     if rand < utils.clamp(CASKET_DROP_RATE + kupowersMMBPower + prowessCasketsPower, 0, 1) then
         return true
     end

--- a/scripts/mixins/spawn_casket.lua
+++ b/scripts/mixins/spawn_casket.lua
@@ -12,14 +12,16 @@ g_mixins = g_mixins or {}
 g_mixins.spawn_casket = function(mob)
     mob:addListener("DEATH", "DEATH_SPAWN_CASKET", function(mob, player, isKiller)
         local mobPos = mob:getPos()
-
-        if mob:getMaster() ~= nil then
-            local master = mob:getMaster()
-            if master:isMob() then -- sanity check, ensuring the mob killed is not a player's pet.
+        
+        if player then
+            if mob:getMaster() ~= nil then
+                local master = mob:getMaster()
+                if master:isMob() then -- sanity check, ensuring the mob killed is not a player's pet.
+                    tpz.caskets.spawnCasket(player, mob, mobPos.x, mobPos.y, mobPos.z, mobPos.rot)
+                end
+            else
                 tpz.caskets.spawnCasket(player, mob, mobPos.x, mobPos.y, mobPos.z, mobPos.rot)
             end
-        else
-            tpz.caskets.spawnCasket(player, mob, mobPos.x, mobPos.y, mobPos.z, mobPos.rot)
         end
     end)
 end


### PR DESCRIPTION
Had an issuse where the local var was not being checked correctly, now fixed.
Added a player check to ensure the casket mixin will not execute if no player is present on mob death.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [X] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [X] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

