### PR TITLE
Cleans up Aquillina and makes Flash in the Pan 15 minute cooldown ser…

### DIFF
--- a/scripts/zones/Bastok_Markets/IDs.lua
+++ b/scripts/zones/Bastok_Markets/IDs.lua
@@ -67,6 +67,7 @@ zones[tpz.zone.BASTOK_MARKETS] =
     },
     npc =
     {
+        AQUILLINA = 17739784,
         HALLOWEEN_SKINS =
         {
             [17739805] = 45, -- Olwyn

--- a/scripts/zones/Bastok_Markets/npcs/Aquillina.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Aquillina.lua
@@ -2,43 +2,42 @@
 -- Area: Bastok Markets
 -- NPC: Aquillina
 -- Starts & Finishes Repeatable Quest: A Flash In The Pan
--- Note: Reapeatable every 15 minutes.
+-- Note: Reapeatable server-wide every 15 minutes.
 -- !pos -97 -5 -81 235
 -----------------------------------
-require("scripts/globals/npc_util");
-require("scripts/globals/quests");
+local ID = require("scripts/zones/Bastok_Markets/IDs")
+require("scripts/globals/npc_util")
+require("scripts/globals/quests")
 
 function onTrade(player,npc,trade)
-    if (player:getQuestStatus(BASTOK,tpz.quest.id.bastok.A_FLASH_IN_THE_PAN) >= QUEST_ACCEPTED) then
-        if (os.time() >= player:getCharVar("FlashInThePan")) then
-            if (npcUtil.tradeHas( trade, {{768,4}} )) then
-                player:startEvent(219);
-            end
+    if player:getQuestStatus(BASTOK,tpz.quest.id.bastok.A_FLASH_IN_THE_PAN) ~= QUEST_AVAILABLE and npcUtil.tradeHas(trade, {{768,4}}) then
+        if npc:getLocalVar("FlashInThePan") <= os.time() then
+            player:startEvent(219)
         else
-            player:startEvent(218);
+            player:startEvent(218)
         end
     end
-end;
+end
 
 function onTrigger(player,npc)
-    if (player:getQuestStatus(BASTOK,tpz.quest.id.bastok.A_FLASH_IN_THE_PAN) == QUEST_AVAILABLE) then
-        player:startEvent(217);
+    if player:getQuestStatus(BASTOK,tpz.quest.id.bastok.A_FLASH_IN_THE_PAN) == QUEST_AVAILABLE then
+        player:startEvent(217)
     else
-        player:startEvent(116);
+        player:startEvent(116)
     end
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-    if (csid == 217) then
-        player:addQuest(BASTOK, tpz.quest.id.bastok.A_FLASH_IN_THE_PAN);
-    elseif (csid == 219) then
-        local fame = player:hasCompletedQuest(BASTOK, tpz.quest.id.bastok.A_FLASH_IN_THE_PAN) and 8 or 75;
-        if (npcUtil.completeQuest(player, BASTOK, tpz.quest.id.bastok.A_FLASH_IN_THE_PAN, {gil=100, fame=fame})) then
-            player:confirmTrade();
-            player:setCharVar("FlashInThePan",os.time() + 900);
+    if csid == 217 then
+        player:addQuest(BASTOK, tpz.quest.id.bastok.A_FLASH_IN_THE_PAN)
+    elseif csid == 219 then
+        local fame = player:hasCompletedQuest(BASTOK, tpz.quest.id.bastok.A_FLASH_IN_THE_PAN) and 8 or 75
+        if npcUtil.completeQuest(player, BASTOK, tpz.quest.id.bastok.A_FLASH_IN_THE_PAN, {gil=100, fame=fame}) then
+            player:confirmTrade()
+            GetNPCByID(ID.npc.AQUILLINA):setLocalVar("FlashInThePan",os.time() + 900)
         end
     end
-end;
+end


### PR DESCRIPTION
…ver-wide.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Makes Flash in the Pan have a 15 minute cooldown server-wide, as [intended](https://ffxiclopedia.fandom.com/wiki/A_Flash_in_the_Pan).

Also cleans up her script nicely.