### PR TITLE
Rov fix gilgamesh letter and zeid ii

### DIFF
--- a/scripts/zones/Mhaura/npcs/Ekokoko.lua
+++ b/scripts/zones/Mhaura/npcs/Ekokoko.lua
@@ -16,7 +16,7 @@ function onTrade(player, npc, trade)
         player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.RIDING_ON_THE_CLOUDS) == QUEST_ACCEPTED and
         player:getCharVar("ridingOnTheClouds_3") == 6
      then
-        if (trade:hasItemQty(1127, 1) and trade:getItemCount() == 1) then -- Trade Kindred seal
+        if trade:hasItemQty(1127, 1) and trade:getItemCount() == 1 then -- Trade Kindred seal
             player:setCharVar("ridingOnTheClouds_3", 0)
             player:tradeComplete()
             player:addKeyItem(tpz.ki.SOMBER_STONE)
@@ -31,7 +31,7 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-    if (math.random() > 0.5) then
+    if math.random() > 0.5 then
         player:startEvent(51)
     else
         player:startEvent(52)
@@ -42,9 +42,10 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
+    -- RoV: Set Free
     if csid == 370 then
         player:confirmTrade()
-        if not player:hasJob(0) then -- Is Subjob Unlocked
+        if player:hasJob(0) == 0 then -- Is Subjob Unlocked
             npcUtil.giveKeyItem(player, tpz.ki.GILGAMESHS_INTRODUCTORY_LETTER)
         else
             if not npcUtil.giveItem(player, 8711) then return end

--- a/scripts/zones/Norg/npcs/_700.lua
+++ b/scripts/zones/Norg/npcs/_700.lua
@@ -44,6 +44,12 @@ function onTrigger(player,npc)
         player:startEvent(277)
     elseif RhapsodiesMission == tpz.mission.id.rov.WHAT_LIES_BEYOND then
         player:startEvent(278)
+    elseif player:getCharVar("ZeidIICipher") == 1 then
+        if npcUtil.giveItem(player, 10160) then -- Cipher: Zeid II
+            player:completeMission(ROV, tpz.mission.id.rov.VOLTO_OSCURO)
+            player:addMission(ROV, tpz.mission.id.rov.RING_MY_BELL)
+            player:setCharVar("ZeidIICipher", 0)
+        end
     elseif RhapsodiesMission == tpz.mission.id.rov.VOLTO_OSCURO then
         player:startEvent(279)
     elseif
@@ -94,9 +100,12 @@ function onEventFinish(player,csid,option)
         player:completeMission(ROV, tpz.mission.id.rov.WHAT_LIES_BEYOND)
         player:addMission(ROV, tpz.mission.id.rov.THE_TIES_THAT_BIND)
     elseif csid == 279 then
-        player:addItem(10159) -- Cipher: Zeid II
-        player:completeMission(ROV, tpz.mission.id.rov.VOLTO_OSCURO)
-        player:addMission(ROV, tpz.mission.id.rov.RING_MY_BELL)
+        if npcUtil.giveItem(player, 10160) then -- Cipher: Zeid II
+            player:completeMission(ROV, tpz.mission.id.rov.VOLTO_OSCURO)
+            player:addMission(ROV, tpz.mission.id.rov.RING_MY_BELL)
+        else
+            player:setCharVar("ZeidIICipher", 1)
+        end
     elseif csid == 284 then
         player:completeMission(ROV, tpz.mission.id.rov.RING_MY_BELL)
         player:addMission(ROV, tpz.mission.id.rov.SPIRITS_AWOKEN)

--- a/scripts/zones/Selbina/npcs/Abelard.lua
+++ b/scripts/zones/Selbina/npcs/Abelard.lua
@@ -161,9 +161,11 @@ function onEventFinish(player,csid,option)
         if (tablets % (2 * 0x7fff)) >= 0x7fff then
             npcUtil.giveKeyItem(player, tpz.ki.MAP_OF_THE_CRAWLERS_NEST)
         end
+
+    -- RoV: Set Free
     elseif csid == 178 then
         player:confirmTrade()
-        if not player:hasJob(0) then -- Is Subjob Unlocked
+        if player:hasJob(0) == 0 then -- Is Subjob Unlocked
             npcUtil.giveKeyItem(player, tpz.ki.GILGAMESHS_INTRODUCTORY_LETTER)
         else
             if not npcUtil.giveItem(player, 8711) then return end


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

gilgamesh letter was not given to chars with subjob locked. Also lion ii was given for RoV quest instead of zeid ii

Thank you Hiro and @ffxijuggalo from Canaria server :cat: 