### PR TITLE
Fix checking wrong requirement

### DIFF
--- a/scripts/zones/West_Ronfaure/npcs/Vilatroire.lua
+++ b/scripts/zones/West_Ronfaure/npcs/Vilatroire.lua
@@ -112,9 +112,9 @@ function onEventUpdate(player, csid, option)
                     player:updateEvent(4) -- not the same race
                 end
             elseif questAdvancedTeamwork == QUEST_ACCEPTED then
-                if partySameJobCount == partySameJobCount then
+                if partySameJobCount == partySizeRequirement then
                     player:setLocalVar("advTmwrk_pass", 1)
-                    player:updateEvent(15, 3) -- race requirements met
+                    player:updateEvent(15, 3) -- job requirements met
                 else
                     player:updateEvent(5) -- not the same job
                 end


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

