### PR TITLE
Working Curio Vendor Moogle

### DIFF
--- a/scripts/globals/shop.lua
+++ b/scripts/globals/shop.lua
@@ -6,7 +6,23 @@
 require("scripts/globals/conquest")
 require("scripts/globals/settings")
 require("scripts/globals/crafting")
+require("scripts/globals/keyitems")
 -----------------------------------
+
+-----------------------------------
+-- IDs for Curio Vendor Moogle
+-----------------------------------
+
+curio =
+{
+    ["medicine"]        = 1,
+    ["ammunition"]      = 2,
+    ["ninjutsuTools"]   = 3,
+    ["foodStuffs"]      = 4,
+    ["scrolls"]         = 5,
+    ["keys"]            = 6,
+    -- keyitems not implemented yet
+}
 
 tpz = tpz or {}
 
@@ -48,6 +64,25 @@ tpz.shop =
 
         for i = 1, #stock, 3 do
             if guildRank >= stock[i+2] then
+                player:addShopItem(stock[i], stock[i+1])
+            end
+        end
+
+        player:sendMenu(2)
+    end,
+
+    --[[ *******************************************************************************
+        send curio vendor moogle shop shop dialog to player
+        stock is of form {itemId1, price1, keyItemRequired, ...}
+        log is default set to -1 as it's needed as part of createShop()
+    ******************************************************************************* --]]
+    curioVendorMoogle = function(player, stock)
+        local log = -1
+
+        player:createShop(#stock / 3, log)
+
+        for i = 1, #stock, 3 do
+            if player:hasKeyItem(stock[i+2]) then
                 player:addShopItem(stock[i], stock[i+1])
             end
         end
@@ -382,6 +417,158 @@ tpz.shop =
                 8827,    5300,      tpz.craftRank.AMATEUR,      -- Smithing Kit 45
                 8828,    7600,      tpz.craftRank.AMATEUR,      -- Smithing Kit 50
                 9247, 1126125,      tpz.craftRank.AMATEUR       -- Niobium Ore
+        }
+    },
+
+    curioVendorMoogleStock =
+    {
+        [curio.medicine] =
+        {
+                4112,     300,      tpz.ki.RHAPSODY_IN_WHITE,   -- Potion
+                4116,     600,      tpz.ki.RHAPSODY_IN_UMBER,   -- Hi-Potion
+                4128,     650,      tpz.ki.RHAPSODY_IN_WHITE,   -- Ether
+                4132,    1300,      tpz.ki.RHAPSODY_IN_UMBER,   -- Hi-Ether
+                4145,   15000,      tpz.ki.RHAPSODY_IN_AZURE,   -- Elixir
+                4148,     300,      tpz.ki.RHAPSODY_IN_WHITE,   -- Antidote
+                4150,    1000,      tpz.ki.RHAPSODY_IN_UMBER,   -- Eye Drops
+                4151,     700,      tpz.ki.RHAPSODY_IN_UMBER,   -- Echo Drops
+                4156,     500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Mulsum
+                4164,     500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Prism Powder
+                4165,     500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Silent Oil
+                4166,     250,      tpz.ki.RHAPSODY_IN_WHITE,   -- Deodorizer
+                4172,    1000,      tpz.ki.RHAPSODY_IN_AZURE,   -- Reraiser
+        },
+        [curio.ammunition] =
+        {
+                4219,     400,      tpz.ki.RHAPSODY_IN_WHITE,   -- Stone Quiver
+                4220,     680,      tpz.ki.RHAPSODY_IN_WHITE,   -- Bone Quiver
+                4225,    1200,      tpz.ki.RHAPSODY_IN_WHITE,   -- Iron Quiver
+                4221,    1350,      tpz.ki.RHAPSODY_IN_WHITE,   -- Beetle Quiver
+                4226,    2040,      tpz.ki.RHAPSODY_IN_WHITE,   -- Silver Quiver
+                4222,    2340,      tpz.ki.RHAPSODY_IN_WHITE,   -- Horn Quiver
+                5333,    3150,      tpz.ki.RHAPSODY_IN_UMBER,   -- Sleep Quiver
+                4223,    3500,      tpz.ki.RHAPSODY_IN_UMBER,   -- Scorpion Quiver
+                4224,    7000,      tpz.ki.RHAPSODY_IN_AZURE,   -- Demon Quiver
+                5332,    8800,      tpz.ki.RHAPSODY_IN_AZURE,   -- Kabura Quiver
+                4227,     400,      tpz.ki.RHAPSODY_IN_WHITE,   -- Bronze Bolt Quiver
+                5334,     800,      tpz.ki.RHAPSODY_IN_WHITE,   -- Blind Bolt Quiver
+                5335,    1250,      tpz.ki.RHAPSODY_IN_WHITE,   -- Acid Bolt Quiver
+                5337,    1500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Sleep Bolt Quiver
+                5339,    2100,      tpz.ki.RHAPSODY_IN_WHITE,   -- Bloody Bolt Quiver
+                5338,    2100,      tpz.ki.RHAPSODY_IN_WHITE,   -- Venom Bolt Quiver
+                5336,    2400,      tpz.ki.RHAPSODY_IN_WHITE,   -- Holy Bolt Quiver
+                4228,    3500,      tpz.ki.RHAPSODY_IN_UMBER,   -- Mythril Bolt Quiver
+                4229,    5580,      tpz.ki.RHAPSODY_IN_AZURE,   -- Darksteel Bolt Quiver
+                5359,     400,      tpz.ki.RHAPSODY_IN_WHITE,   -- Bronze Bullet Pouch
+                5363,    1920,      tpz.ki.RHAPSODY_IN_WHITE,   -- Bullet Pouch
+                5341,    2400,      tpz.ki.RHAPSODY_IN_WHITE,   -- Spartan Bullet Pouch
+                5353,    4800,      tpz.ki.RHAPSODY_IN_UMBER,   -- Iron Bullet Pouch
+                5340,    4800,      tpz.ki.RHAPSODY_IN_UMBER,   -- Silver Bullet Pouch
+                5342,    7100,      tpz.ki.RHAPSODY_IN_AZURE,   -- Corsair Bullet Pouch
+                5416,    7600,      tpz.ki.RHAPSODY_IN_AZURE,   -- Steel Bullet Pouch
+                6299,    1400,      tpz.ki.RHAPSODY_IN_WHITE,   -- Shuriken Pouch
+                6297,    2280,      tpz.ki.RHAPSODY_IN_WHITE,   -- Juji Shuriken Pouch
+                6298,    4640,      tpz.ki.RHAPSODY_IN_UMBER,   -- Manji Shuriken Pouch
+                6302,    7000,      tpz.ki.RHAPSODY_IN_AZURE,   -- Fuma Shuriken Pouch
+        },
+        [curio.ninjutsuTools] =
+        {
+                5308,    3000,      tpz.ki.RHAPSODY_IN_WHITE,   -- Toolbag (Uchi)
+                5309,    3000,      tpz.ki.RHAPSODY_IN_WHITE,   -- Toolbag (Tsurara)
+                5310,    3000,      tpz.ki.RHAPSODY_IN_WHITE,   -- Toolbag (Kawahori-Ogi)
+                5311,    3000,      tpz.ki.RHAPSODY_IN_WHITE,   -- Toolbag (Makibishi)
+                5312,    3000,      tpz.ki.RHAPSODY_IN_WHITE,   -- Toolbag (Hiraishin)
+                5313,    3000,      tpz.ki.RHAPSODY_IN_WHITE,   -- Toolbag (Mizu-Deppo)
+                5314,    5000,      tpz.ki.RHAPSODY_IN_WHITE,   -- Toolbag (Shihei)
+                5315,    5000,      tpz.ki.RHAPSODY_IN_WHITE,   -- Toolbag (Jusatsu)
+                5316,    5000,      tpz.ki.RHAPSODY_IN_WHITE,   -- Toolbag (Kaginawa)
+                5317,    5000,      tpz.ki.RHAPSODY_IN_WHITE,   -- Toolbag (Sairui-Ran)
+                5318,    5000,      tpz.ki.RHAPSODY_IN_WHITE,   -- Toolbag (Kodoku)
+                5319,    3000,      tpz.ki.RHAPSODY_IN_WHITE,   -- Toolbag (Shinobi-Tabi)
+                5417,    3000,      tpz.ki.RHAPSODY_IN_WHITE,   -- Toolbag (Sanjaku-Tenugui)
+        },
+        [curio.foodStuffs] =
+        {
+                4378,      60,      tpz.ki.RHAPSODY_IN_WHITE,   -- Selbina Milk
+                4299,     100,      tpz.ki.RHAPSODY_IN_WHITE,   -- Orange au Lait
+                5703,     100,      tpz.ki.RHAPSODY_IN_WHITE,   -- Uleguerand Milk
+                4422,     200,      tpz.ki.RHAPSODY_IN_WHITE,   -- Orange Juice
+                4405,     160,      tpz.ki.RHAPSODY_IN_WHITE,   -- Rice Ball
+                4376,     120,      tpz.ki.RHAPSODY_IN_WHITE,   -- Meat Jerky
+                4371,     184,      tpz.ki.RHAPSODY_IN_WHITE,   -- Grilled Hare
+                4381,     720,      tpz.ki.RHAPSODY_IN_UMBER,   -- Meat Mithkabob
+                4456,     550,      tpz.ki.RHAPSODY_IN_WHITE,   -- Boiled Crab
+                4398,    1080,      tpz.ki.RHAPSODY_IN_UMBER,   -- Fish Mithkabob
+                5166,    1500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Coeurl Sub
+                4538,     900,      tpz.ki.RHAPSODY_IN_WHITE,   -- Roast Pipira
+                6217,     500,      tpz.ki.RHAPSODY_IN_AZURE,   -- Anchovy Slice
+                6215,     400,      tpz.ki.RHAPSODY_IN_UMBER,   -- Pepperoni Slice
+                4488,    1000,      tpz.ki.RHAPSODY_IN_WHITE,   -- Jack-o'-Lantern
+                5775,     500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Chocolate Crepe
+                4413,     320,      tpz.ki.RHAPSODY_IN_WHITE,   -- Apple Pie
+                4421,     800,      tpz.ki.RHAPSODY_IN_WHITE,   -- Melon Pie
+                4410,     344,      tpz.ki.RHAPSODY_IN_WHITE,   -- Roast Mushroom
+                4510,      24,      tpz.ki.RHAPSODY_IN_WHITE,   -- Acorn Cookie
+                4394,      12,      tpz.ki.RHAPSODY_IN_AZURE,   -- Ginger Cookie
+                5782,    1000,      tpz.ki.RHAPSODY_IN_WHITE,   -- Sugar Rusk
+                5779,    1000,      tpz.ki.RHAPSODY_IN_WHITE,   -- Cherry Macaron
+                5885,    1000,      tpz.ki.RHAPSODY_IN_WHITE,   -- Saltena
+                5886,    2000,      tpz.ki.RHAPSODY_IN_AZURE,   -- Elshena
+                5889,    1000,      tpz.ki.RHAPSODY_IN_WHITE,   -- Stuffed Pitaru
+                5890,    2000,      tpz.ki.RHAPSODY_IN_AZURE,   -- Poultry Pitaru
+        },
+        [curio.scrolls] =
+        {
+                4181,     500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Instant Warp
+                4182,     500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Instant Reraise
+                5428,     500,      tpz.ki.RHAPSODY_IN_AZURE,   -- Instant Retrace
+                5988,     500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Instant Protect
+                5989,     500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Instant Shell
+                5990,     500,      tpz.ki.RHAPSODY_IN_UMBER,   -- Instant Stoneskin
+        },
+        [curio.keys] =
+        {
+                1024,    2500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Ghelsba Chest Key
+                1025,    2500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Palborough Chest Key
+                1026,    2500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Giddeus Chest Key
+                1027,    2500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Ranperre Chest Key
+                1028,    2500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Dangruf Chest Key
+                1029,    2500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Horutoto Chest Key
+                1030,    2500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Ordelle Chest Key
+                1031,    2500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Gusgen Chest Key
+                1032,    2500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Shakhrami Chest Key
+                1033,    2500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Davoi Chest Key
+                1034,    2500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Beadeaux Chest Key
+                1035,    2500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Oztroja Chest Key
+                1036,    2500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Delkfutt Chest Key
+                1037,    2500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Fei'Yin Chest Key
+                1038,    2500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Zvahl Chest Key
+                1039,    2500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Eldieme Chest Key
+                1040,    2500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Nest Chest Key
+                1041,    2500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Garlaige Chest Key
+                1043,    5000,      tpz.ki.RHAPSODY_IN_UMBER,   -- Beadeaux Coffer Key
+                1042,    5000,      tpz.ki.RHAPSODY_IN_UMBER,   -- Davoi Coffer Key
+                1044,    5000,      tpz.ki.RHAPSODY_IN_UMBER,   -- Oztroja Coffer Key
+                1045,    5000,      tpz.ki.RHAPSODY_IN_UMBER,   -- Nest Coffer Key
+                1046,    5000,      tpz.ki.RHAPSODY_IN_UMBER,   -- Eldieme Coffer Key
+                1047,    5000,      tpz.ki.RHAPSODY_IN_UMBER,   -- Garlaige Coffer Key
+                1048,    5000,      tpz.ki.RHAPSODY_IN_UMBER,   -- Zvhal Coffer Key
+                1049,    5000,      tpz.ki.RHAPSODY_IN_UMBER,   -- Uggalepih Coffer Key
+                1050,    5000,      tpz.ki.RHAPSODY_IN_UMBER,   -- Den Coffer Key
+                1051,    5000,      tpz.ki.RHAPSODY_IN_UMBER,   -- Kuftal Coffer Key
+                1052,    5000,      tpz.ki.RHAPSODY_IN_UMBER,   -- Boyahda Coffer Key
+                1053,    5000,      tpz.ki.RHAPSODY_IN_UMBER,   -- Cauldron Coffer Key
+                1054,    5000,      tpz.ki.RHAPSODY_IN_UMBER,   -- Quicksand Coffer Key
+                1055,    2500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Grotto Chest Key
+                1056,    2500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Onzozo Chest Key
+                1057,    5000,      tpz.ki.RHAPSODY_IN_UMBER,   -- Toraimarai Coffer Key
+                1058,    5000,      tpz.ki.RHAPSODY_IN_UMBER,   -- Ru'Aun Coffer Key
+                1059,    5000,      tpz.ki.RHAPSODY_IN_UMBER,   -- Grotto Coffer Key
+                1060,    5000,      tpz.ki.RHAPSODY_IN_UMBER,   -- Ve'Lugannon Coffer Key
+                1061,    2500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Sacrarium Chest Key
+                1062,    2500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Oldton Chest Key
+                1063,    5000,      tpz.ki.RHAPSODY_IN_UMBER,   -- Newton Coffer Key
+                1064,    2500,      tpz.ki.RHAPSODY_IN_WHITE,   -- Pso'Xja Chest Key
         }
     }
 }

