### PR TITLE
Allow Exit from Escha - Zi'Tah

### DIFF
--- a/scripts/zones/Escha_ZiTah/npcs/Undulating_Confluence.lua
+++ b/scripts/zones/Escha_ZiTah/npcs/Undulating_Confluence.lua
@@ -1,0 +1,23 @@
+-----------------------------------
+-- Area: Escha - Zi'Tah Island (288)
+--  NPC: Undulating Confluence
+-- !pos --344.275 1.659 -182.613 288
+-----------------------------------
+local ID = require("scripts/zones/Escha_ZiTah/IDs")
+-----------------------------------
+
+function onTrade(player, npc, trade)
+end
+
+function onTrigger(player, npc)
+    player:startEvent(4)
+end
+
+function onEventUpdate(player, csid, option)
+end
+
+function onEventFinish(player, csid, option)
+    if csid == 4 and option == 1 then
+        player:setPos(-203, -20, 81, 76, 126)
+    end
+end

--- a/scripts/zones/Qufim_Island/npcs/Undulating_Confluence.lua
+++ b/scripts/zones/Qufim_Island/npcs/Undulating_Confluence.lua
@@ -31,8 +31,8 @@ function onEventFinish(player, csid, option)
         player:completeMission(ROV, tpz.mission.id.rov.AT_THE_HEAVENS_DOOR)
         player:addMission(ROV, tpz.mission.id.rov.THE_LIONS_ROAR)
     elseif csid == 64 then
-        player:setPos(0, 0, 0, 0, 288)
+        player:setPos(-338, 6, -225, 172, 288)
     elseif csid == 65 and option == 1 then
-        player:setPos(0, 0, 0, 0, 288)
+        player:setPos(-338, 6, -225, 172, 288)
     end
 end


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Addresses #696 

Scripted Undulating Confluence inside Escha Zi'Tah to allow for players to exit while completing ROV 1-10.

Corrected POS on zone in from Qufim Island as well.