### PR TITLE
Fix Time-of-Day events not firing reliably (Night mobs not spawn/despawn)

### DIFF
--- a/src/map/vana_time.cpp
+++ b/src/map/vana_time.cpp
@@ -196,8 +196,10 @@ TIMETYPE CVanaTime::SyncTime()
     m_vHour = (uint32)((m_vanaDate % VTIME_DAY)   / VTIME_HOUR);
     m_vMin  = (uint32)( m_vanaDate % VTIME_HOUR);
 
-    if (m_vMin == 0)
+    static int8 lastTickedHour = m_vHour;
+    if (m_vHour == (lastTickedHour+1)%24)
     {
+        lastTickedHour = m_vHour;
         switch (m_vHour)
         {
             case  0: m_TimeType = TIME_NIGHT;   return TIME_MIDNIGHT;


### PR DESCRIPTION
This fixes longstanding intermittent issues with Evening Mobs not spawning, not de-spawning, Day/Night Latents not always taking effect, guild shops not always restocking, and many more things which are dependent on reliable time-transition detections.

The long explanation of this problem is that the time_server runs based on a delay of 2400ms (one vanadiel minute), while the SyncTime() function uses the true system clock to generate the current Vanadiel Time. Since a delay-based sync cycle is variable given various system loads, conditions, and code execution, it will drift in and out of phase with the SyncTime() time generation, leading to vanadiel minutes periodically being skipped or repeated. If this skipped second was minute 0 of an hour, this would result in TOTD updates not firing.

TOTD updates are the only absolutely essential trigger based on this, and so should detect hour boundaries rather than "minute 0". I don't believe a rewrite of the clock mechanism is necessary or helpful, as the overall vanadiel timekeeping is still accurate; rather we just be cognizant of the granularity of its momentary accuracy.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Fixes #282