### PR TITLE
Remove on_zone flag from Dynamis effect

### DIFF
--- a/scripts/globals/effects/dynamis.lua
+++ b/scripts/globals/effects/dynamis.lua
@@ -17,35 +17,39 @@ end
 -----------------------------------
 
 function onEffectTick(target,effect)
-    local lastTimeUpdate = target:getLocalVar("dynamis_lasttimeupdate")
-    local remainingTimeLimit = effect:getTimeRemaining() / 1000
-    local message = 0
+    if target:getCurrentRegion() == tpz.region.DYNAMIS then
+        local lastTimeUpdate = target:getLocalVar("dynamis_lasttimeupdate")
+        local remainingTimeLimit = effect:getTimeRemaining() / 1000
+        local message = 0
 
-    if lastTimeUpdate > 600 and remainingTimeLimit < 600 then
-        message = 600
-    elseif lastTimeUpdate > 300 and remainingTimeLimit < 300 then
-        message = 300
-    elseif lastTimeUpdate > 60 and remainingTimeLimit < 60 then
-        message = 60
-    elseif lastTimeUpdate > 30 and remainingTimeLimit < 30 then
-        message = 30
-    elseif lastTimeUpdate > 10 and remainingTimeLimit < 10 then
-        message = 10
-    end
+        if lastTimeUpdate > 600 and remainingTimeLimit < 600 then
+            message = 600
+        elseif lastTimeUpdate > 300 and remainingTimeLimit < 300 then
+            message = 300
+        elseif lastTimeUpdate > 60 and remainingTimeLimit < 60 then
+            message = 60
+        elseif lastTimeUpdate > 30 and remainingTimeLimit < 30 then
+            message = 30
+        elseif lastTimeUpdate > 10 and remainingTimeLimit < 10 then
+            message = 10
+        end
 
-    if message ~= 0 then
-        local time = message
-        local minutes = 0
-        if time >= 60 then
-            minutes = 1
-            time = time / 60
+        if message ~= 0 then
+            local time = message
+            local minutes = 0
+            if time >= 60 then
+                minutes = 1
+                time = time / 60
+            end
+            if time == 1 then
+                target:messageSpecial(zones[target:getZoneID()].text.DYNAMIS_TIME_UPDATE_1, time, minutes)
+            else
+                target:messageSpecial(zones[target:getZoneID()].text.DYNAMIS_TIME_UPDATE_2, time, minutes)
+            end
+            target:setLocalVar("dynamis_lasttimeupdate", message)
         end
-        if time == 1 then
-            target:messageSpecial(zones[target:getZoneID()].text.DYNAMIS_TIME_UPDATE_1, time, minutes)
-        else
-            target:messageSpecial(zones[target:getZoneID()].text.DYNAMIS_TIME_UPDATE_2, time, minutes)
-        end
-        target:setLocalVar("dynamis_lasttimeupdate", message)
+    else
+        target:delStatusEffectSilent(tpz.effect.DYNAMIS)
     end
 end
 
@@ -59,10 +63,12 @@ function onEffectLose(target,effect)
     target:delKeyItem(tpz.ki.AMBER_GRANULES_OF_TIME)
     target:delKeyItem(tpz.ki.ALABASTER_GRANULES_OF_TIME)
     target:delKeyItem(tpz.ki.OBSIDIAN_GRANULES_OF_TIME)
-    if effect:getTimeRemaining() == 0 then
-        target:messageSpecial(zones[target:getZoneID()].text.DYNAMIS_TIME_EXPIRED)
-        target:disengage()
-        target:startEvent(100)
+    if target:getCurrentRegion() == tpz.region.DYNAMIS then
+        if effect:getTimeRemaining() == 0 then
+            target:messageSpecial(zones[target:getZoneID()].text.DYNAMIS_TIME_EXPIRED)
+            target:disengage()
+            target:startEvent(100)
+        end
     end
 end
 

--- a/scripts/globals/effects/sj_restriction.lua
+++ b/scripts/globals/effects/sj_restriction.lua
@@ -15,11 +15,5 @@ function onEffectTick(target,effect)
 end
 
 function onEffectLose(target,effect)
-    local power = effect:getPower()
-    -- fix crash on logout / login
-    if (power > tpz.MAX_JOB_TYPE or power < 0) then
-        power = 0
-    end
-
-    target:sjRestriction(power,false)
+    target:recalculateStats()
 end

--- a/sql/status_effects.sql
+++ b/sql/status_effects.sql
@@ -669,7 +669,7 @@ INSERT INTO `status_effects` VALUES (796,'haste_samba_haste_effect',320,0,0,0,0,
 INSERT INTO `status_effects` VALUES (797,'teleport',32,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (798,'chainbound',32,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (799,'skillchain',32,0,0,0,0,0,0,0);
-INSERT INTO `status_effects` VALUES (800,'dynamis',33554688,0,0,0,0,0,0,0);
+INSERT INTO `status_effects` VALUES (800,'dynamis',33554432,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (801,'meditate',32,0,0,0,0,0,7,0);
 INSERT INTO `status_effects` VALUES (802,'elemental_resistance_down',8389408,0,0,0,0,0,0,0);
 /*!40000 ALTER TABLE `status_effects` ENABLE KEYS */;


### PR DESCRIPTION
Update effect to clear if player leaves the zone, but not on tractor.
Also replace bad function call in sj_restriction. Fixes #695

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

