### PR TITLE
Fix some ENABLE settings

### DIFF
--- a/scripts/globals/maws.lua
+++ b/scripts/globals/maws.lua
@@ -55,7 +55,7 @@ end
 tpz.maws.onTrigger = function(player, npc)
     local ID = zones[player:getZoneID()]
 
-    if not ENABLE_WOTG == 1 then
+    if ENABLE_WOTG == 0 then
         player:messageSpecial(ID.text.NOTHING_HAPPENS)
         return
     end

--- a/scripts/zones/Lower_Delkfutts_Tower/Zone.lua
+++ b/scripts/zones/Lower_Delkfutts_Tower/Zone.lua
@@ -27,7 +27,7 @@ function onZoneIn(player, prevZone)
     end
     if player:getCurrentMission(ZILART) == tpz.mission.id.zilart.RETURN_TO_DELKFUTTS_TOWER and player:getCharVar("ZilartStatus") <= 1 then
         cs = 15
-    elseif ENABLE_COP == 1 and prevZone == tpz.zone.QUFIM_ISLAND and player:getCurrentMission(COP) == tpz.mission.id.cop.ANCIENT_FLAMES_BECKON then
+    elseif ENABLE_COP == 1 and prevZone == tpz.zone.QUFIM_ISLAND and player:getCurrentMission(COP) < tpz.mission.id.cop.THE_RITES_OF_LIFE then
         cs = 22
     elseif player:getCurrentMission(ACP) == tpz.mission.id.acp.BORN_OF_HER_NIGHTMARES and prevZone == tpz.zone.QUFIM_ISLAND then
         cs = 34

--- a/scripts/zones/Lower_Jeuno/npcs/Darcia.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Darcia.lua
@@ -25,7 +25,7 @@ function onTrigger(player,npc)
     local turnOffOptionToPay    = 16
     local turnOffAskingForWork  = 32
 
-    if not ENABLE_SOA then
+    if ENABLE_SOA == 0 then
         player:startEvent(10124)
     elseif rumorsFromTheWest then
         player:startEvent(10117, 0, turnOffDungeonInfo + turnOffAskingForWork)


### PR DESCRIPTION
COP: `cop-log` branch will change the starting ID from zero
WOTG: Just making its usage consistent with other ENABLE settings
SOA: 0 evaluates as true in lua

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date


