### PR TITLE
Fix mission ID when none accepted

### DIFF
--- a/scripts/commands/checkmission.lua
+++ b/scripts/commands/checkmission.lua
@@ -46,7 +46,7 @@ function onTrigger(player,logId,target)
     -- report mission
     local currentMission = targ:getCurrentMission(logId)
 
-    if ((logId <= 3) and (currentMission == 255)) then
+    if ((logId <= 3) and (currentMission == 65535)) then
         player:PrintToPlayer( string.format( "No current %s mission for %s.", logName, targ:getName() ) )
     else
         player:PrintToPlayer( string.format( "Current %s Mission ID is %s for %s.", logName, currentMission, targ:getName() ) )

--- a/scripts/globals/missions.lua
+++ b/scripts/globals/missions.lua
@@ -82,7 +82,7 @@ tpz.mission.id =
         LIGHTBRINGER            = 21, -- ± --
         BREAKING_BARRIERS       = 22, -- ± --
         THE_HEIR_TO_THE_LIGHT   = 23,
-        NONE                    = 255,
+        NONE                    = 65535,
     },
 
     -----------------------------------
@@ -114,7 +114,7 @@ tpz.mission.id =
         ENTER_THE_TALEKEEPER      = 21,
         THE_SALT_OF_THE_EARTH     = 22,
         WHERE_TWO_PATHS_CONVERGE  = 23,
-        NONE                      = 255,
+        NONE                      = 65535,
     },
 
     -----------------------------------
@@ -146,7 +146,7 @@ tpz.mission.id =
         THE_JESTER_WHO_D_BE_KING      = 21,
         DOLL_OF_THE_DEAD              = 22,
         MOON_READING                  = 23,
-        NONE                          = 255,
+        NONE                          = 65535,
     },
 
     -----------------------------------
@@ -172,7 +172,7 @@ tpz.mission.id =
         THE_CELESTIAL_NEXUS           = 28,
         AWAKENING                     = 30,
         THE_LAST_VERSE                = 31,
-        NONE                          = 255,
+        NONE                          = 65535,
     },
 
     -----------------------------------


### PR DESCRIPTION
Current mission ID was being truncated to 8 bits in core previously, but now uses the full 16 bits available. Not having a current mission sets current mission ID to `-1` or `65535` which was being truncated to `255` previously. This should be `65535` now.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