--- a/scripts/zones/Port_Bastok/npcs/Curio_Vendor_Moogle.lua
+++ b/scripts/zones/Port_Bastok/npcs/Curio_Vendor_Moogle.lua
@@ -1,0 +1,32 @@
+-----------------------------------
+-- Area: Port Bastok
+--  NPC: Curio Vendor Moogle
+--  Shop NPC
+-----------------------------------
+require("scripts/globals/settings")
+require("scripts/globals/keyitems")
+require("scripts/globals/shop")
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end
+
+function onTrigger(player,npc)
+    if not player:hasKeyItem(tpz.ki.RHAPSODY_IN_WHITE) then
+        player:startEvent(9600)
+    else
+        player:startEvent(9601)
+    end
+end
+
+function onEventUpdate(player,csid,option)
+end
+
+function onEventFinish(player,csid,option)
+    if csid == 9601 then
+        if option >= 1 and option <= 6 then
+            local stock = tpz.shop.curioVendorMoogleStock[option]
+            tpz.shop.curioVendorMoogle(player, stock)
+        end
+    end
+end

--- a/scripts/zones/Port_San_dOria/npcs/Curio_Vendor_Moogle.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Curio_Vendor_Moogle.lua
@@ -1,0 +1,32 @@
+-----------------------------------
+-- Area: Port San d'Oria
+--  NPC: Curio Vendor Moogle
+--  Shop NPC
+-----------------------------------
+require("scripts/globals/settings")
+require("scripts/globals/keyitems")
+require("scripts/globals/shop")
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end
+
+function onTrigger(player,npc)
+    if not player:hasKeyItem(tpz.ki.RHAPSODY_IN_WHITE) then
+        player:startEvent(9600)
+    else
+        player:startEvent(9601)
+    end
+end
+
+function onEventUpdate(player,csid,option)
+end
+
+function onEventFinish(player,csid,option)
+    if csid == 9601 then
+        if option >= 1 and option <= 6 then
+            local stock = tpz.shop.curioVendorMoogleStock[option]
+            tpz.shop.curioVendorMoogle(player, stock)
+        end
+    end
+end

