### PR TITLE
Winsock updates

### DIFF
--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -18,7 +18,6 @@ else()
         -DFMT_USE_WINDOWS_H=0
         -D_CRT_SECURE_NO_WARNINGS
         -D_CRT_NONSTDC_NO_DEPRECATE
-        -D_WINSOCK_DEPRECATED_NO_WARNINGS
         /Ob2 # Inline Function Expansion
         /Oy- # Frame-Pointer Omission
         /MP # Build with Multiple Processes

--- a/src/common/socket.cpp
+++ b/src/common/socket.cpp
@@ -276,12 +276,12 @@ bool _vsocket_final(void){
 }
 
 // hostname/ip conversion functions
-const char* ip2str(uint32 ip, char ip_str[16])
+std::string ip2str(uint32 ip)
 {
     uint32 reversed_ip = htonl(ip);
-    char* address = new char[INET_ADDRSTRLEN];
+    char address[INET_ADDRSTRLEN];
     inet_ntop(AF_INET, &reversed_ip, address, INET_ADDRSTRLEN);
-    return (ip_str == NULL) ? address : strncpy(ip_str, address, 16);
+    return std::string(address);
 }
 
 uint32 str2ip(const char* ip_str)

--- a/src/common/socket.cpp
+++ b/src/common/socket.cpp
@@ -156,10 +156,6 @@ time_t last_tick;
 time_t tick_time;
 time_t stall_time = 60;
 
-uint32 g_addr_[16];   // ip addresses of local host (host byte order)
-
-int32 naddr_;   // # of ip addresses
-
 int32 makeConnection(uint32 ip, uint16 port, int32 type)
 {
 	struct sockaddr_in remote_address;
@@ -225,94 +221,6 @@ void do_close(int32 fd)
 	sClose(fd); // We don't really care if these closing functions return an error, we are just shutting down and not reusing this socket.
 }
 
-/// Retrieve local ips in host byte order.
-/// Uses loopback is no address is found.
-int socket_getips(uint32* ips, int max)
-{
-	int num = 0;
-
-	if( ips == NULL || max <= 0 )
-		return 0;
-
-#ifdef WIN32
-	{
-		char fullhost[255];
-		u_long** a;
-		struct hostent* hent;
-
-		// XXX This should look up the local IP addresses in the registry
-		// instead of calling gethostbyname. However, the way IP addresses
-		// are stored in the registry is annoyingly complex, so I'll leave
-		// this as T.B.D. [Meruru]
-		if( gethostname(fullhost, sizeof(fullhost)) == SOCKET_ERROR )
-		{
-			ShowError("socket_getips: No hostname defined!\n");
-			return 0;
-		}
-		else
-		{
-			hent = gethostbyname(fullhost);
-			if( hent == NULL ){
-				ShowError("socket_getips: Cannot resolve our own hostname to an IP address\n");
-				return 0;
-			}
-			a = (u_long**)hent->h_addr_list;
-			for( ; a[num] != NULL && num < max; ++num)
-				ips[num] = (uint32)ntohl(*a[num]);
-		}
-	}
-#else // not WIN32
-	{
-		int pos;
-		int fd;
-		char buf[2*16*sizeof(struct ifreq)];
-		struct ifconf ic;
-		struct ifreq* ir;
-		struct sockaddr_in* a;
-		u_long ad;
-
-		fd = sSocket(AF_INET, SOCK_STREAM, 0);
-
-		memset(buf, 0x00, sizeof(buf));
-
-		// The ioctl call will fail with Invalid Argument if there are more
-		// interfaces than will fit in the buffer
-		ic.ifc_len = sizeof(buf);
-		ic.ifc_buf = buf;
-		if( sIoctl(fd, SIOCGIFCONF, &ic) == -1 )
-		{
-			ShowError("socket_getips: SIOCGIFCONF failed!\n");
-			return 0;
-		}
-		else
-		{
-			for( pos=0; pos < ic.ifc_len && num < max; )
-			{
-				ir = (struct ifreq*)(buf+pos);
-				a = (struct sockaddr_in*) &(ir->ifr_addr);
-				if( a->sin_family == AF_INET ){
-					ad = ntohl(a->sin_addr.s_addr);
-					if( ad != INADDR_LOOPBACK && ad != INADDR_ANY )
-						ips[num++] = (uint32)ad;
-				}
-	#if (defined(BSD) && BSD >= 199103) || defined(_AIX) || defined(__APPLE__)
-				pos += ir->ifr_addr.sa_len + sizeof(ir->ifr_name);
-	#else// not AIX or APPLE
-				pos += sizeof(struct ifreq);
-	#endif//not AIX or APPLE
-			}
-		}
-		sClose(fd);
-	}
-#endif // not W32
-
-	// Use loopback if no ips are found
-	if( num == 0 )
-		ips[num++] = (uint32)INADDR_LOOPBACK;
-
-	return num;
-}
-
 bool _vsocket_init(void)
 {
 #ifdef WIN32
@@ -356,12 +264,7 @@ bool _vsocket_init(void)
 	}
 #endif
 
