### PR TITLE
zone_weather slim down / optimize for speed

### DIFF
--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -290,37 +290,44 @@ void CZone::LoadZoneLines()
     }
 }
 
-/************************************************************************
-*                                                                       *
-*  Загружаем параметры погоды                                           *
-*                                                                       *
-************************************************************************/
+/*************************************************************************
+*                                                                        *
+*  Loads weather for the zone from zone_bweather SQL Table               *
+*                                                                        *
+*  Weather is a rotating pattern of 2160 vanadiel days for each zone.    *
+*  It's stored as a blob of 2160 16-bit values, each representing 1 day  *
+*  starting from day 0 and storing 3 5-bit weather values each.          *
+*                                                                        *
+*              0        00000       00000        00000                   *
+*              ^        ^^^^^       ^^^^^        ^^^^^                   *
+*          padding      normal      common       rare                    *
+*                                                                        *
+*************************************************************************/
 
 void CZone::LoadZoneWeather()
 {
     static const char* Query =
-        "SELECT "
-        "weather_day,"
-        "normal,"
-        "common,"
-        "rare "
-        "FROM zone_weather "
-        "WHERE zoneid = %u "
-        "ORDER BY weather_day";
+        "SELECT weather FROM zone_weather WHERE zone = %u;";
 
     int32 ret = Sql_Query(SqlHandle, Query, m_zoneID);
-
     if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0)
     {
-        while (Sql_NextRow(SqlHandle) == SQL_SUCCESS)
-        {
-            m_WeatherVector.insert(std::make_pair((uint16)Sql_GetUIntData(SqlHandle, 0), zoneWeather_t(Sql_GetIntData(SqlHandle, 1),
-                Sql_GetIntData(SqlHandle, 2), Sql_GetIntData(SqlHandle, 3))));
-        }
+            Sql_NextRow(SqlHandle);
+            auto weatherBlob = reinterpret_cast<uint16*>(Sql_GetData(SqlHandle, 0));
+            for(uint16 i = 0; i < WEATHER_CYCLE; i++)
+            {
+                if(weatherBlob[i])
+                {
+                    uint8 w_normal = static_cast<uint8>( weatherBlob[i] >> 10);
+                    uint8 w_common = static_cast<uint8>((weatherBlob[i] >> 5) & 0x1F);
+                    uint8 w_rare   = static_cast<uint8>( weatherBlob[i] & 0x1F);
+                    m_WeatherVector.insert(std::make_pair(i, zoneWeather_t(w_normal, w_common, w_rare)));
+                }
+            }
     }
     else
     {
-        ShowFatalError(CL_RED"CZone::LoadZoneWeather: Cannot load zone weather (%u)\n" CL_RESET, m_zoneID);
+        ShowFatalError(CL_RED"CZone::LoadZoneWeather: Cannot load zone weather (%u). Ensure zone_weather.sql has been imported!\n" CL_RESET, m_zoneID);
     }
 }
 


### PR DESCRIPTION
<img align="right" src="https://user-images.githubusercontent.com/12466395/83200195-aabb7680-a0f7-11ea-9e20-050828a91235.png"/>

No longer can zone_weather be the butt of jokes. She's lean and fast and remembers how you laughed when she was big; so she's not giving you her number.

In seriousness, zone_weather is big. 237,000 rows of daily weather data that takes a long time to import, and a lot of space to store. It's the largest DB table by a wide margin. This switches the inefficient existing storage to just one neatly packed bit pattern per zone. Those interested in technical specs can see the comment above loadZoneWeather() where it's detailed for you.

### Gains
```
SQL File Size:              83% reduction
SQL Import time:            97% reduction
Server weather load:        55% reduction
Raw table Size:             40% reduction
```
This will be especially welcome to those who aren't running on high end hardware, or those trying to run on Raspberry Pi's where SQL transaction IO can be limiting.

### Considerations
The table will no longer be in human-readable form, though I would argue it was far from human-friendly before, and the weather table has generally gone untouched for quite some time so I consider it essentially static. That said, the fixed-length data format was designed to be easy to work with, and a tool or script could be made to make editing zones easier than was even possible previously.

The new weather blobs ~~live in a new table which~~ needs to be imported or the server will display errors that the user should "Import zone_weather.sql". I don't believe any migrate step is needed at this time, as the table is new and shares nothing in common with the old one. 

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits