### PR TITLE
Improvements for xiloader error reporting

### DIFF
--- a/src/login/login_auth.cpp
+++ b/src/login/login_auth.cpp
@@ -214,9 +214,9 @@ int32 login_parse(int32 fd)
             {
                 ShowWarning(CL_WHITE"login_parse" CL_RESET": New account attempt <" CL_WHITE"%s" CL_RESET"> but is disabled in config.\n", escaped_name);
                 session[fd]->wdata.resize(1);
-                ref<uint8>(session[fd]->wdata.data(), 0) = LOGIN_ERROR_CREATE;
+                ref<uint8>(session[fd]->wdata.data(), 0) = LOGIN_ERROR_CREATE_DISABLED;
                 do_close_login(sd, fd);
-                return 0;
+                return -1;
             }
 
            //looking for same login
@@ -279,7 +279,7 @@ int32 login_parse(int32 fd)
             else {
                 ShowWarning(CL_WHITE"login_parse" CL_RESET": account<" CL_WHITE"%s" CL_RESET"> already exists\n", escaped_name);
                 session[fd]->wdata.resize(1);
-                ref<uint8>(session[fd]->wdata.data(), 0) = LOGIN_ERROR_CREATE;
+                ref<uint8>(session[fd]->wdata.data(), 0) = LOGIN_ERROR_CREATE_TAKEN;
                 do_close_login(sd, fd);
             }
             break;

--- a/src/login/login_auth.h
+++ b/src/login/login_auth.h
@@ -42,7 +42,9 @@
 #define LOGIN_REQUEST_NEW_PASSWORD       0x05
 
 #define LOGIN_ERROR                      0x02
-#define LOGIN_ERROR_CREATE               0x04
+#define LOGIN_ERROR_CREATE               0x09
+#define LOGIN_ERROR_CREATE_TAKEN         0x04
+#define LOGIN_ERROR_CREATE_DISABLED      0x08
 #define LOGIN_ERROR_CHANGE_PASSWORD      0x07
 
 extern int32 login_fd;


### PR DESCRIPTION
Topaz previously only used one account creation status code for any and all errors, which was reported in xiloader as "Username is taken" in all cases. Many times, this was not true; particularly if account_creation is set false in the config, or if an SQL error had occurred server-side.

This PR adds 2 new return codes, and corrects their usage. This new verbosity is dependent on using the new xiloader, but it is 100% backwards compatible; old versions can still work normally with their existing reduced clarity in error reporting.

This serves to make the account-creation flag a wholly complete and properly handled feature.

**This PR should probably be held until my corresponding [PR for improvements in xiloader](https://github.com/zircon-tpl/xiloader/pull/2) is merged.**

**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits