### PR TITLE
Trust Engage Condition Fix

### DIFF
--- a/src/map/ai/controllers/player_controller.cpp
+++ b/src/map/ai/controllers/player_controller.cpp
@@ -206,6 +206,11 @@ bool CPlayerController::WeaponSkill(uint16 targid, uint16 wsid)
     return false;
 }
 
+time_point CPlayerController::getLastAttackTime()
+{
+    return m_LastAttackTime;
+}
+
 void CPlayerController::setLastAttackTime(time_point _LastAttackTime)
 {
     m_LastAttackTime = _LastAttackTime;

--- a/src/map/ai/controllers/player_controller.h
+++ b/src/map/ai/controllers/player_controller.h
@@ -44,6 +44,7 @@ public:
     virtual bool RangedAttack(uint16 targid);
     virtual bool UseItem(uint16 targid, uint8 loc, uint8 slotid);
 
+    time_point getLastAttackTime();
     void setLastAttackTime(time_point);
     void setLastErrMsgTime(time_point);
     time_point getLastErrMsgTime();

--- a/src/map/ai/controllers/trust_controller.cpp
+++ b/src/map/ai/controllers/trust_controller.cpp
@@ -154,7 +154,7 @@ void CTrustController::DoRoamTick(time_point tick)
     auto PMaster = static_cast<CCharEntity*>(POwner->PMaster);
     auto masterLastAttackTime = static_cast<CPlayerController*>(PMaster->PAI->GetController())->getLastAttackTime();
     bool masterMeleeSwing = masterLastAttackTime > server_clock::now() - 1s;
-    bool trustEngageCondition = (PMaster->GetBattleTarget() && masterMeleeSwing);
+    bool trustEngageCondition = PMaster->GetBattleTarget() && masterMeleeSwing;
 
     if (PMaster->PAI->IsEngaged() && trustEngageCondition)
     {

--- a/src/map/ai/controllers/trust_controller.cpp
+++ b/src/map/ai/controllers/trust_controller.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 */
 
 #include "trust_controller.h"
+#include "player_controller.h"
 
 #include "../../ability.h"
 #include "../ai_container.h"
@@ -151,7 +152,9 @@ void CTrustController::DoCombatTick(time_point tick)
 void CTrustController::DoRoamTick(time_point tick)
 {
     auto PMaster = static_cast<CCharEntity*>(POwner->PMaster);
-    bool trustEngageCondition = (PMaster->GetBattleTarget() && PMaster->GetBattleTarget()->PLastAttacker == PMaster);
+    auto masterLastAttackTime = static_cast<CPlayerController*>(PMaster->PAI->GetController())->getLastAttackTime();
+    bool masterMeleeSwing = masterLastAttackTime > server_clock::now() - 1s;
+    bool trustEngageCondition = (PMaster->GetBattleTarget() && masterMeleeSwing);
 
     if (PMaster->PAI->IsEngaged() && trustEngageCondition)
     {


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

`m_LastAttackTime` is pretty much the only thing that's set in Char's `OnAttack`, so I've hijacked that. It has the added benefit of not relying on a pointer to any enemy, which may or may not disappear at any given moment.

Tested as a Lv10 WHM in Kuftal tunnel, failing to hit crabs and trusts trying to save me 👍 