### PR TITLE
IP/Subnet mask in socket was calculated incorrectly

### DIFF
--- a/src/common/socket.cpp
+++ b/src/common/socket.cpp
@@ -632,12 +632,14 @@ int access_ipmask(const char* str, AccessControl* acc)
 				mask = (mask >> 1) | 0x80000000;
 				--m[0];
 			}
-			mask = ntohl(mask);
 		} else
 		{// just this ip
 			mask = 0xFFFFFFFF;
 		}
 	}
+
+    ip = ntohl(ip);
+
 	if( access_debug ){
 		ShowInfo("access_ipmask: Loaded IP:%d.%d.%d.%d mask:%d.%d.%d.%d\n", CONVIP(ip), CONVIP(mask));
 	}


### PR DESCRIPTION
- Fixes #686
- ntohl changes from network byte order to host byte order
- Mask was swapped, IP was not swapped

Test on win/nix, but not for every mask combination

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

