### PR TITLE
Add configurable multiplier for normally-dropped gil

### DIFF
--- a/conf/default/map.conf
+++ b/conf/default/map.conf
@@ -150,6 +150,9 @@ blood_pact_shared_timer: 0
 #Adjust mob drop rate. Acts as a multiplier, so default is 1.
 drop_rate_multiplier: 1.0
 
+#Multiplier for gil naturally dropped by mobs. Does not apply to the bonus gil from all_mobs_gil_bonus. Default is 1.0.
+mob_gil_multiplier: 1.0
+
 #All mobs drop this much extra gil per mob LV even if they normally drop zero.
 all_mobs_gil_bonus: 0
 

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -757,7 +757,7 @@ void CMobEntity::DistributeRewards()
             }
 
             // check for gil (beastmen drop gil, some NMs drop gil)
-            if (CanDropGil() || (map_config.all_mobs_gil_bonus > 0 && getMobMod(MOBMOD_GIL_MAX) >= 0)) // Negative value of MOBMOD_GIL_MAX is used to prevent gil drops in Dynamis/Limbus.
+            if ((map_config.mob_gil_multiplier > 0 && CanDropGil()) || (map_config.all_mobs_gil_bonus > 0 && getMobMod(MOBMOD_GIL_MAX) >= 0)) // Negative value of MOBMOD_GIL_MAX is used to prevent gil drops in Dynamis/Limbus.
             {
                 charutils::DistributeGil(PChar, this); // TODO: REALISATION MUST BE IN TREASUREPOOL
             }

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -986,6 +986,7 @@ int32 map_config_default()
     map_config.max_time_lastupdate = 60000;
     map_config.newstyle_skillups = 7;
     map_config.drop_rate_multiplier = 1.0f;
+    map_config.mob_gil_multiplier = 1.0f;
     map_config.all_mobs_gil_bonus = 0;
     map_config.max_gil_bonus = 9999;
     map_config.Battle_cap_tweak = 0;
@@ -1182,6 +1183,10 @@ int32 map_config_read(const int8* cfgName)
         else if (strcmp(w1, "drop_rate_multiplier") == 0)
         {
             map_config.drop_rate_multiplier = (float)atof(w2);
+        }
+        else if (strcmp(w1, "mob_gil_multiplier") == 0)
+        {
+            map_config.mob_gil_multiplier = (float)atof(w2);
         }
         else if (strcmp(w1, "all_mobs_gil_bonus") == 0)
         {

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -114,6 +114,7 @@ struct map_config_t
     float  ability_recast_multiplier; // Adjust ability recast time
     int8   blood_pact_shared_timer;   // Default is 0. Disable/enable old school shared timer for SMN blood pacts.
     float  drop_rate_multiplier;      // Multiplier for drops
+    float  mob_gil_multiplier;        // Gil multiplier for gil normally dropped by mobs. (Does not stack with all_mobs_gil_bonus.)
     uint32 all_mobs_gil_bonus;        // Sets the amount of bonus gil (per level) all mobs will drop.
     uint32 max_gil_bonus;             // Maximum total bonus gil that can be dropped. Default 9999 gil.
     uint8  newstyle_skillups;         // Allows failed parries and blocks to trigger skill up chance.

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3145,6 +3145,11 @@ namespace charutils
         uint32 gil = PMob->GetRandomGil();
         uint32 gBonus = 0;
 
+        if (gil && map_config.mob_gil_multiplier >= 0)
+        {
+            gil = static_cast<uint32>(gil * map_config.mob_gil_multiplier);
+        }
+
         if (map_config.all_mobs_gil_bonus > 0)
         {
             gBonus = map_config.all_mobs_gil_bonus*PMob->GetMLevel();


### PR DESCRIPTION
Topaz lacked a really good way of controlling Gil payouts for those who don't like adding Gil to every single mob kill. This PR adds a modifier for the naturally-dropped Gil amounts. This multiplier does not apply to the gil from *all_mobs_gil_bonus*, only the normally-dropped amounts.

This combined with the all_mobs_gil_bonus affords much needed economic flexibility, including the option to set it to 0 and tweak all_mobs_gil_bonus to offer flat per-level Gil payouts server-wide.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

