### PR TITLE
Implement Rampart as -25% SDT rather than 100% magic shield

### DIFF
--- a/scripts/globals/abilities/rampart.lua
+++ b/scripts/globals/abilities/rampart.lua
@@ -1,6 +1,8 @@
 -----------------------------------
 -- Ability: Rampart
--- Grants a Magic Shield effect and enhances defense for party members within area of effect.
+-- Grants all party members within the area of effect -25% SDT.
+-- SDT is multiplicative with regular Damage Taken; many forms of SDT are for a single type or element of damage
+-- However, Rampart's SDT is for all damage types.
 -- Obtained: Paladin Level 62
 -- Recast Time: 5:00
 -- Duration: 0:30
@@ -15,5 +17,5 @@ end
 
 function onUseAbility(player,target,ability)
     local duration = 30 + player:getMod(tpz.mod.RAMPART_DURATION)
-    target:addStatusEffect(tpz.effect.MAGIC_SHIELD, 1, 0, duration)
+    target:addStatusEffect(tpz.effect.RAMPART, 25, 0, duration)
 end

--- a/scripts/globals/effects/rampart.lua
+++ b/scripts/globals/effects/rampart.lua
@@ -1,0 +1,22 @@
+-----------------------------------
+--     tpz.effect.RAMPART
+-----------------------------------
+
+function onEffectGain(target,effect)
+    local power = -1 * effect:getPower()
+    target:addMod(tpz.mod.UDMGPHYS, power)
+    target:addMod(tpz.mod.UDMGBREATH, power)
+    target:addMod(tpz.mod.UDMGMAGIC, power)
+    target:addMod(tpz.mod.UDMGRANGE, power)
+end
+
+function onEffectTick(target,effect)
+end
+
+function onEffectLose(target,effect)
+    local power = -1 * effect:getPower()
+    target:delMod(tpz.mod.UDMGPHYS, power)
+    target:delMod(tpz.mod.UDMGBREATH, power)
+    target:delMod(tpz.mod.UDMGMAGIC, power)
+    target:delMod(tpz.mod.UDMGRANGE, power)
+end

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -771,6 +771,7 @@ tpz.effect =
     NEGATE_CURSE             = 609,
     NEGATE_CHARM             = 610,
     MAGIC_EVASION_BOOST_II   = 611,
+    RAMPART                  = 623,
     -- Effect icons in packet can go from 0-767, so no custom effects should go in that range.
 
     -- Purchased from Cruor Prospector

--- a/sql/status_effects.sql
+++ b/sql/status_effects.sql
@@ -637,6 +637,7 @@ INSERT INTO `status_effects` VALUES (609,'negate_curse',289,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (610,'negate_charm',289,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (611,'magic_evasion_boost_ii',32,0,0,0,0,0,0,0);
 
+INSERT INTO `status_effects` VALUES (623,'rampart',5243168,0,0,0,0,0,0,0);
 
 INSERT INTO `status_effects` VALUES (768,'abyssea_str',256,0,0,0,0,0,1,0);
 INSERT INTO `status_effects` VALUES (769,'abyssea_dex',256,0,0,0,0,0,6,0);

--- a/src/map/status_effect.h
+++ b/src/map/status_effect.h
@@ -674,6 +674,7 @@ enum EFFECT
     EFFECT_NEGATE_CURSE             = 609,
     EFFECT_NEGATE_CHARM             = 610,
     EFFECT_MAGIC_EVASION_BOOST_II   = 611,
+    EFFECT_RAMPART                  = 623,
 
     // Effect icons in packet can go from 0-767, so no custom effects should go in that range.
 


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Rampart's effect was changed in Feb. version update to be a -25% SDT that's multiplicative with DT.
https://forum.square-enix.com/ffxi/threads/56444-February-12-2020-%28JST%29-Version-Update
https://www.ffxiah.com/forum/topic/46016/first-and-final-line-of-defense-v20/72/#3487802