### PR TITLE
Fix Shen crash on pop

### DIFF
--- a/scripts/zones/Bibiki_Bay/npcs/qm1.lua
+++ b/scripts/zones/Bibiki_Bay/npcs/qm1.lua
@@ -12,7 +12,7 @@ function onTrade(player,npc,trade)
         SpawnMob(ID.mob.SHEN):updateClaim(player);
         for i = 1, 2 do
             if (not GetMobByID(ID.mob.SHEN+i):isSpawned()) then
-                SpawnMob(ID.mob.SHEN+i):updateEnmity(target);
+                SpawnMob(ID.mob.SHEN+i):updateEnmity(player);
             end
         end
     end


### PR DESCRIPTION
Fixes `updateEnmity` call on wrong target. Mob logic wasn't touched.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

