### PR TITLE
Add requirements.txt for migration.py

### DIFF
--- a/migrations/README.md
+++ b/migrations/README.md
@@ -20,12 +20,9 @@ For Ubuntu it's already installed.
 
 ## Installing MySQLdb
 
-A Mysql driver is required to execute mysql commands.
+A Mysql driver is required to execute mysql commands. This and any other required dependencies can be installed by running the following from bash or command prompt/powershell:
 
-For Windows user, you can get an [exe of MySQLdb](http://sourceforge.net/project/showfiles.php?group_id=22307).
-
-For Ubuntu, `sudo apt-get install python-mysqldb`.
-
+pip install -r requirements.txt
 
 ## Running Migrations
 

--- a/migrations/requirements.txt
+++ b/migrations/requirements.txt
@@ -1,0 +1,1 @@
+mysql-connector-python==8.0.20


### PR DESCRIPTION
In the future, all users can run:

`pip install -r requirements.txt`
---OR---
`pip3 install -r requirements.txt`

This will install any needed dependencies.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

