### PR TITLE
Ensure Enmity is Applied

### DIFF
--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -131,6 +131,8 @@ void CTrustEntity::OnAbility(CAbilityState& state, action_t& action)
             actionTarget.messageID = ability::GetAbsorbMessage(actionTarget.messageID);
             actionTarget.param = -value;
         }
+
+        state.ApplyEnmity();
     }
 }
 


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Easy one liner...

Enmity generating trust skills currently are not generating enmity towards the user.  This is due to a missing call to state.ApplyEnmity().  Added the missing line to trustentity.cpp -> OnAbility.

A page of old commented out BST logic buried this call in charentity.cpp OnAbility which is what trustentify OnAbility seems to be based on.