--- a/scripts/zones/Port_Windurst/npcs/Curio_Vendor_Moogle.lua
+++ b/scripts/zones/Port_Windurst/npcs/Curio_Vendor_Moogle.lua
@@ -1,0 +1,32 @@
+-----------------------------------
+-- Area: Port Windurst
+--  NPC: Curio Vendor Moogle
+--  Shop NPC
+-----------------------------------
+require("scripts/globals/settings")
+require("scripts/globals/keyitems")
+require("scripts/globals/shop")
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end
+
+function onTrigger(player,npc)
+    if not player:hasKeyItem(tpz.ki.RHAPSODY_IN_WHITE) then
+        player:startEvent(9600)
+    else
+        player:startEvent(9601)
+    end
+end
+
+function onEventUpdate(player,csid,option)
+end
+
+function onEventFinish(player,csid,option)
+    if csid == 9601 then
+        if option >= 1 and option <= 6 then
+            local stock = tpz.shop.curioVendorMoogleStock[option]
+            tpz.shop.curioVendorMoogle(player, stock)
+        end
+    end
+end


### PR DESCRIPTION
Added all shop items (except keyitems) for all curio moogles (UP to RHAPSODIES IN AZURE as the other quests have not been scripted, but should be easy to just populate with correct information once they are)
Made it a global to not have to have those scripts all over the place.
Thank you Hiro from the Canaria server for testing and making sure that the prices and order was correct.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

