### PR TITLE
Add configurable subjob cap ratio..

### DIFF
--- a/conf/default/map.conf
+++ b/conf/default/map.conf
@@ -136,6 +136,16 @@ player_mp_multiplier: 1.0
 #Sets the fraction of MP a subjob provides to the main job. Retail is half and this acts as a divisor so default is 2
 sj_mp_divisor: 2.0
 
+# Modify ratio of subjob-to-mainjob
+# 0 = no subjobs
+# 1 = 1/2   (default, 75/37, 99/49)
+# 2 = 2/3   (75/50, 99/66)
+# 3 = equal (75/75, 99/99)
+subjob_ratio: 1
+
+#Also adjust monsters subjob in ratio adjustments? 1= true / 0 = false
+include_mob_sj: 0
+
 #Adjust base stats (str/vit/etc.) for NMs, regular mobs, and players. Acts as a multiplier, so default is 1.
 nm_stat_multiplier:     1.0
 mob_stat_multiplier:    1.0

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -776,10 +776,38 @@ void CBattleEntity::SetMLevel(uint8 mlvl)
 
 void CBattleEntity::SetSLevel(uint8 slvl)
 {
-    m_slvl = (slvl > (m_mlvl >> 1) ? (m_mlvl == 1 ? 1 : (m_mlvl >> 1)) : slvl);
+    if (!map_config.include_mob_sj && (this->objtype == TYPE_MOB && this->objtype != TYPE_PET))
+    {
+        // Technically, we shouldn't be assuming mobs even have a ratio they must adhere to.
+        // But there is no place in the DB to set subLV right now.
+        m_slvl = (slvl > (m_mlvl >> 1) ? (m_mlvl == 1 ? 1 : (m_mlvl >> 1)) : slvl);
+    }
+    else
+    {
+        switch (map_config.subjob_ratio)
+        {
+            case 0: //no SJ...Where is your Altana now?
+                m_slvl = 0;
+                break;
+            case 1: // 1/2 (75/37, 99/49)
+                m_slvl = (slvl > (m_mlvl >> 1) ? (m_mlvl == 1 ? 1 : (m_mlvl >> 1)) : slvl);
+                break;
+            case 2: // 2/3 (75/50, 99/66)
+                m_slvl = (slvl > (m_mlvl * 2) / 3 ? (m_mlvl == 1 ? 1 : (m_mlvl * 2) / 3) : slvl);
+                break;
+            case 3: // equal (75/75, 99/99)
+                m_slvl = (slvl > m_mlvl ? (m_mlvl == 1 ? 1 : m_mlvl) : slvl);
+                break;
+            default: // Error
+                ShowError("Error setting subjob level: Invalid ratio '%s' check your map.conf file!\n", map_config.subjob_ratio);
+                break;
+        }
+    }
 
     if (this->objtype & TYPE_PC)
+    {
         Sql_Query(SqlHandle, "UPDATE char_stats SET slvl = %u WHERE charid = %u LIMIT 1;", m_slvl, this->id);
+    }
 }
 
 /************************************************************************

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -977,6 +977,8 @@ int32 map_config_default()
     map_config.mob_mp_multiplier = 1.0f;
     map_config.player_mp_multiplier = 1.0f;
     map_config.sj_mp_divisor = 2.0f;
+    map_config.subjob_ratio = 1;
+    map_config.include_mob_sj = false;
     map_config.nm_stat_multiplier = 1.0f;
     map_config.mob_stat_multiplier = 1.0f;
     map_config.player_stat_multiplier = 1.0f;
@@ -1159,6 +1161,14 @@ int32 map_config_read(const int8* cfgName)
         else if (strcmp(w1, "sj_mp_divisor") == 0)
         {
             map_config.sj_mp_divisor = (float)atof(w2);
+        }
+        else if (strcmp(w1, "subjob_ratio") == 0)
+        {
+            map_config.subjob_ratio = atoi(w2);
+        }
+        else if (strcmp(w1, "include_mob_sj") == 0)
+        {
+            map_config.include_mob_sj = atoi(w2);
         }
         else if (strcmp(w1, "nm_stat_multiplier") == 0)
         {

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -109,6 +109,8 @@ struct map_config_t
     float  mob_mp_multiplier;         // Multiplier for max MP pool of mob
     float  player_mp_multiplier;      // Multiplier for max MP pool of player
     float  sj_mp_divisor;             // Divisor to use on subjob max MP
+    int8   subjob_ratio;              // Modify ratio of subjob-to-mainjob
+    bool   include_mob_sj;            // Include mobs in effects of SJ ratio setting
     float  nm_stat_multiplier;        // Multiplier for str/vit/etc of NMs
     float  mob_stat_multiplier;       // Multiplier for str/vit/etc of mobs
     float  player_stat_multiplier;    // Multiplier for str/vit/etc. of NMs of player


### PR DESCRIPTION
..and an option to apply to mobs that I hope is eventually deprecated by the ability to manually set mobs sj lv range. :smiley: 

The player options also apply to pets with the exception of charm pets, since those are mobs.

if `subjob_ratio` is 1, player subjobs are normal (one half) as in retail. This is the default option.
2 will set cap of two-thirds, so a lv 75 player can have a subjob up to lv 50, or a lv 99 player up to lv66
3 will make subjobs capped even to mainjob.
0 will make subjobs lv 0 and grant nothing.

I did not want to do this as a float value divisor or multiplier for several reasons, not the least of which is explaining to people the proper math with get the ratio they intended.

`include_mob_sj` determines if the adjustments also apply to monsters.

NOTE: since `SetSLevel()` handled the cap in its entirely, all existing attempts to set the subjob should lead back to here and rely on this. However any instance where a previous editor did not know this probably ***already had incorrect sub levels before I changed anything.***

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits
