### PR TITLE
Fixes crystal drops for parties.

### DIFF
--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -919,19 +919,36 @@ void CMobEntity::DropItems(CCharEntity* PChar)
 
         uint8 effect = 0; // Begin Adding Crystals
         
-        if (conquest::GetRegionOwner(PChar->loc.zone->GetRegionID()) <= 2 && m_Element > 0) // Valid Signet Zone
+        if (m_Element > 0)
         {
-            effect = 1;
+            uint8 regionID = PChar->loc.zone->GetRegionID();
+            switch (regionID)
+            {
+                // Sanction Regions
+                case REGION_WEST_AHT_URHGAN:
+                case REGION_MAMOOL_JA_SAVAGE:
+                case REGION_HALVUNG:
+                case REGION_ARRAPAGO:
+                    effect = 2;
+                    break;
+                // Sigil Regions
+                case REGION_RONFAURE_FRONT:
+                case REGION_NORVALLEN_FRONT:
+                case REGION_GUSTABERG_FRONT:
+                case REGION_DERFLAND_FRONT:
+                case REGION_SARUTA_FRONT:
+                case REGION_ARAGONEAU_FRONT:
+                case REGION_FAUREGANDI_FRONT:
+                case REGION_VALDEAUNIA_FRONT:
+                    effect = 3;
+                    break;
+                // Signet Regions
+                default:
+                    effect = (conquest::GetRegionOwner(PChar->loc.zone->GetRegionID()) <= 2) ? 1 : 0;
+                    break;
+            }
         }
-        else if (PChar->loc.zone->GetRegionID() >= 28 && PChar->loc.zone->GetRegionID() <= 32 && m_Element > 0) // Valid Sanction Zone
-        {
-            effect = 2;
-        }
-        else if (PChar->loc.zone->GetRegionID() >= 33 && PChar->loc.zone->GetRegionID() <= 40 && m_Element > 0) // Valid Sigil Zone
-        {
-            effect = 3;
-        }
-        int crystalRolls = 0;
+        uint8 crystalRolls = 0;
         PChar->ForParty([this, &crystalRolls, &effect](CBattleEntity* PMember)
         {
             switch(effect)
@@ -958,7 +975,7 @@ void CMobEntity::DropItems(CCharEntity* PChar)
                     break;
             }
         });
-        for (int i = 0; i < crystalRolls; i++)
+        for (uint8 i = 0; i < crystalRolls; i++)
         {
             if (tpzrand::GetRandomNumber(100) < 20 && AddItemToPool(4095 + m_Element, ++dropCount))
             {

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -834,32 +834,21 @@ void CMobEntity::DropItems(CCharEntity* PChar)
         }
     }
 
-    //check for seal drops
-    /* MobLvl >= 1 = Beastmen Seals ID=1126
-    >= 50 = Kindred Seals ID=1127
-    >= 75 = Kindred Crests ID=2955
-    >= 90 = High Kindred Crests ID=2956
-    */
+
 
     uint16 Pzone = PChar->getZone();
 
     bool validZone = ((Pzone > 0 && Pzone < 39) || (Pzone > 42 && Pzone < 134) || (Pzone > 135 && Pzone < 185) || (Pzone > 188 && Pzone < 255));
 
-    if (validZone && charutils::CheckMob(PChar->GetMLevel(), GetMLevel()) > EMobDifficulty::TooWeak)
+    if (validZone && charutils::CheckMob(m_HiPCLvl, GetMLevel()) > EMobDifficulty::TooWeak)
     {
-        if (((PChar->StatusEffectContainer->HasStatusEffect(EFFECT_SIGNET) && conquest::GetRegionOwner(PChar->loc.zone->GetRegionID()) <= 2) ||
-            (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_SANCTION) && PChar->loc.zone->GetRegionID() >= 28 && PChar->loc.zone->GetRegionID() <= 32) ||
-            (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_SIGIL) && PChar->loc.zone->GetRegionID() >= 33 && PChar->loc.zone->GetRegionID() <= 40)) &&
-            m_Element > 0 && tpzrand::GetRandomNumber(100) < 20) // Need to move to CRYSTAL_CHANCE constant
-        {
-            if (AddItemToPool(4095 + m_Element, ++dropCount))
-                return;
-        }
 
-        // Todo: Avatarite and Geode drops during day/weather. Much higher chance during weather than day.
-        // Item element matches day/weather element, not mob crystal. Lv80+ xp mobs can drop Avatarite.
-        // Wiki's have conflicting info on mob lv required for Geodes. One says 50 the other 75. I think 50 is correct.
-
+        //check for seal drops
+        /* MobLvl >= 1 = Beastmen Seals ID=1126
+        >= 50 = Kindred Seals ID=1127
+        >= 75 = Kindred Crests ID=2955
+        >= 90 = High Kindred Crests ID=2956
+        */
         if (tpzrand::GetRandomNumber(100) < 20 && PChar->PTreasurePool->CanAddSeal() && !getMobMod(MOBMOD_NO_DROPS))
         {
             //RULES: Only 1 kind may drop per mob
@@ -922,6 +911,58 @@ void CMobEntity::DropItems(CCharEntity* PChar)
                 //b.seal only
                 if (AddItemToPool(1126, ++dropCount))
                     return;
+            }
+        }
+        // Todo: Avatarite and Geode drops during day/weather. Much higher chance during weather than day.
+        // Item element matches day/weather element, not mob crystal. Lv80+ xp mobs can drop Avatarite.
+        // Wiki's have conflicting info on mob lv required for Geodes. One says 50 the other 75. I think 50 is correct.
+
+        uint8 effect = 0; // Begin Adding Crystals
+        
+        if (conquest::GetRegionOwner(PChar->loc.zone->GetRegionID()) <= 2 && m_Element > 0) // Valid Signet Zone
+        {
+            effect = 1;
+        }
+        else if (PChar->loc.zone->GetRegionID() >= 28 && PChar->loc.zone->GetRegionID() <= 32 && m_Element > 0) // Valid Sanction Zone
+        {
+            effect = 2;
+        }
+        else if (PChar->loc.zone->GetRegionID() >= 33 && PChar->loc.zone->GetRegionID() <= 40 && m_Element > 0) // Valid Sigil Zone
+        {
+            effect = 3;
+        }
+        int crystalRolls = 0;
+        PChar->ForParty([this, &crystalRolls, &effect](CBattleEntity* PMember)
+        {
+            switch(effect)
+            {
+                case 1:
+                    if (PMember->StatusEffectContainer->HasStatusEffect(EFFECT_SIGNET) && PMember->getZone() == getZone() && distance(PMember->loc.p, loc.p) < 100)
+                    {
+                        crystalRolls++;
+                    }
+                    break;
+                case 2:
+                    if (PMember->StatusEffectContainer->HasStatusEffect(EFFECT_SANCTION) && PMember->getZone() == getZone() && distance(PMember->loc.p, loc.p) < 100)
+                    {
+                        crystalRolls++;
+                    }
+                    break;
+                case 3:
+                    if (PMember->StatusEffectContainer->HasStatusEffect(EFFECT_SIGIL) && PMember->getZone() == getZone() && distance(PMember->loc.p, loc.p) < 100)
+                    {
+                        crystalRolls++;
+                    }
+                    break;
+                default:
+                    break;
+            }
+        });
+        for (int i = 0; i < crystalRolls; i++)
+        {
+            if (tpzrand::GetRandomNumber(100) < 20 && AddItemToPool(4095 + m_Element, ++dropCount))
+            {
+                return;
             }
         }
     }

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3261,15 +3261,15 @@ namespace charutils
             }
         });
         pcinzone = std::max(pcinzone, PMob->m_HiPartySize);
+        maxlevel = std::max(maxlevel, PMob->m_HiPCLvl);
+        PMob->m_HiPartySize = pcinzone;
+        PMob->m_HiPCLvl = maxlevel;
 
         PChar->ForAlliance([&PMob, &region, &minlevel, &maxlevel, &pcinzone](CBattleEntity* PPartyMember)
         {
             CCharEntity* PMember = dynamic_cast<CCharEntity*>(PPartyMember);
             if (!PMember || PMember->isDead())
                 return;
-
-            maxlevel = std::max(maxlevel, PMob->m_HiPCLvl);
-            PMob->m_HiPCLvl = maxlevel;
 
             bool chainactive = false;
 

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3269,6 +3269,7 @@ namespace charutils
                 return;
 
             maxlevel = std::max(maxlevel, PMob->m_HiPCLvl);
+            PMob->m_HiPCLvl = maxlevel;
 
             bool chainactive = false;
 


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Adds functionality for multiple crystal drops from a mob while in a party.  Also re-orders drops to make seals occur before crystals as is retail.  The code was tested on my server in a party of 1 to 3 people and works well.  The code was styled a tiny bit differently for topaz, so this exact code wasn't built or tested.

Closes issue #551 

Co-contribution credit to Teotwawki and cocosolos for working on this with me.