-	// Get initial local ips
-	naddr_ = socket_getips(g_addr_,16);
-
 	sFD_ZERO(&readfds);
-
-
 
 	// initialise last send-receive tick
 	last_tick = time(NULL);
@@ -373,22 +276,20 @@ bool _vsocket_final(void){
 }
 
 // hostname/ip conversion functions
-uint32 host2ip(const char* hostname)
-{
-	struct hostent* h = gethostbyname(hostname);
-	return (h != NULL) ? ntohl(*(uint32*)h->h_addr) : 0;
-}
-
 const char* ip2str(uint32 ip, char ip_str[16])
 {
-	struct in_addr addr;
-	addr.s_addr = htonl(ip);
-	return (ip_str == NULL) ? inet_ntoa(addr) : strncpy(ip_str, inet_ntoa(addr), 16);
+    uint32 reversed_ip = htonl(ip);
+    char* address = new char[INET_ADDRSTRLEN];
+    inet_ntop(AF_INET, &reversed_ip, address, INET_ADDRSTRLEN);
+	return (ip_str == NULL) ? address : strncpy(ip_str, address, 16);
 }
 
 uint32 str2ip(const char* ip_str)
 {
-	return ntohl(inet_addr(ip_str));
+    uint32 ip;
+    inet_pton(AF_INET, ip_str, &ip);
+
+    return ntohl(ip);
 }
 
 // Reorders bytes from network to little endian (Windows).
@@ -822,7 +723,7 @@ int32 makeListenBind_tcp(const char* ip, uint16 port,RecvFunc connect_client)
 	//set_nonblocking(fd, 1);
 
 	server_address.sin_family      = AF_INET;
-	server_address.sin_addr.s_addr = inet_addr(ip);
+    inet_pton(AF_INET, ip, &server_address.sin_addr.s_addr);
 	server_address.sin_port        = htons(port);
 
 	result = sBind(fd, (struct sockaddr*)&server_address, sizeof(server_address));

--- a/src/common/socket.cpp
+++ b/src/common/socket.cpp
@@ -281,7 +281,7 @@ const char* ip2str(uint32 ip, char ip_str[16])
     uint32 reversed_ip = htonl(ip);
     char* address = new char[INET_ADDRSTRLEN];
     inet_ntop(AF_INET, &reversed_ip, address, INET_ADDRSTRLEN);
-	return (ip_str == NULL) ? address : strncpy(ip_str, address, 16);
+    return (ip_str == NULL) ? address : strncpy(ip_str, address, 16);
 }
 
 uint32 str2ip(const char* ip_str)
@@ -722,9 +722,9 @@ int32 makeListenBind_tcp(const char* ip, uint16 port,RecvFunc connect_client)
 	//setsocketopts(fd);
 	//set_nonblocking(fd, 1);
 
-	server_address.sin_family      = AF_INET;
+    server_address.sin_family      = AF_INET;
     inet_pton(AF_INET, ip, &server_address.sin_addr.s_addr);
