### PR TITLE
Add key trading to mystery box

### DIFF
--- a/scripts/globals/gobbiemysterybox.lua
+++ b/scripts/globals/gobbiemysterybox.lua
@@ -87,26 +87,20 @@ local gobbieJunk =
     19220
 }
 tpz.mystery.onTrade = function (player, npc, trade, events)
-    if not trade then
-        return false
-    elseif trade:getItemCount() == 1 then
-        local keyID = trade:getItemId(0)
-        if keyID == nil or keyID < 1 or keyID > 65535 or trade:getItemCount() ~= 1 or trade:getSlotQty(0) ~= 1 then
-            return false
-        else
+    if trade:getItemCount() == 1 then
+        local tradeID = trade:getItemId(0)
+        if keyToDial[tradeID] ~= nil then
             if player:getFreeSlotsCount() == 0 then
-                player:startEvent(events.FULL_INV, keyID, keyToDial[keyID])
-            elseif keyToDial[keyID] ~= 0 then
-                if player:getFreeSlotsCount() == 0 then
-                    player:startEvent(events.FULL_INV, keyID, keyToDial[keyID])
-                else
-                    player:setLocalVar("gobbieBoxKey", keyID)
-                    player:startEvent(events.KEY_TRADE, keyID, keyToDial[keyID])
-                end
-            else -- trade for points
+                player:startEvent(events.FULL_INV, tradeID, keyToDial[tradeID])
                 return false
             end
+            player:setLocalVar("gobbieBoxKey", tradeID)
+            player:startEvent(events.KEY_TRADE, tradeID, keyToDial[tradeID])
+        else -- trade for points
+            return false
         end
+    else
+        return false
     end
 end
 
@@ -150,19 +144,19 @@ tpz.mystery.onEventUpdate = function (player, csid, option, events)
         if option == 1 then
             local keyID = player:getLocalVar("gobbieBoxKey")
             player:setLocalVar("gobbieBoxKey", 0)
