### PR TITLE
#569 - onMobSpawn (Linux) no spells

### DIFF
--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -49,11 +49,6 @@ CTrustEntity::CTrustEntity(CCharEntity* PChar)
     PAI = std::make_unique<CAIContainer>(this, std::make_unique<CPathFind>(this), std::make_unique<CTrustController>(PChar, this), std::make_unique<CTargetFind>(this));
 }
 
-const int8* CTrustEntity::GetName()
-{
-    return (const int8*)packetName.c_str();
-}
-
 void CTrustEntity::PostTick()
 {
     CBattleEntity::PostTick();

--- a/src/map/entities/trustentity.h
+++ b/src/map/entities/trustentity.h
@@ -32,11 +32,6 @@ public:
     explicit CTrustEntity(CCharEntity*);
     ~CTrustEntity() override = default;
 
-    // Note: The default name is the lowercase spell script name, so we override GetName()
-    // to return the packetName instead, which makes the behaviour consistant with other uses
-    // of GetName()
-    const int8* GetName() override;
-
     void PostTick() override;
     void FadeOut() override;
     void Die() override;


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

change GetName() from packet_name to name
resolves #569 trust spells do not work on Linux