### PR TITLE
ensure trust spells are level appropriate

### DIFF
--- a/src/map/ai/helpers/gambits_container.cpp
+++ b/src/map/ai/helpers/gambits_container.cpp
@@ -135,7 +135,11 @@ void CGambitsContainer::Tick(time_point tick)
             {
                 if (action.reaction_mod == G_REACTION_MODIFIER::SELECT_SPECIFIC)
                 {
-                    controller->Cast(target->targid, static_cast<SpellID>(action.reaction_arg));
+                    auto spell_id = POwner->SpellContainer->GetAvailable(static_cast<SpellID>(action.reaction_arg));
+                    if (spell_id.has_value())
+                    {
+                        controller->Cast(target->targid, static_cast<SpellID>(spell_id.value()));
+                    }
                 }
                 else if (action.reaction_mod == G_REACTION_MODIFIER::SELECT_HIGHEST)
                 {

--- a/src/map/ai/helpers/gambits_container.cpp
+++ b/src/map/ai/helpers/gambits_container.cpp
@@ -1,10 +1,22 @@
 #include "gambits_container.h"
 
+#include "../../spell.h"
 #include "../../utils/battleutils.h"
 
 void CGambitsContainer::AddGambit(G_SELECTOR selector, G_TRIGGER trigger, uint16 trigger_condition, G_REACTION reaction, G_REACTION_MODIFIER reaction_mod, uint16 reaction_arg, uint16 retry_delay)
 {
-    actions.push_back(Action_t{ selector, trigger, trigger_condition, reaction, reaction_mod, reaction_arg, retry_delay });
+    bool available = true;
+    if (reaction == G_REACTION::MA && reaction_mod == G_REACTION_MODIFIER::SELECT_SPECIFIC)
+    {
+        if (!spell::CanUseSpell(static_cast<CBattleEntity*>(POwner), static_cast<SpellID>(reaction_arg)))
+        {
+            available = false;
+        }
+    }
+    if (available)
+    {
+        actions.push_back(Action_t{ selector, trigger, trigger_condition, reaction, reaction_mod, reaction_arg, retry_delay });
+    }
 }
 
 void CGambitsContainer::Tick(time_point tick)

--- a/src/map/mob_spell_container.cpp
+++ b/src/map/mob_spell_container.cpp
@@ -108,6 +108,35 @@ void CMobSpellContainer::RemoveSpell(SpellID spellId)
     m_hasSpells = !(m_gaList.empty() && m_damageList.empty() && m_buffList.empty() && m_debuffList.empty() && m_healList.empty() && m_naList.empty());
 }
 
+std::optional<SpellID> CMobSpellContainer::GetAvailable(SpellID spellId)
+{
+    bool match = false;
+    auto searchInList = [&](std::vector<SpellID>& list)
+    {
+        for (auto id : list)
+        {
+            if (static_cast<uint16>(spellId) ==  static_cast<uint16>(id))
+            {
+                auto spell = spell::GetSpell(id);
+                bool hasEnoughMP = spell->getMPCost() <= m_PMob->health.mp;
+                bool isNotInRecast = !m_PMob->PRecastContainer->Has(RECAST_MAGIC, static_cast<uint16>(spellId));
+                if (isNotInRecast && hasEnoughMP)
+                {
+                    match = true;
+                }
+            }
+        };
+    };
+    searchInList(m_gaList);
+    searchInList(m_damageList);
+    searchInList(m_buffList);
+    searchInList(m_debuffList);
+    searchInList(m_healList);
+    searchInList(m_naList);
+
+    return  (match) ? std::optional<SpellID>(spellId) : std::nullopt;
+}
+
 std::optional<SpellID> CMobSpellContainer::GetBestAvailable(SPELLFAMILY family)
 {
     std::vector<SpellID> matches;
@@ -117,9 +146,9 @@ std::optional<SpellID> CMobSpellContainer::GetBestAvailable(SPELLFAMILY family)
         {
             auto spell = spell::GetSpell(id);
             bool sameFamily = (family == SPELLFAMILY_NONE) ? true : spell->getSpellFamily() == family;
-            bool hasEnougnMP = spell->getMPCost() <= m_PMob->health.mp;
+            bool hasEnoughMP = spell->getMPCost() <= m_PMob->health.mp;
             bool isNotInRecast = !m_PMob->PRecastContainer->Has(RECAST_MAGIC, static_cast<uint16>(id));
-            if (sameFamily && hasEnougnMP && isNotInRecast)
+            if (sameFamily && hasEnoughMP && isNotInRecast)
             {
                 matches.push_back(id);
             }

--- a/src/map/mob_spell_container.cpp
+++ b/src/map/mob_spell_container.cpp
@@ -110,31 +110,11 @@ void CMobSpellContainer::RemoveSpell(SpellID spellId)
 
 std::optional<SpellID> CMobSpellContainer::GetAvailable(SpellID spellId)
 {
-    bool match = false;
-    auto searchInList = [&](std::vector<SpellID>& list)
-    {
-        for (auto id : list)
-        {
-            if (static_cast<uint16>(spellId) ==  static_cast<uint16>(id))
-            {
-                auto spell = spell::GetSpell(id);
-                bool hasEnoughMP = spell->getMPCost() <= m_PMob->health.mp;
-                bool isNotInRecast = !m_PMob->PRecastContainer->Has(RECAST_MAGIC, static_cast<uint16>(spellId));
-                if (isNotInRecast && hasEnoughMP)
-                {
-                    match = true;
-                }
-            }
-        };
-    };
-    searchInList(m_gaList);
-    searchInList(m_damageList);
-    searchInList(m_buffList);
-    searchInList(m_debuffList);
-    searchInList(m_healList);
-    searchInList(m_naList);
+    auto spell = spell::GetSpell(spellId);
+    bool hasEnoughMP = spell->getMPCost() <= m_PMob->health.mp;
+    bool isNotInRecast = !m_PMob->PRecastContainer->Has(RECAST_MAGIC, static_cast<uint16>(spellId));
 
-    return  (match) ? std::optional<SpellID>(spellId) : std::nullopt;
+    return  (isNotInRecast && hasEnoughMP) ? std::optional<SpellID>(spellId) : std::nullopt;
 }
 
 std::optional<SpellID> CMobSpellContainer::GetBestAvailable(SPELLFAMILY family)

--- a/src/map/mob_spell_container.h
+++ b/src/map/mob_spell_container.h
@@ -61,6 +61,7 @@ public:
   void AddSpell(SpellID spellId);
   void RemoveSpell(SpellID spellId);
 
+  std::optional<SpellID> GetAvailable(SpellID spellId);
   std::optional<SpellID> GetBestAvailable(SPELLFAMILY family);
 
   std::vector<SpellID> m_gaList;

--- a/src/map/spell.cpp
+++ b/src/map/spell.cpp
@@ -602,8 +602,14 @@ namespace spell
             {
                 // cant cast cause im hidden or untargetable
                 if (PCaster->IsNameHidden() || static_cast<CMobEntity*>(PCaster)->IsUntargetable())
+                {
                     return false;
-
+                }
+                // ensure trust level is appropriate+
+                if (PCaster->objtype == TYPE_TRUST && PCaster->GetMLevel() < JobMLVL)
+                {
+                    return false;
+                }
                 // Mobs can cast any non-given char spell
                 return true;
             }


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- x[] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Purpose of this pull request is to ensure Trust Spells are both level appropriate and pass required checks in order to cast.

In the current implementation gambits registered with the SELECT_SPECIFIC reaction modifier will be cast regardless of level, recast timer and current MP.

This pull request adds one method to mob_spell_container (GetAvailable) in the same style as (GetBestAvailable) in order to check the trust has the spell in a spell container, has the appropriate mp to cast the spell, and the spell is currently not on cooldown.

This will still allow the trust lua files to register any needed gambits without regard to the trust level or other conditions and keep the flow as simple and straight forward as possible.

If a more appropriate method already exists rather than the new method added, I'm happy to modify the PR accordingly.
