### PR TITLE
Artisan Moogles + Mog Sack

### DIFF
--- a/scripts/globals/artisan.lua
+++ b/scripts/globals/artisan.lua
@@ -22,11 +22,6 @@ local menuFlags = {
 	aexpand = 0x2,
 }
 
-local getEpochDays = function()
-    local time = os.date("*t")
-    return time.year*365 + time.yday
-end
-
 tpz.artisan.moogleOnTrigger = function(player, npc)
     local csid = event[player:getZoneID()]
     local menuMask = 0
@@ -62,13 +57,13 @@ tpz.artisan.moogleOnUpdate = function(player,csid,option)
         end
 
     elseif option == 3 then -- Client requests sack + scroll status
-        local scrollAvail = player:getCharVar("[artisan]nextScroll") <= getEpochDays() and 1 or 0
+        local scrollAvail = player:getCharVar("[artisan]nextScroll") < getMidnight() and 1 or 0
         local sackSize = player:getContainerSize(tpz.inv.MOGSACK)
         if sackSize > 0 then sackSize = sackSize + 1 end
         player:updateEvent(0, 0, 0, sackSize, 0, 0, 0, scrollAvail)
 
     elseif option == 4 then -- Main dialogue
-        local scrollAvail = player:getCharVar("[artisan]nextScroll") <= getEpochDays() and 1 or 0
+        local scrollAvail = player:getCharVar("[artisan]nextScroll") < getMidnight() and 1 or 0
         local sackSize = player:getContainerSize(tpz.inv.MOGSACK)
         if sackSize > 0 then sackSize = sackSize + 1 end
         player:updateEvent(0, 0, player:getGil(), sackSize, 0, 0, 0, scrollAvail)
@@ -79,10 +74,10 @@ tpz.artisan.moogleOnFinish = function(player,csid,option)
     local zone = zones[player:getZoneID()]
 
     if option == 99 then -- Get Scroll
-        if player:getCharVar("[artisan]nextScroll") <= getEpochDays() then
+        if player:getCharVar("[artisan]nextScroll") < getMidnight() then
             if player:addItem(4181) then
                 player:messageSpecial(zone.text.ITEM_OBTAINED,4181)
-                player:setCharVar("[artisan]nextScroll", getEpochDays() + 1)
+                player:setCharVar("[artisan]nextScroll", getMidnight())
             else
                 player:messageSpecial(zone.text.ITEM_CANNOT_BE_OBTAINED,4181)
             end

--- a/scripts/globals/artisan.lua
+++ b/scripts/globals/artisan.lua
@@ -1,0 +1,91 @@
+-----------------------------------
+--
+--  Artisan Moogles
+--
+-----------------------------------
+require('scripts/globals/zone')
+require('scripts/globals/status')
+-----------------------------------
+
+tpz = tpz or {}
+tpz.artisan = tpz.artisan or {}
+
+local event = {
+    [tpz.zone.BASTOK_MARKETS] = 544,
+    [tpz.zone.WINDURST_WOODS] = 833,
+    [tpz.zone.RULUDE_GARDENS] = 10162,
+    [tpz.zone.SOUTHERN_SAN_DORIA] = 960
+}
+local menuFlags = {
+	expand = 0x8,
+	abags = 0x4,
+	aexpand = 0x2,
+}
+
+local getEpochDays = function()
+    local time = os.date("*t")
+    return time.year*365 + time.yday
+end
+
+tpz.artisan.moogleOnTrigger = function(player, npc)
+    local csid = event[player:getZoneID()]
+    local menuMask = 0
+    local mogVisited = player:getCharVar("[artisan]visited")
+    local sackSize = player:getContainerSize(tpz.inv.MOGSACK)
+    if mogVisited == 0 then player:setCharVar("[artisan]visited", 1) end
+    if sackSize > 0 then
+        sackSize = sackSize + 1
+    else
+        menuMask = menuFlags.expand + menuFlags.aexpand
+    end
+    player:startEvent(csid, 0, 0, 0, sackSize, 0, 0, menuMask, mogVisited)
+end
+
+tpz.artisan.moogleOnUpdate = function(player,csid,option)
+
+    if option == 1 then -- Buy sack
+        if player:getGil() >= 9980 and player:getContainerSize(tpz.inv.MOGSACK) == 0 then
+            player:delGil(9980)
+            player:changeContainerSize(tpz.inv.MOGSACK, 30)
+            player:updateEvent(0, 0, 0, 30+1, 0, 0, 0, 2)
+        end
+
+    elseif option == 2 then -- Expand sack
+        local sackSize = player:getContainerSize(tpz.inv.MOGSACK)
+        local gobbieSize = player:getContainerSize(tpz.inv.INVENTORY)
+        local gobbieCanUpgrade = gobbieSize < 80 and 1 or 0
+        if sackSize < gobbieSize and sackSize > 0 then
+            player:changeContainerSize(tpz.inv.MOGSACK, gobbieSize - sackSize)
+            player:updateEvent((gobbieSize-30)/5, 0, 0, player:getContainerSize(tpz.inv.MOGSACK)+1, 0, 0, 2, 0)
+        else
+            player:updateEvent(0, 0, 0, 0, 0, 0, gobbieCanUpgrade, 0)
+        end
+
+    elseif option == 3 then -- Client requests sack + scroll status
+        local scrollAvail = player:getCharVar("[artisan]nextScroll") <= getEpochDays() and 1 or 0
+        local sackSize = player:getContainerSize(tpz.inv.MOGSACK)
+        if sackSize > 0 then sackSize = sackSize + 1 end
+        player:updateEvent(0, 0, 0, sackSize, 0, 0, 0, scrollAvail)
+
+    elseif option == 4 then -- Main dialogue
+        local scrollAvail = player:getCharVar("[artisan]nextScroll") <= getEpochDays() and 1 or 0
+        local sackSize = player:getContainerSize(tpz.inv.MOGSACK)
+        if sackSize > 0 then sackSize = sackSize + 1 end
+        player:updateEvent(0, 0, player:getGil(), sackSize, 0, 0, 0, scrollAvail)
+    end
+end
+
+tpz.artisan.moogleOnFinish = function(player,csid,option)
+    local zone = zones[player:getZoneID()]
+
+    if option == 99 then -- Get Scroll
+        if player:getCharVar("[artisan]nextScroll") <= getEpochDays() then
+            if player:addItem(4181) then
+                player:messageSpecial(zone.text.ITEM_OBTAINED,4181)
+                player:setCharVar("[artisan]nextScroll", getEpochDays() + 1)
+            else
+                player:messageSpecial(zone.text.ITEM_CANNOT_BE_OBTAINED,4181)
+            end
+        end
+    end
+end

