### PR TITLE
[FIX] Set CharVar for EcoWarrior NMs Killed to 0 after completing quest

### DIFF
--- a/scripts/zones/Maze_of_Shakhrami/mobs/Wyrmfly.lua
+++ b/scripts/zones/Maze_of_Shakhrami/mobs/Wyrmfly.lua
@@ -26,7 +26,7 @@ function onMobDeath(mob, player, isKiller)
             end
         end
         if allFliesDead then
-            player:setCharVar("ECOR_WAR_WIN-NMs_killed", 1)
+            player:setCharVar("ECO_WAR_WIN-NMs_killed", 1)
         end
     end
 end

--- a/scripts/zones/Maze_of_Shakhrami/npcs/Ahko_Mhalijikhari.lua
+++ b/scripts/zones/Maze_of_Shakhrami/npcs/Ahko_Mhalijikhari.lua
@@ -33,7 +33,7 @@ function onEventFinish(player, csid, option)
     if csid == 62 and option == 1 then
         player:addStatusEffect(tpz.effect.LEVEL_RESTRICTION, 20, 0, 0)
     elseif csid == 65 then
-        player:setCharVar("ECOR_WAR_WIN-NMs_killed", 0)
+        player:setCharVar("ECO_WAR_WIN-NMs_killed", 0)
         player:delStatusEffect(tpz.effect.LEVEL_RESTRICTION)
     elseif csid == 64 then
         player:delStatusEffect(tpz.effect.LEVEL_RESTRICTION)

--- a/scripts/zones/Maze_of_Shakhrami/npcs/qm2.lua
+++ b/scripts/zones/Maze_of_Shakhrami/npcs/qm2.lua
@@ -21,7 +21,7 @@ function onTrigger(player, npc)
         player:hasStatusEffect(tpz.effect.LEVEL_RESTRICTION) and
         not player:hasKeyItem(tpz.ki.INDIGESTED_MEAT)
     then
-        if player:getCharVar("ECOR_WAR_WIN-NMs_killed") == 1 then
+        if player:getCharVar("ECO_WAR_WIN-NMs_killed") == 1 then
             npcUtil.giveKeyItem(player, tpz.ki.INDIGESTED_MEAT)
         elseif npcUtil.popFromQM(player, npc, {ID.mob.WYRMFLY_OFFSET, ID.mob.WYRMFLY_OFFSET + 1, ID.mob.WYRMFLY_OFFSET + 2}, {hide = 0}) then
             -- no further action

--- a/scripts/zones/Windurst_Waters/npcs/Lumomo.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Lumomo.lua
@@ -53,7 +53,7 @@ function onEventFinish(player,csid,option)
             player:messageSpecial(ID.text.ITEM_OBTAINED,4198);
             player:addTitle(tpz.title.EMERALD_EXTERMINATOR);
             player:addFame(WINDURST, 80);
-            player:setCharVar("ECOR_WAR_WIN-NMs_killed", 0)
+            player:setCharVar("ECO_WAR_WIN-NMs_killed", 0)
             player:setCharVar("ECO-WAR_ConquestWeek",getConquestTally())
             player:setCharVar("ECO_WARRIOR_ACTIVE",0);
         else

--- a/scripts/zones/Windurst_Waters/npcs/Lumomo.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Lumomo.lua
@@ -53,6 +53,7 @@ function onEventFinish(player,csid,option)
             player:messageSpecial(ID.text.ITEM_OBTAINED,4198);
             player:addTitle(tpz.title.EMERALD_EXTERMINATOR);
             player:addFame(WINDURST, 80);
+            player:setCharVar("ECOR_WAR_WIN-NMs_killed", 0)
             player:setCharVar("ECO-WAR_ConquestWeek",getConquestTally())
             player:setCharVar("ECO_WARRIOR_ACTIVE",0);
         else


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

As per issue, an exploit existed where you could complete the Ecowarrior quest without having a CharVar reset, allowing you to just complete it each week without having to defeat the monster. Now, on successful completion of the question, the CharVar is reset. 

Closes issue: #484 