-	server_address.sin_port        = htons(port);
+    server_address.sin_port        = htons(port);
 
 	result = sBind(fd, (struct sockaddr*)&server_address, sizeof(server_address));
 	if( result == SOCKET_ERROR ) {

--- a/src/common/socket.h
+++ b/src/common/socket.h
@@ -162,7 +162,7 @@ void socket_init();
 void socket_final();
 
 // hostname/ip conversion functions
-const char* ip2str(uint32 ip, char ip_str[16]);
+std::string ip2str(uint32 ip);
 
 uint32 str2ip(const char* ip_str);
 

--- a/src/common/socket.h
+++ b/src/common/socket.h
@@ -14,6 +14,7 @@
 #ifdef WIN32
     #define FD_SETSIZE 1000
 	#include <winsock2.h>
+	#include <WS2tcpip.h>
 	typedef long in_addr_t;
 #else
 	#include <sys/types.h>
@@ -161,8 +162,6 @@ void socket_init();
 void socket_final();
 
 // hostname/ip conversion functions
-uint32 host2ip(const char* hostname);
-
 const char* ip2str(uint32 ip, char ip_str[16]);
 
 uint32 str2ip(const char* ip_str);
@@ -170,12 +169,6 @@ uint32 str2ip(const char* ip_str);
 #define CONVIP(ip) ((ip)>>24)&0xFF,((ip)>>16)&0xFF,((ip)>>8)&0xFF,((ip)>>0)&0xFF
 
 uint16 ntows(uint16 netshort);
-
-int socket_getips(uint32* ips, int max);
-
-extern uint32 g_addr_[16];   // ip addresses of local host (host byte order)
-
-extern int32 naddr_;   // # of ip addresses
 
 /************************************************/
 /*

--- a/src/login/lobby.cpp
+++ b/src/login/lobby.cpp
@@ -92,8 +92,8 @@ int32 lobbydata_parse(int32 fd)
     if (RFIFOREST(fd) >= 1)
     {
         char* buff = &session[fd]->rdata[0];
-        if (ref<uint8>(buff, 0) == 0x0d) ShowDebug(CL_RED"Posible Crash Attempt from IP: " CL_WHITE"<%s>\n" CL_RESET, ip2str(session[fd]->client_addr, nullptr));
-        ShowDebug("lobbydata_parse:Incoming Packet:" CL_WHITE"<%x>" CL_RESET" from ip:<%s>\n", ref<uint8>(buff, 0), ip2str(sd->client_addr, nullptr));
+        if (ref<uint8>(buff, 0) == 0x0d) ShowDebug(CL_RED"Posible Crash Attempt from IP: " CL_WHITE"<%s>\n" CL_RESET, ip2str(session[fd]->client_addr));
+        ShowDebug("lobbydata_parse:Incoming Packet:" CL_WHITE"<%x>" CL_RESET" from ip:<%s>\n", ref<uint8>(buff, 0), ip2str(sd->client_addr));
 
         int32 code = ref<uint8>(buff, 0);
         switch (code)
@@ -102,7 +102,7 @@ int32 lobbydata_parse(int32 fd)
             {
                 if (RFIFOREST(fd) < 9)
                 {
-                    ShowError("lobbydata_parse:" CL_WHITE"<%s>" CL_RESET" sent less then 9 bytes\n", ip2str(session[fd]->client_addr, nullptr));
+                    ShowError("lobbydata_parse:" CL_WHITE"<%s>" CL_RESET" sent less then 9 bytes\n", ip2str(session[fd]->client_addr));
                     do_close_lobbydata(sd, fd);
                     return -1;
                 }
@@ -312,7 +312,7 @@ int32 lobbydata_parse(int32 fd)
                     ZonePort = (uint16)Sql_GetUIntData(SqlHandle, 1);
                     ref<uint32>(ReservePacket, (0x38)) = ZoneIP;
                     ref<uint16>(ReservePacket, (0x3C)) = ZonePort;
-                    ShowInfo("lobbydata_parse: zoneid:(%u),zoneip:(%s),zoneport:(%u) for char:(%u)\n", ZoneID, ip2str(ntohl(ZoneIP), nullptr), ZonePort, charid);
+                    ShowInfo("lobbydata_parse: zoneid:(%u),zoneip:(%s),zoneport:(%u) for char:(%u)\n", ZoneID, ip2str(ntohl(ZoneIP)), ZonePort, charid);
 
                     if (maint_config.maint_mode == 0 || gmlevel > 0)
                     {
@@ -395,7 +395,7 @@ int32 lobbydata_parse(int32 fd)
                     fmtQuery = "INSERT INTO account_ip_record(login_time,accid,charid,client_ip)\
                             VALUES ('%s', %u, %u, '%s');";
 
-                    if (Sql_Query(SqlHandle, fmtQuery, timeAndDate, sd->accid, charid, ip2str(sd->client_addr, nullptr)) == SQL_ERROR)
+                    if (Sql_Query(SqlHandle, fmtQuery, timeAndDate, sd->accid, charid, ip2str(sd->client_addr)) == SQL_ERROR)
                     {
                         ShowError("lobbyview_parse: Could not write info to account_ip_record.\n");
                     }
@@ -403,7 +403,7 @@ int32 lobbydata_parse(int32 fd)
 
                 do_close_tcp(sd->login_lobbyview_fd);
 
-                ShowStatus("lobbydata_parse: client %s finished work with " CL_GREEN"lobbyview" CL_RESET"\n", ip2str(sd->client_addr, nullptr));
+                ShowStatus("lobbydata_parse: client %s finished work with " CL_GREEN"lobbyview" CL_RESET"\n", ip2str(sd->client_addr));
                 break;
             }
             default:
@@ -430,7 +430,7 @@ int32 do_close_lobbydata(login_session_data_t *loginsd, int32 fd)
     }
     else
     {
-        ShowInfo("lobbydata_parse: " CL_WHITE"%s" CL_RESET" shutdown the socket\n", ip2str(session[fd]->client_addr, nullptr));
+        ShowInfo("lobbydata_parse: " CL_WHITE"%s" CL_RESET" shutdown the socket\n", ip2str(session[fd]->client_addr));
         do_close_tcp(fd);
         return 0;
     }
@@ -475,7 +475,7 @@ int32 lobbyview_parse(int32 fd)
     if (RFIFOREST(fd) >= 9)
     {
         char* buff = &session[fd]->rdata[0];
-        ShowDebug("lobbyview_parse:Incoming Packet:" CL_WHITE"<%x>" CL_RESET" from ip:<%s>\n", ref<uint8>(buff, 8), ip2str(sd->client_addr, nullptr));
+        ShowDebug("lobbyview_parse:Incoming Packet:" CL_WHITE"<%x>" CL_RESET" from ip:<%s>\n", ref<uint8>(buff, 8), ip2str(sd->client_addr));
         uint8 code = ref<uint8>(buff, 8);
         switch (code)
         {
@@ -566,7 +566,7 @@ int32 lobbyview_parse(int32 fd)
                 //delete char
                 uint32 CharID = ref<uint32>(session[fd]->rdata.data(), 0x20);
 
-                ShowInfo(CL_WHITE"lobbyview_parse" CL_RESET":attempt to delete char:<" CL_WHITE"%d" CL_RESET"> from ip:<%s>\n", CharID, ip2str(sd->client_addr, nullptr));
+                ShowInfo(CL_WHITE"lobbyview_parse" CL_RESET":attempt to delete char:<" CL_WHITE"%d" CL_RESET"> from ip:<%s>\n", CharID, ip2str(sd->client_addr));
 
                 uint8 sendsize = 0x20;
 

--- a/src/login/lobby.cpp
+++ b/src/login/lobby.cpp
@@ -308,7 +308,7 @@ int32 lobbydata_parse(int32 fd)
                     //new char only (first login from char create)
                     if (PrevZone == 0)  key3[16] += 6;
 
-                    ZoneIP = inet_addr((const char*)Sql_GetData(SqlHandle, 0));
+                    inet_pton(AF_INET, (const char*)Sql_GetData(SqlHandle, 0), &ZoneIP);
                     ZonePort = (uint16)Sql_GetUIntData(SqlHandle, 1);
                     ref<uint32>(ReservePacket, (0x38)) = ZoneIP;
                     ref<uint16>(ReservePacket, (0x3C)) = ZonePort;

--- a/src/login/login_auth.cpp
+++ b/src/login/login_auth.cpp
@@ -93,7 +93,7 @@ int32 login_parse(int32 fd)
         //data check
         if (check_string(name, 16) && check_string(password, 16))
         {
-            ShowWarning(CL_WHITE"login_parse" CL_RESET":" CL_WHITE"%s" CL_RESET" send unreadable data\n", ip2str(sd->client_addr, nullptr));
+            ShowWarning(CL_WHITE"login_parse" CL_RESET":" CL_WHITE"%s" CL_RESET" send unreadable data\n", ip2str(sd->client_addr));
             session[fd]->wdata.resize(1);
             ref<uint8>(session[fd]->wdata.data(), 0) = LOGIN_ERROR;
             do_close_login(sd, fd);
@@ -365,7 +365,7 @@ int32 login_parse(int32 fd)
         }
         break;
         default:
-            ShowWarning("login_parse: undefined code:[%d], ip sender:<%s>\n", code, ip2str(session[fd]->client_addr, nullptr));
+            ShowWarning("login_parse: undefined code:[%d], ip sender:<%s>\n", code, ip2str(session[fd]->client_addr));
             do_close_login(sd, fd);
             break;
         };
@@ -380,7 +380,7 @@ int32 login_parse(int32 fd)
 
 int32 do_close_login(login_session_data_t* loginsd, int32 fd)
 {
-    ShowInfo(CL_WHITE"login_parse" CL_RESET":" CL_WHITE"%s" CL_RESET"shutdown socket...\n", ip2str(loginsd->client_addr, nullptr));
+    ShowInfo(CL_WHITE"login_parse" CL_RESET":" CL_WHITE"%s" CL_RESET"shutdown socket...\n", ip2str(loginsd->client_addr));
     erase_loginsd(fd);
     do_close_tcp(fd);
     return 0;

--- a/src/login/login_session.cpp
+++ b/src/login/login_session.cpp
@@ -56,7 +56,7 @@ login_session_data_t *find_loginsd_byip(uint32 ip)
     }
 
     if (multiple_ip_count > 1) {
-        ShowInfo("Detected %i instances from %s. Returning best account match.\n", multiple_ip_count, ip2str(ip, nullptr));
+        ShowInfo("Detected %i instances from %s. Returning best account match.\n", multiple_ip_count, ip2str(ip));
     }
     ////////////////
     for (login_sd_list_t::iterator i = login_sd_list.begin();

--- a/src/login/message_server.cpp
+++ b/src/login/message_server.cpp
@@ -81,11 +81,13 @@ void message_server_parse(MSGSERVTYPE type, zmq::message_t* extra, zmq::message_
     in_addr from_ip;
     uint16 from_port = 0;
     bool ipstring = false;
+    char from_address[INET_ADDRSTRLEN];
 
     if (from)
     {
         from_ip.s_addr = ref<uint32>((uint8*)from->data(), 0);
         from_port = ref<uint16>((uint8*)from->data(), 4);
+        inet_ntop(AF_INET, &from_ip, from_address, INET_ADDRSTRLEN);
     }
     switch (type)
     {
@@ -158,14 +160,14 @@ void message_server_parse(MSGSERVTYPE type, zmq::message_t* extra, zmq::message_
         }
         default:
         {
-            ShowDebug("Message: unknown type received: %d from %s:%hu\n", type, inet_ntoa(from_ip), from_port);
+            ShowDebug("Message: unknown type received: %d from %s:%hu\n", static_cast<uint8>(type), from_address, from_port);
             break;
         }
     }
 
     if (ret != SQL_ERROR)
     {
-        ShowDebug("Message: Received message %d from %s:%hu\n", type, inet_ntoa(from_ip), from_port);
+        ShowDebug("Message: Received message %d from %s:%hu\n", static_cast<uint8>(type), from_address, from_port);
 
         while (Sql_NextRow(ChatSqlHandle) == SQL_SUCCESS)
         {
@@ -173,8 +175,7 @@ void message_server_parse(MSGSERVTYPE type, zmq::message_t* extra, zmq::message_
 
             if (ipstring)
             {
-                int8* ip_string = Sql_GetData(ChatSqlHandle, 0);
-                ip = inet_addr((const char*)ip_string);
+                inet_pton(AF_INET, (const char*)Sql_GetData(SqlHandle, 0), &ip);
             }
             else
             {
@@ -184,7 +185,10 @@ void message_server_parse(MSGSERVTYPE type, zmq::message_t* extra, zmq::message_
             uint64 port = Sql_GetUIntData(ChatSqlHandle, 1);
             in_addr target;
             target.s_addr = (unsigned long)ip;
-            ShowDebug("Message:  -> rerouting to %s:%lu\n", inet_ntoa(target), port);
+
+            char target_address[INET_ADDRSTRLEN];
+            inet_ntop(AF_INET, &target, target_address, INET_ADDRSTRLEN);
+            ShowDebug("Message:  -> rerouting to %s:%lu\n", target_address, port);
             ip |= (port << 32);
 
             if (type == MSG_CHAT_PARTY || type == MSG_PT_RELOAD || type == MSG_PT_DISBAND)

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -150,7 +150,11 @@ int32 do_init(int32 argc, char** argv)
     for (int i = 1; i < argc; i++)
     {
         if (strcmp(argv[i], "--ip") == 0)
-            map_ip.s_addr = inet_addr(argv[i + 1]);
+        {
+            uint32 ip;
+            inet_pton(AF_INET, argv[i + 2], &ip);
+            map_ip.s_addr = ip;
+        }
         else if (strcmp(argv[i], "--port") == 0)
             map_port = std::stoi(argv[i + 1]);
     }

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -125,12 +125,12 @@ map_session_data_t* mapsession_createsession(uint32 ip, uint16 port)
 
     const char* fmtQuery = "SELECT charid FROM accounts_sessions WHERE inet_ntoa(client_addr) = '%s' LIMIT 1;";
 
-    int32 ret = Sql_Query(SqlHandle, fmtQuery, ip2str(map_session_data->client_addr, nullptr));
+    int32 ret = Sql_Query(SqlHandle, fmtQuery, ip2str(map_session_data->client_addr));
 
     if (ret == SQL_ERROR ||
         Sql_NumRows(SqlHandle) == 0)
     {
-        ShowError(CL_RED"recv_parse: Invalid login attempt from %s\n" CL_RESET, ip2str(map_session_data->client_addr, nullptr));
+        ShowError(CL_RED"recv_parse: Invalid login attempt from %s\n" CL_RESET, ip2str(map_session_data->client_addr));
         return nullptr;
     }
     return map_session_data;
@@ -440,8 +440,7 @@ int32 map_decipher_packet(int8* buff, size_t size, sockaddr_in* from, map_sessio
         return 0;
     }
 
-    int8 ip_str[16];
-    ShowError("map_encipher_packet: bad packet from <%s>\n", ip2str(ip, (char*)ip_str));
+    ShowError("map_encipher_packet: bad packet from <%s>\n", ip2str(ip));
     return -1;
 }
 
@@ -463,7 +462,7 @@ int32 recv_parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_da
     }
     catch (...)
     {
-        ShowError(CL_RED"Possible crash attempt from: %s\n" CL_RESET, ip2str(map_session_data->client_addr, nullptr));
+        ShowError(CL_RED"Possible crash attempt from: %s\n" CL_RESET, ip2str(map_session_data->client_addr));
         return -1;
     }
 #else

--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -70,7 +70,7 @@ namespace message
 
     void parse(MSGSERVTYPE type, zmq::message_t* extra, zmq::message_t* packet)
     {
-        ShowDebug("Message: Received message %d from message server\n", type);
+        ShowDebug("Message: Received message %d from message server\n", static_cast<uint8>(type));
         switch (type)
         {
         case MSG_LOGIN:

--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -608,7 +608,7 @@ namespace message
             int ret = Sql_Query(SqlHandle, "SELECT zoneip, zoneport FROM zone_settings GROUP BY zoneip, zoneport ORDER BY COUNT(*) DESC;");
             if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) > 0 && Sql_NextRow(SqlHandle) == SQL_SUCCESS)
             {
-                ipp = inet_addr((const char*)Sql_GetData(SqlHandle, 0));
+                inet_pton(AF_INET, (const char*)Sql_GetData(SqlHandle, 0), &ipp);
                 port = Sql_GetUIntData(SqlHandle, 1);
             }
         }

--- a/src/map/transport.cpp
+++ b/src/map/transport.cpp
@@ -121,7 +121,9 @@ void CTransportHandler::InitializeTransport()
                             zone_settings ON ((transport >> 12) & 0xFFF) = zoneid WHERE \
                             IF(%d <> 0, '%s' = zoneip AND %d = zoneport, TRUE);";
 
-    int32 ret = Sql_Query(SqlHandle, fmtQuery, map_ip.s_addr, inet_ntoa(map_ip), map_port);
+    char address[INET_ADDRSTRLEN];
+    inet_ntop(AF_INET, &map_ip, address, INET_ADDRSTRLEN);
+    int32 ret = Sql_Query(SqlHandle, fmtQuery, map_ip.s_addr, address, map_port);
 
     if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0)
     {
@@ -181,7 +183,7 @@ void CTransportHandler::InitializeTransport()
                 zone_settings ON zone = zoneid WHERE \
                 IF(%d <> 0, '%s' = zoneip AND %d = zoneport, TRUE)";
 
-    ret = Sql_Query(SqlHandle, fmtQuery, map_ip.s_addr, inet_ntoa(map_ip), map_port);
+    ret = Sql_Query(SqlHandle, fmtQuery, map_ip.s_addr, address, map_port);
 
     if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0)
     {

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -268,7 +268,9 @@ void LoadNPCList()
         ON (npcid & 0xFFF000) >> 12 = zone_settings.zoneid \
         WHERE IF(%d <> 0, '%s' = zoneip AND %d = zoneport, TRUE);";
 
-    int32 ret = Sql_Query(SqlHandle, Query, map_ip.s_addr, inet_ntoa(map_ip), map_port);
+    char address[INET_ADDRSTRLEN];
+    inet_ntop(AF_INET, &map_ip, address, INET_ADDRSTRLEN);
+    int32 ret = Sql_Query(SqlHandle, Query, map_ip.s_addr, address, map_port);
 
     if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0)
     {
@@ -360,7 +362,9 @@ void LoadMOBList()
             WHERE NOT (pos_x = 0 AND pos_y = 0 AND pos_z = 0) AND IF(%d <> 0, '%s' = zoneip AND %d = zoneport, TRUE) \
             AND mob_groups.zoneid = ((mobid >> 12) & 0xFFF);";
 
-    int32 ret = Sql_Query(SqlHandle, Query, map_ip.s_addr, inet_ntoa(map_ip), map_port);
+    char address[INET_ADDRSTRLEN];
+    inet_ntop(AF_INET, &map_ip, address, INET_ADDRSTRLEN);
+    int32 ret = Sql_Query(SqlHandle, Query, map_ip.s_addr, address, map_port);
 
     if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0)
     {
@@ -543,7 +547,7 @@ void LoadMOBList()
         WHERE IF(%d <> 0, '%s' = zoneip AND %d = zoneport, TRUE) \
         AND mob_groups.zoneid = ((mobid >> 12) & 0xFFF);";
 
-    ret = Sql_Query(SqlHandle, PetQuery, map_ip.s_addr, inet_ntoa(map_ip), map_port);
+    ret = Sql_Query(SqlHandle, PetQuery, map_ip.s_addr, address, map_port);
 
     if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0)
     {
@@ -627,7 +631,9 @@ void LoadZoneList()
     std::vector<uint16> zones;
     const char* query = "SELECT zoneid FROM zone_settings WHERE IF(%d <> 0, '%s' = zoneip AND %d = zoneport, TRUE);";
 
-    int ret = Sql_Query(SqlHandle, query, map_ip.s_addr, inet_ntoa(map_ip), map_port);
+    char address[INET_ADDRSTRLEN];
+    inet_ntop(AF_INET, &map_ip, address, INET_ADDRSTRLEN);
+    int ret = Sql_Query(SqlHandle, query, map_ip.s_addr, address, map_port);
 
     if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0)
     {
@@ -1036,7 +1042,7 @@ uint64 GetZoneIPP(uint16 zoneID)
 
     if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0 && Sql_NextRow(SqlHandle) == SQL_SUCCESS)
     {
-        ipp = inet_addr((const char*)Sql_GetData(SqlHandle, 0));
+        inet_pton(AF_INET, (const char*)Sql_GetData(SqlHandle, 0), &ipp);
         uint64 port = Sql_GetUIntData(SqlHandle, 1);
         ipp |= (port << 32);
     }

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -357,7 +357,7 @@ void CZone::LoadZoneSettings()
     {
         m_zoneName.insert(0, (const char*)Sql_GetData(SqlHandle, 0));
 
-        m_zoneIP = inet_addr((const char*)Sql_GetData(SqlHandle, 1));
+        inet_pton(AF_INET, (const char*)Sql_GetData(SqlHandle, 1), &m_zoneIP);
         m_zonePort = (uint16)Sql_GetUIntData(SqlHandle, 2);
         m_zoneMusic.m_songDay = (uint8)Sql_GetUIntData(SqlHandle, 3);   // background music (day)
         m_zoneMusic.m_songNight = (uint8)Sql_GetUIntData(SqlHandle, 4);   // background music (night)

--- a/win32/vcxproj/topaz_connect.vcxproj
+++ b/win32/vcxproj/topaz_connect.vcxproj
@@ -144,7 +144,7 @@
       <PrecompiledHeader>
       </PrecompiledHeader>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;NOMINMAX;FMT_HEADER_ONLY;FMT_USE_WINDOWS_H=0;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;DEBUGLOGLOGIN;_WINSOCK_DEPRECATED_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NOMINMAX;FMT_HEADER_ONLY;FMT_USE_WINDOWS_H=0;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;DEBUGLOGLOGIN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)..\external;$(ProjectDir)..\external\mysql;$(ProjectDir)..\external\zmq;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -160,7 +160,7 @@
       <PrecompiledHeader>
       </PrecompiledHeader>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;NOMINMAX;FMT_HEADER_ONLY;FMT_USE_WINDOWS_H=0;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;DEBUGLOGLOGIN;_WINSOCK_DEPRECATED_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NOMINMAX;FMT_HEADER_ONLY;FMT_USE_WINDOWS_H=0;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;DEBUGLOGLOGIN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)..\external;$(ProjectDir)..\external\mysql;$(ProjectDir)..\external\zmq;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -201,7 +201,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NOMINMAX;FMT_HEADER_ONLY;FMT_USE_WINDOWS_H=0;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;_CONSOLE;DEBUGLOGLOGIN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NOMINMAX;FMT_HEADER_ONLY;FMT_USE_WINDOWS_H=0;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;NDEBUG;_CONSOLE;DEBUGLOGLOGIN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)..\external;$(ProjectDir)..\external\mysql;$(ProjectDir)..\external\zmq;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>

--- a/win32/vcxproj/topaz_connect.vcxproj
+++ b/win32/vcxproj/topaz_connect.vcxproj
@@ -144,7 +144,7 @@
       <PrecompiledHeader>
       </PrecompiledHeader>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;NOMINMAX;FMT_HEADER_ONLY;FMT_USE_WINDOWS_H=0;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;DEBUGLOGLOGIN;_WINSOCK_DEPRECATED_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NOMINMAX;FMT_HEADER_ONLY;FMT_USE_WINDOWS_H=0;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;DEBUGLOGLOGIN;_WINSOCK_DEPRECATED_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)..\external;$(ProjectDir)..\external\mysql;$(ProjectDir)..\external\zmq;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -180,7 +180,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NOMINMAX;FMT_HEADER_ONLY;FMT_USE_WINDOWS_H=0;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;_CONSOLE;DEBUGLOGLOGIN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NOMINMAX;FMT_HEADER_ONLY;FMT_USE_WINDOWS_H=0;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;NDEBUG;_CONSOLE;DEBUGLOGLOGIN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)..\external;$(ProjectDir)..\external\mysql;$(ProjectDir)..\external\zmq;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>

--- a/win32/vcxproj/topaz_game.vcxproj
+++ b/win32/vcxproj/topaz_game.vcxproj
@@ -96,7 +96,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(ProjectDir)..\external;$(ProjectDir)..\external\mysql;$(ProjectDir)..\external\zmq;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;NOMINMAX;FMT_HEADER_ONLY;FMT_USE_WINDOWS_H=0;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;_DEBUG;_CONSOLE;DEBUGLOGMAP;_CRT_SECURE_NO_WARNINGS;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NOMINMAX;FMT_HEADER_ONLY;FMT_USE_WINDOWS_H=0;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_DEBUG;_CONSOLE;DEBUGLOGMAP;_CRT_SECURE_NO_WARNINGS;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -120,7 +120,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(ProjectDir)..\external;$(ProjectDir)..\external\mysql;$(ProjectDir)..\external\zmq;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;NOMINMAX;FMT_HEADER_ONLY;FMT_USE_WINDOWS_H=0;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;_DEBUG;_CONSOLE;DEBUGLOGMAP;_CRT_SECURE_NO_WARNINGS;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NOMINMAX;FMT_HEADER_ONLY;FMT_USE_WINDOWS_H=0;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_DEBUG;_CONSOLE;DEBUGLOGMAP;_CRT_SECURE_NO_WARNINGS;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <PrecompiledHeader>
@@ -141,7 +141,7 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NOMINMAX;FMT_HEADER_ONLY;FMT_USE_WINDOWS_H=0;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;DEBUGLOGMAP;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NOMINMAX;FMT_HEADER_ONLY;FMT_USE_WINDOWS_H=0;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;DEBUGLOGMAP;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
@@ -173,7 +173,7 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NOMINMAX;FMT_HEADER_ONLY;FMT_USE_WINDOWS_H=0;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;DEBUGLOGMAP;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NOMINMAX;FMT_HEADER_ONLY;FMT_USE_WINDOWS_H=0;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;DEBUGLOGMAP;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>


### PR DESCRIPTION
- Removing _WINSOCK_DEPRECATED_NO_WARNINGS (connect/game)
- Remove unused functions host2ip, socket_getips
- Fixing log statements using MSGSERVTYPE and not casting to uint
- cmake updated

Tested on win/nix

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [X] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [X] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