--- a/scripts/globals/artisan.lua
+++ b/scripts/globals/artisan.lua
@@ -25,8 +25,8 @@ local menuFlags = {
 tpz.artisan.moogleOnTrigger = function(player, npc)
     local csid = event[player:getZoneID()]
     local menuMask = 0
-    local mogVisited = player:getCharVar("[artisan]visited")
     local sackSize = player:getContainerSize(tpz.inv.MOGSACK)
+    local mogVisited = (sackSize > 0 or player:getCharVar("[artisan]visited") > 0) and 1 or 0
     if mogVisited == 0 then player:setCharVar("[artisan]visited", 1) end
     if sackSize > 0 then
         sackSize = sackSize + 1
@@ -42,6 +42,7 @@ tpz.artisan.moogleOnUpdate = function(player,csid,option)
         if player:getGil() >= 9980 and player:getContainerSize(tpz.inv.MOGSACK) == 0 then
             player:delGil(9980)
             player:changeContainerSize(tpz.inv.MOGSACK, 30)
+            player:setCharVar("[artisan]visited", 0)
             player:updateEvent(0, 0, 0, 30+1, 0, 0, 0, 2)
         end
 

--- a/scripts/zones/Bastok_Markets/npcs/Artisan_Moogle.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Artisan_Moogle.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- Area: Bastok Markets
+--  NPC: Artisan Moogle
+-----------------------------------
+require("scripts/globals/artisan")
+
+function onTrigger(player,npc)
+    tpz.artisan.moogleOnTrigger(player, npc)
+end
+
+function onEventUpdate(player,csid,option)
+    tpz.artisan.moogleOnUpdate(player, npc, option)
+end
+
+function onEventFinish(player,csid,option)
+    tpz.artisan.moogleOnFinish(player, npc, option)
+end

--- a/scripts/zones/RuLude_Gardens/npcs/Artisan_Moogle.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Artisan_Moogle.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- Area: Ru'Lude Gardens
+--  NPC: Artisan Moogle
+-----------------------------------
+require("scripts/globals/artisan")
+
+function onTrigger(player,npc)
+    tpz.artisan.moogleOnTrigger(player, npc)
+end
+
+function onEventUpdate(player,csid,option)
+    tpz.artisan.moogleOnUpdate(player, npc, option)
+end
+
+function onEventFinish(player,csid,option)
+    tpz.artisan.moogleOnFinish(player, npc, option)
+end

--- a/scripts/zones/Southern_San_dOria/npcs/Artisan_Moogle.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Artisan_Moogle.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- Area: Southern San d'Oria
+--  NPC: Artisan Moogle
+-----------------------------------
+require("scripts/globals/artisan")
+
+function onTrigger(player,npc)
+    tpz.artisan.moogleOnTrigger(player, npc)
+end
+
+function onEventUpdate(player,csid,option)
+    tpz.artisan.moogleOnUpdate(player, npc, option)
+end
+
+function onEventFinish(player,csid,option)
+    tpz.artisan.moogleOnFinish(player, npc, option)
+end

--- a/scripts/zones/Windurst_Woods/npcs/Artisan_Moogle.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Artisan_Moogle.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- Area: Windurst Woods
+--  NPC: Artisan Moogle
+-----------------------------------
+require("scripts/globals/artisan")
+
+function onTrigger(player,npc)
+    tpz.artisan.moogleOnTrigger(player, npc)
+end
+
+function onEventUpdate(player,csid,option)
+    tpz.artisan.moogleOnUpdate(player, npc, option)
+end
+
+function onEventFinish(player,csid,option)
+    tpz.artisan.moogleOnFinish(player, npc, option)
+end

--- a/sql/char_storage.sql
+++ b/sql/char_storage.sql
@@ -32,7 +32,7 @@ CREATE TABLE IF NOT EXISTS `char_storage` (
   `safe` tinyint(2) unsigned NOT NULL DEFAULT '50',
   `locker` tinyint(2) unsigned NOT NULL DEFAULT '0',
   `satchel` tinyint(2) unsigned NOT NULL DEFAULT '30',
-  `sack` tinyint(2) unsigned NOT NULL DEFAULT '30',
+  `sack` tinyint(2) unsigned NOT NULL DEFAULT '0',
   `case` tinyint(2) unsigned NOT NULL DEFAULT '80',
   `wardrobe` tinyint(2) unsigned NOT NULL DEFAULT '80',
   `wardrobe2` tinyint(2) unsigned NOT NULL DEFAULT '80',


### PR DESCRIPTION
Fully implemented code for the 4 Artisan Moogles and accompanying Mog Sack purchase/expansion abilities. They also now provide Warp Scrolls to players once per day as in retail. As retail-like capability exists now for purchasing Mob Sacks, this also sets default Mog Sack size for new players to 0 (as retail). Existing DBs will not be migrated, so as to not cause surprise issues for server admins & players.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

