### PR TITLE
Take zone and distance into account for Trust Gambits

### DIFF
--- a/src/map/ai/helpers/gambits_container.cpp
+++ b/src/map/ai/helpers/gambits_container.cpp
@@ -121,7 +121,9 @@ void CGambitsContainer::Tick(time_point tick)
             for (uint8 i = 0; i < master->PParty->members.size(); ++i)
             {
                 auto member = master->PParty->members.at(i);
-                if (checkTrigger(member, action.trigger, action.trigger_condition))
+                if (POwner->loc.zone == member->loc.zone &&
+                    distance(POwner->loc.p, member->loc.p) <= 20.0f &&
+                    checkTrigger(member, action.trigger, action.trigger_condition))
                 {
                     target = member;
                     break;


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

From Discord:
```
Galieon (wiseowl)
we're testing out the initial trusts over on Dawnbreak and found a bug with kupipi
if the party member is not in range, out of zone, etc, her AI spams rotation of Protectra/Shellra and nothing else
```

Nice catch, all other gambits rely on the fact that a trust cannot exist outside of the same zone as its master. This selector views the whole party, regardless of the zone (or distance).

This should fix that. I'll test this tomorrow, and possibly put a 60-second cooldown on Kupipi's Protectra/Shellra, so if strange conditions happen she's able to do other things.