### PR TITLE
Caskets: Split area loot

### DIFF
--- a/scripts/globals/casket_loot.lua
+++ b/scripts/globals/casket_loot.lua
@@ -1,3 +1,9 @@
+-----------------------------------------------------------
+-- Caskets loot tables
+-- Note: some zones are split into high and low teir,
+-- this is because some zones have high mobs and low mobs,
+-- and the drops are level dependant.
+-----------------------------------------------------------
 tpz = tpz or {}
 tpz.casket_loot = tpz.casket_loot or {}
 

--- a/scripts/globals/caskets.lua
+++ b/scripts/globals/caskets.lua
@@ -58,6 +58,15 @@ local casketInfo =
         167, 169, 172, 173, 174, 176, 177, 178, 184, 190, 191, 192,
         193, 194, 195, 196, 197, 198, 204, 205, 207, 208, 212, 213
     },
+    splitZones = set{
+       tpz.zone.ZERUHN_MINES,
+       tpz.zone.KORROLOKA_TUNNEL,
+       tpz.zone.KING_RANPERRES_TOMB,
+       tpz.zone.ORDELLES_CAVES,
+       tpz.zone.OUTER_HORUTOTO_RUINS,
+       tpz.zone.GUSGEN_MINES,
+       tpz.zone.MAZE_OF_SHAKHRAMI
+    },
     cs =
     {
         [0]  = 1000, [1]  = 1003, [2]  = 1006, [3]  = 1009, [4]  = 1012, [5]  = 1015,
@@ -402,10 +411,7 @@ function getDrops(npc, dropType, zoneId)
         local tempCount    = 1
         local randomTable  = {1,3,1,2,1,2,1,1,3,1,2,1}
 
-        if zoneId == 172 or zoneId == 173 or zoneId == 190 or
-           zoneId == 191 or zoneId == 193 or zoneId == 194 or
-           zoneId == 196 or zoneId == 198 then
-
+        if casketInfo.splitZones[zoneId] then
             local mobLvl = npc:getLocalVar("[caskets]MOBLVL")
             if mobLvl > 50 then
                 tempDrops = tpz.casket_loot.casketItems[zoneId].tempsHi
@@ -450,9 +456,7 @@ function getDrops(npc, dropType, zoneId)
         local itemCount    = 1
         local randomTable  = {1,4,1,3,1,1,2,1,3,1,2,1}
 
-        if zoneId == 172 or zoneId == 173 or zoneId == 190 or
-           zoneId == 191 or zoneId == 193 or zoneId == 194 or
-           zoneId == 196 or zoneId == 198 then
+        if casketInfo.splitZones[zoneId] then
             local mobLvl = npc:getLocalVar("[caskets]MOBLVL")
             if mobLvl > 50 then
                 drops = tpz.casket_loot.casketItems[zoneId].itemsHi

--- a/scripts/globals/caskets.lua
+++ b/scripts/globals/caskets.lua
@@ -201,7 +201,7 @@ end
 ---------------------------------------------------------------------------------------------
 -- Desc: Sets all the base localVar's, type of chest and if locked, sets the random number.
 ---------------------------------------------------------------------------------------------
-local function setCasketData(player, x, y, z, r, npc, partyID)
+local function setCasketData(player, x, y, z, r, npc, partyID, mobLvl)
     ---------------------------------------------------------------------------------------------------
     -- NOTE: Super Kupowers Myriad Mystery Boxes add an additional 20% chance the chest will be locked.
     ---------------------------------------------------------------------------------------------------
@@ -231,6 +231,7 @@ local function setCasketData(player, x, y, z, r, npc, partyID)
         -------------------------------------
         npc:setLocalVar("[caskets]PARTYID", partyID)
         npc:setLocalVar("[caskets]ITEMS_SET", 0)
+        npc:setLocalVar("[caskets]MOBLVL", mobLvl)
 
         if chestStyle == 966 then
             npc:setLocalVar("[caskets]ATTEMPTS", attempts)
@@ -401,10 +402,23 @@ function getDrops(npc, dropType, zoneId)
         local tempCount    = 1
         local randomTable  = {1,3,1,2,1,2,1,1,3,1,2,1}
 
+        if zoneId == 172 or zoneId == 173 or zoneId == 190 or
+           zoneId == 191 or zoneId == 193 or zoneId == 194 or
+           zoneId == 196 or zoneId == 198 then
+
+            local mobLvl = npc:getLocalVar("[caskets]MOBLVL")
+            if mobLvl > 50 then
+                tempDrops = tpz.casket_loot.casketItems[zoneId].tempsHi
+            else
+                tempDrops = tpz.casket_loot.casketItems[zoneId].tempsLow
+            end
+        else
+            tempDrops = tpz.casket_loot.casketItems[zoneId].temps
+        end
+
         tempCount = randomTable[math.random(1, #randomTable)]
 
         for i = 1, tempCount do
-            local tempDrops = tpz.casket_loot.casketItems[zoneId].temps
             local sum = 0
 
             for k, v in pairs(tempDrops) do
@@ -436,10 +450,23 @@ function getDrops(npc, dropType, zoneId)
         local itemCount    = 1
         local randomTable  = {1,4,1,3,1,1,2,1,3,1,2,1}
 
+        if zoneId == 172 or zoneId == 173 or zoneId == 190 or
+           zoneId == 191 or zoneId == 193 or zoneId == 194 or
+           zoneId == 196 or zoneId == 198 then
+            local mobLvl = npc:getLocalVar("[caskets]MOBLVL")
+            if mobLvl > 50 then
+                drops = tpz.casket_loot.casketItems[zoneId].itemsHi
+            else
+                drops = tpz.casket_loot.casketItems[zoneId].itemsLow
+                canDropReigonal = false
+            end
+        else
+            drops = tpz.casket_loot.casketItems[zoneId].items
+        end
+
         itemCount = randomTable[math.random(1, #randomTable)]
 
         for i = 1, itemCount do
-            local drops = tpz.casket_loot.casketItems[zoneId].items
             local sum = 0
 
             for k, v in pairs(drops) do
@@ -459,8 +486,8 @@ function getDrops(npc, dropType, zoneId)
             if item == 0 or item == nil then
                 items[i] = 4112 -- default to potion
             else
-                if math.random() < 0.05 then
-                    items[i] = tpz.casket_loot.casketItems[zoneId].regionalItems[math.random(1, #tpz.casket_loot.casketItems[zoneId].regionalItems)]
+                if math.random() < 0.05 and canDropReigonal then
+                    items[1] = casketItems[zoneId].regionalItems[math.random(1, #casketItems[zoneId].regionalItems)]
                 else
                     items[i] = item
                 end
@@ -609,7 +636,7 @@ tpz.caskets.spawnCasket = function (player, mob, x, y, z, r)
     end
 
     if dropChance(player) then
-        setCasketData(player, x, y, z, r, npc, chestOwner)
+        setCasketData(player, x, y, z, r, npc, chestOwner, mob:getMainLvl())
     end
 end
 

--- a/scripts/globals/caskets.lua
+++ b/scripts/globals/caskets.lua
@@ -458,7 +458,6 @@ function getDrops(npc, dropType, zoneId)
                 drops = tpz.casket_loot.casketItems[zoneId].itemsHi
             else
                 drops = tpz.casket_loot.casketItems[zoneId].itemsLow
-                canDropReigonal = false
             end
         else
             drops = tpz.casket_loot.casketItems[zoneId].items
@@ -486,7 +485,7 @@ function getDrops(npc, dropType, zoneId)
             if item == 0 or item == nil then
                 items[i] = 4112 -- default to potion
             else
-                if math.random() < 0.05 and canDropReigonal then
+                if math.random() < 0.05 then
                     items[1] = casketItems[zoneId].regionalItems[math.random(1, #casketItems[zoneId].regionalItems)]
                 else
                     items[i] = item


### PR DESCRIPTION
This allows areas with split mob levels to assign loot to caskets,
previously left out from a mistake on a rebase.


<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [X] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [X] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