-            switch (keyID): caseof
+            switch (keyToDial[keyID]): caseof
             {
-                [8973] = function() itemID = SelectDailyItem(player, 6) end,  -- special dial
-                [9217] = function() -- abjuration
+                [6] = function() itemID = SelectDailyItem(player, 6) end,  -- special dial
+                [9] = function() -- abjuration
                     itemID = abjurationItems[math.random(1, #abjurationItems)]
                     if player:hasItem(itemID) then
                         itemID = gobbieJunk[math.random(1, #gobbieJunk)]
                     end
                 end,
-                [9218] = function() itemID = fortuneItems[math.random(1, #fortuneItems)] end, -- fortune
-              --[????] = function()  end, -- furnishing
-                [9274] = function()-- anniversary
-                    if math.random(1,100) == 1 then -- 1% chance for extra rare item?
+                [10] = function() itemID = fortuneItems[math.random(1, #fortuneItems)] end, -- fortune
+              --[??] = function()  end, -- furnishing
+                [13] = function()-- anniversary
+                    if math.random(1,100) == 1 then -- 1% chance for ANV exclusive item?
                         itemID = anniversaryItems[math.random(1, #anniversaryItems)] 
                     else
                         itemID = SelectDailyItem(player, 6)

--- a/scripts/globals/gobbiemysterybox.lua
+++ b/scripts/globals/gobbiemysterybox.lua
@@ -18,6 +18,97 @@ local costs =
     [5] = 10,
     [6] = 50
 }
+local keyToDial =
+{
+    [8973] = 6,  -- special dial
+    [9217] = 9,  -- abjuration
+    [9218] = 10, -- fortune
+  --[????] = 11, -- furnishing
+    [9274] = 13, -- anniversary
+}
+local abjurationItems =
+{
+    1314,1315,1316,1317,1318, -- dryadic
+    1319,1320,1321,1322,1323, -- earthen
+    1324,1325,1326,1327,1328, -- aquarian
+    1329,1330,1331,1332,1333, -- martial
+    1334,1335,1336,1337,1338, -- wyrmal
+    1339,1340,1341,1342,1343, -- neptunal
+    1441,1442,                -- food
+    2429,2430,2431,2432,2433, -- phantasmal
+    2434,2435,2436,2437,2438, -- hadean
+    3559,3560,3561,3562,3563, -- corvine
+    3564,3565,3566,3567,3568, -- supernal
+    3569,3570,3571,3572,3573, -- transitory
+    3574,3575,3576,3577,3578, -- foreboding
+    3579,3580,3581,3582,3583, -- lenitive
+    8762,8763,8764,8765,8766, -- bushin
+    8767,8768,8769,8770,8771, -- vale
+    8772,8773,8774,8775,8776, -- grove
+    8777,8778,8779,8780,8781, -- triton
+    8782,8783,8784,8785,8786, -- shinryu
+    8787,8788,8789,8790,8791, -- abyssal
+    9105,9106,9107,9108,9109, -- cronian
+    9110,9111,9112,9113,9114, -- arean
+    9115,9116,9117,9118,9119, -- jovian
+    9120,9121,9122,9123,9124, -- venerian
+    9125,9126,9127,9128,9129, -- cyllenian
+}
+local fortuneItems =
+{
+    5737,5736, -- alexandrite
+    6180,6183,6532, -- pluton
+    6181,6184,6535, -- beitetsu
+    6182,6185,6534, -- rift boulder
+    5854,5855,5856,5857,5858, -- frayed pouches
+    5109,5110,5111,5112,5946,5947,6264,6345,6346,6370,6486,6487,6488 -- frayed sacks
+}
+local anniversaryItems =
+{
+    9274 -- just give them back their key until this table can be populated
+}
+local gobbieJunk =
+{
+    507,
+    508,
+    510,
+    511,
+    566,
+    568,
+    1239,
+    1868,
+    2542,
+    2543,
+    4539,
+    4543,
+    9777,
+    15203,
+    18180,
+    19220
+}
+tpz.mystery.onTrade = function (player, npc, trade, events)
+    if not trade then
+        return false
+    elseif trade:getItemCount() == 1 then
+        local keyID = trade:getItemId(0)
+        if keyID == nil or keyID < 1 or keyID > 65535 or trade:getItemCount() ~= 1 or trade:getSlotQty(0) ~= 1 then
+            return false
+        else
+            if player:getFreeSlotsCount() == 0 then
+                player:startEvent(events.FULL_INV, keyID, keyToDial[keyID])
+            elseif keyToDial[keyID] ~= 0 then
+                if player:getFreeSlotsCount() == 0 then
+                    player:startEvent(events.FULL_INV, keyID, keyToDial[keyID])
+                else
+                    player:setLocalVar("gobbieBoxKey", keyID)
+                    player:startEvent(events.KEY_TRADE, keyID, keyToDial[keyID])
+                end
+            else -- trade for points
+                return false
+            end
+        end
+    end
+end
 
 tpz.mystery.onTrigger = function (player, npc, events)
     local event = events
@@ -40,7 +131,7 @@ tpz.mystery.onTrigger = function (player, npc, events)
             player:startEvent(event.DEFAULT, specialDialUsed, adoulinDialUsed, pictlogicaDialUsed, wantedDialUsed, 0, 0, hideOptionFlags, dailyTallyPoints)
         end
     else
-        player:messageSpecial(event.LIL_BABY, GOBBIE_BOX_MIN_AGE - playerAgeDays)
+        player:messageSpecial(zones[player:getZoneID()].text.YOU_MUST_WAIT_ANOTHER_N_DAYS, GOBBIE_BOX_MIN_AGE - playerAgeDays)
     end
 end
 
@@ -53,9 +144,41 @@ tpz.mystery.onEventUpdate = function (player, csid, option, events)
     local adoulinDialUsed = player:getMaskBit(gobbieBoxUsed, 1) and 1 or 0
     local pictlogicaDialUsed = player:getMaskBit(gobbieBoxUsed, 2) and 1 or 0
     local wantedDialUsed = player:getMaskBit(gobbieBoxUsed, 3) and 1 or 0
-    local itemid = 0
+    local itemID = 0
 
-    if csid == event.DEFAULT then
+    if csid == event.KEY_TRADE then
+        if option == 1 then
+            local keyID = player:getLocalVar("gobbieBoxKey")
+            player:setLocalVar("gobbieBoxKey", 0)
+            switch (keyID): caseof
+            {
+                [8973] = function() itemID = SelectDailyItem(player, 6) end,  -- special dial
+                [9217] = function() -- abjuration
+                    itemID = abjurationItems[math.random(1, #abjurationItems)]
+                    if player:hasItem(itemID) then
+                        itemID = gobbieJunk[math.random(1, #gobbieJunk)]
+                    end
+                end,
+                [9218] = function() itemID = fortuneItems[math.random(1, #fortuneItems)] end, -- fortune
+              --[????] = function()  end, -- furnishing
+                [9274] = function()-- anniversary
+                    if math.random(1,100) == 1 then -- 1% chance for extra rare item?
+                        itemID = anniversaryItems[math.random(1, #anniversaryItems)] 
+                    else
+                        itemID = SelectDailyItem(player, 6)
+                    end
+                end
+            }
+            player:setCharVar("gobbieBoxHoldingItem", itemID)
+            player:tradeComplete()
+            player:updateEvent(itemID, keyToDial[keyID], 3)
+        elseif option == 2 then
+            if holdingItem > 0 and npcUtil.giveItem(player, holdingItem) then
+                player:setCharVar("gobbieBoxHoldingItem", 0)
+            end
+            player:updateEvent(itemID, 0)
+        end
+    elseif csid == event.DEFAULT then
         if option == 4 then
             player:updateEvent(SelectDailyItem(player, 6), SelectDailyItem(player, 6), SelectDailyItem(player, 6), 0, 0, 0, 0, dailyTallyPoints) -- peek
         else
@@ -74,13 +197,13 @@ tpz.mystery.onEventUpdate = function (player, csid, option, events)
                     if dial_used then
                         player:updateEvent(1, dial, 2) -- already used this dial
                     elseif dailyTallyPoints >= dial_cost then
-                        itemid = SelectDailyItem(player, dial)
-                        player:setCharVar("gobbieBoxHoldingItem", itemid)
+                        itemID = SelectDailyItem(player, dial)
+                        player:setCharVar("gobbieBoxHoldingItem", itemID)
                         player:setCurrency("daily_tally", dailyTallyPoints - dial_cost)
                         if dial_mask then
                             player:setMaskBit(gobbieBoxUsed, "gobbieBoxUsed", dial_mask, true)
                         end
-                        player:updateEvent(itemid, dial, 0)
+                        player:updateEvent(itemID, dial, 0)
                     else
                         player:updateEvent(1, dial, 1) -- not enough points
                     end
@@ -88,7 +211,7 @@ tpz.mystery.onEventUpdate = function (player, csid, option, events)
                 [2] = function()
                     if player:getFreeSlotsCount() == 0 then
                         player:updateEvent(holdingItem, 0, 0, 1) -- inventory full, exit event
-                        player:messageSpecial(event.ITEM_CANNOT_BE_OBTAINED + 2) -- generic "Cannot obtain the item."
+                        player:messageSpecial(zones[player:getZoneID()].text.ITEM_CANNOT_BE_OBTAINED + 2) -- generic "Cannot obtain the item."
                     end
                 end,
                 [5] = function()
@@ -108,7 +231,7 @@ tpz.mystery.onEventFinish = function (player, csid, option, events)
         player:setCurrency("daily_tally", 50)
     elseif csid == event.HOLDING_ITEM then
         if player:getFreeSlotsCount() == 0 then
-            player:messageSpecial(event.ITEM_CANNOT_BE_OBTAINED + 2) -- generic "Cannot obtain the item."
+            player:messageSpecial(zones[player:getZoneID()].text.ITEM_CANNOT_BE_OBTAINED + 2) -- generic "Cannot obtain the item."
         elseif npcUtil.giveItem(player, player:getCharVar("gobbieBoxHoldingItem")) then
             player:setCharVar("gobbieBoxHoldingItem", 0)
         end

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Wondrix.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Wondrix.lua
@@ -1,8 +1,7 @@
 -----------------------------------
--- Area: Windurst Woods
---  NPC: Arbitrix
+-- Area: Aht Urhgan Whitegate
+--  NPC: Wondrix
 -- Gobbie Mystery Box
--- !pos -215.5 0.0 -147.3
 -----------------------------------
 local ID = require("scripts/zones/Aht_Urhgan_Whitegate/IDs")
 require("scripts/globals/settings")
@@ -22,10 +21,12 @@ local events =
     KEY_TRADE               = 989,
     NO_THANKS               = 990,
     FULL_INV                = 991,
-    OTHER_BAD_TRADE         = 992,
-    ITEM_CANNOT_BE_OBTAINED = 219,
-    LIL_BABY                = 833
+    OTHER_BAD_TRADE         = 992
 }
+
+function onTrade(player,npc,trade)
+    tpz.mystery.onTrade(player, npc, trade, events)
+end
 
 function onTrigger(player, npc)
     tpz.mystery.onTrigger(player, npc, events)

--- a/scripts/zones/Bastok_Markets/npcs/Specilox.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Specilox.lua
@@ -1,8 +1,7 @@
 -----------------------------------
--- Area: Windurst Woods
---  NPC: Arbitrix
+-- Area: Bastok Markets
+--  NPC: Specilox
 -- Gobbie Mystery Box
--- !pos -215.5 0.0 -147.3
 -----------------------------------
 local ID = require("scripts/zones/Bastok_Markets/IDs")
 require("scripts/globals/settings")
@@ -22,10 +21,12 @@ local events =
     KEY_TRADE               = 6010,
     NO_THANKS               = 6011,
     FULL_INV                = 6012,
-    OTHER_BAD_TRADE         = 6013,
-    ITEM_CANNOT_BE_OBTAINED = 6382,
-    LIL_BABY                = 6424
+    OTHER_BAD_TRADE         = 6013
 }
+
+function onTrade(player,npc,trade)
+    tpz.mystery.onTrade(player, npc, trade, events)
+end
 
 function onTrigger(player, npc)
     tpz.mystery.onTrigger(player, npc, events)

--- a/scripts/zones/Bastok_Mines/npcs/Bountibox.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Bountibox.lua
@@ -1,8 +1,7 @@
 -----------------------------------
--- Area: Windurst Woods
---  NPC: Arbitrix
+-- Area: Bastok Mines
+--  NPC: Bountibox
 -- Gobbie Mystery Box
--- !pos -215.5 0.0 -147.3
 -----------------------------------
 local ID = require("scripts/zones/Bastok_Mines/IDs")
 require("scripts/globals/settings")
@@ -22,10 +21,12 @@ local events =
     KEY_TRADE               = 6010,
     NO_THANKS               = 6011,
     FULL_INV                = 6012,
-    OTHER_BAD_TRADE         = 6013,
-    ITEM_CANNOT_BE_OBTAINED = 6382,
-    LIL_BABY                = 6424
+    OTHER_BAD_TRADE         = 6013
 }
+
+function onTrade(player,npc,trade)
+    tpz.mystery.onTrade(player, npc, trade, events)
+end
 
 function onTrigger(player, npc)
     tpz.mystery.onTrigger(player, npc, events)

--- a/scripts/zones/Lower_Jeuno/npcs/Sweepstox.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Sweepstox.lua
@@ -1,8 +1,7 @@
 -----------------------------------
--- Area: Windurst Woods
---  NPC: Arbitrix
+-- Area: Lower Jeuno
+--  NPC: Sweepstox
 -- Gobbie Mystery Box
--- !pos -215.5 0.0 -147.3
 -----------------------------------
 local ID = require("scripts/zones/Lower_Jeuno/IDs")
 require("scripts/globals/settings")
@@ -22,10 +21,12 @@ local events =
     KEY_TRADE               = 20065,
     NO_THANKS               = 20066,
     FULL_INV                = 20067,
-    OTHER_BAD_TRADE         = 20068,
-    ITEM_CANNOT_BE_OBTAINED = 6382,
-    LIL_BABY                = 6424
+    OTHER_BAD_TRADE         = 20068
 }
+
+function onTrade(player,npc,trade)
+    tpz.mystery.onTrade(player, npc, trade, events)
+end
 
 function onTrigger(player, npc)
     tpz.mystery.onTrigger(player, npc, events)

--- a/scripts/zones/Port_San_dOria/npcs/Habitox.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Habitox.lua
@@ -1,8 +1,7 @@
 -----------------------------------
--- Area: Windurst Woods
---  NPC: Arbitrix
+-- Area: Port San d'Oria
+--  NPC: Habitox
 -- Gobbie Mystery Box
--- !pos -215.5 0.0 -147.3
 -----------------------------------
 local ID = require("scripts/zones/Port_San_dOria/IDs")
 require("scripts/globals/settings")
@@ -22,10 +21,12 @@ local events =
     KEY_TRADE               = 812,
     NO_THANKS               = 813,
     FULL_INV                = 814,
-    OTHER_BAD_TRADE         = 815,
-    LIL_BABY                = 6468,
-    ITEM_CANNOT_BE_OBTAINED = 6426
+    OTHER_BAD_TRADE         = 815
 }
+
+function onTrade(player,npc,trade)
+    tpz.mystery.onTrade(player, npc, trade, events)
+end
 
 function onTrigger(player, npc)
     tpz.mystery.onTrigger(player, npc, events)

--- a/scripts/zones/Southern_San_dOria/npcs/Mystrix.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Mystrix.lua
@@ -1,8 +1,7 @@
 -----------------------------------
--- Area: Windurst Woods
---  NPC: Arbitrix
+-- Area: Southern San d'Oria
+--  NPC: Mystrix
 -- Gobbie Mystery Box
--- !pos -215.5 0.0 -147.3
 -----------------------------------
 local ID = require("scripts/zones/Southern_San_dOria/IDs")
 require("scripts/globals/settings")
@@ -22,10 +21,12 @@ local events =
     KEY_TRADE               = 4010,
     NO_THANKS               = 4011,
     FULL_INV                = 4012,
-    OTHER_BAD_TRADE         = 4013,
-    ITEM_CANNOT_BE_OBTAINED = 6426,
-    LIL_BABY                = 6468
+    OTHER_BAD_TRADE         = 4013
 }
+
+function onTrade(player,npc,trade)
+    tpz.mystery.onTrade(player, npc, trade, events)
+end
 
 function onTrigger(player, npc)
     tpz.mystery.onTrigger(player, npc, events)

--- a/scripts/zones/Upper_Jeuno/npcs/Priztrix.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Priztrix.lua
@@ -1,8 +1,7 @@
 -----------------------------------
--- Area: Windurst Woods
---  NPC: Arbitrix
+-- Area: Upper Jeuno
+--  NPC: Priztrix
 -- Gobbie Mystery Box
--- !pos -215.5 0.0 -147.3
 -----------------------------------
 local ID = require("scripts/zones/Upper_Jeuno/IDs")
 require("scripts/globals/settings")
@@ -22,10 +21,12 @@ local events =
     KEY_TRADE               = 6010,
     NO_THANKS               = 6011,
     FULL_INV                = 6012,
-    OTHER_BAD_TRADE         = 6013,
-    ITEM_CANNOT_BE_OBTAINED = 6541,
-    LIL_BABY                = 6583
+    OTHER_BAD_TRADE         = 6013
 }
+
+function onTrade(player,npc,trade)
+    tpz.mystery.onTrade(player, npc, trade, events)
+end
 
 function onTrigger(player, npc)
     tpz.mystery.onTrigger(player, npc, events)

--- a/scripts/zones/Windurst_Walls/npcs/Arbitrix.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Arbitrix.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Area: Windurst Woods
+-- Area: Windurst Walls
 --  NPC: Arbitrix
 -- Gobbie Mystery Box
 -- !pos -215.5 0.0 -147.3
@@ -22,10 +22,12 @@ local events =
     KEY_TRADE               = 536,
     NO_THANKS               = 537,
     FULL_INV                = 538,
-    OTHER_BAD_TRADE         = 539,
-    ITEM_CANNOT_BE_OBTAINED = 6541,
-    LIL_BABY                = 6583
+    OTHER_BAD_TRADE         = 539
 }
+
+function onTrade(player,npc,trade)
+    tpz.mystery.onTrade(player, npc, trade, events)
+end
 
 function onTrigger(player, npc)
     tpz.mystery.onTrigger(player, npc, events)

--- a/scripts/zones/Windurst_Woods/npcs/Funtrox.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Funtrox.lua
@@ -1,8 +1,7 @@
 -----------------------------------
 -- Area: Windurst Woods
---  NPC: Arbitrix
+--  NPC: Funtrox
 -- Gobbie Mystery Box
--- !pos -215.5 0.0 -147.3
 -----------------------------------
 local ID = require("scripts/zones/Windurst_Woods/IDs")
 require("scripts/globals/settings")
@@ -22,10 +21,12 @@ local events =
     KEY_TRADE               = 6010,
     NO_THANKS               = 6011,
     FULL_INV                = 6012,
-    OTHER_BAD_TRADE         = 6013,
-    ITEM_CANNOT_BE_OBTAINED = 6541,
-    LIL_BABY                = 6583
+    OTHER_BAD_TRADE         = 6013
 }
+
+function onTrade(player,npc,trade)
+    tpz.mystery.onTrade(player, npc, trade, events)
+end
 
 function onTrigger(player, npc)
     tpz.mystery.onTrigger(player, npc, events)


### PR DESCRIPTION
Adds key trading feature for special, abjuration, fortune, and anniversary dials. Anniversary dial loot is currently not populated and will either give an item from the special dial or give the key back. Fortune key loot is populated based on best guess for what fits (wikis are incomplete).

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

