### PR TITLE
Gobbiebag uses tpz.inv and does the correct bags

### DIFF
--- a/scripts/zones/Lower_Jeuno/npcs/Bluffnix.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Bluffnix.lua
@@ -95,9 +95,8 @@ function onEventFinish(player,csid,option)
             player:addTitle(tpz.title.GRAND_GREEDALOX);
         end
 
-        player:changeContainerSize(0,5);
-        player:changeContainerSize(5,5);
-        player:changeContainerSize(6,5);
+        player:changeContainerSize(tpz.inv.INVENTORY,5);
+        player:changeContainerSize(tpz.inv.MOGSATCHEL,5);
         player:addFame(JEUNO, 30);
         player:tradeComplete();
         player:completeQuest(JEUNO,TheGobbieBag[1]);


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [X] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [X] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

