### PR TITLE
Trust Spells - Loading Order

### DIFF
--- a/src/map/mob_spell_list.cpp
+++ b/src/map/mob_spell_list.cpp
@@ -56,7 +56,8 @@ namespace mobSpellList
                             mob_spell_lists.max_level, \
                             spell_list.content_tag \
                             FROM mob_spell_lists JOIN spell_list ON spell_list.spellid = mob_spell_lists.spell_id \
-                            WHERE spell_list_id < %u;";
+                            WHERE spell_list_id < %u \
+                            ORDER BY min_level ASC;";
 
         int32 ret = Sql_Query(SqlHandle, Query, MAX_MOBSPELLLIST_ID);
 


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Currently Trust spells are loaded into the spell container by order of appearance in the mob_spell_lists.sql.  This presents logic issues for get_highest_available due to not all spells being ordered by absolute highest available order.

This pull basically places an order by clause in the sql upon spell load which will order by minimum level required and will naturally place spells in order so highest available and lowest available are in natural order based on availability.

This should not affect mob casting since all functions were random in nature to begin with, but will resolve trust casting for cases such as Shantotto.
