### PR TITLE
Fix unable to continue RoV questline

### DIFF
--- a/scripts/zones/Konschtat_Highlands/npcs/Shattered_Telepoint.lua
+++ b/scripts/zones/Konschtat_Highlands/npcs/Shattered_Telepoint.lua
@@ -13,7 +13,14 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-    if player:getCurrentMission(COP) == tpz.mission.id.cop.BELOW_THE_ARKS and player:getCharVar("PromathiaStatus") == 1 then
+    -- RoV Missions
+    if player:getCurrentMission(ROV) == tpz.mission.id.rov.THE_PATH_UNTRAVELED and player:getRank() >= 3 then
+        player:startEvent(3)
+    elseif player:getCurrentMission(ROV) == tpz.mission.id.rov.A_LAND_AFTER_TIME then
+        player:startEvent(4)
+
+    -- CoP Missions
+    elseif player:getCurrentMission(COP) == tpz.mission.id.cop.BELOW_THE_ARKS and player:getCharVar("PromathiaStatus") == 1 then
         player:startEvent(913, 0, 0, 1) -- first time in promy -> have you made your preparations cs
     elseif
         player:getCurrentMission(COP) == tpz.mission.id.cop.THE_MOTHERCRYSTALS and
@@ -30,30 +37,19 @@ function onTrigger(player, npc)
         (player:getCurrentMission(COP) == tpz.mission.id.cop.BELOW_THE_ARKS and player:getCharVar("PromathiaStatus") > 1)
     then
         player:startEvent(913) -- normal cs (third promyvion and each entrance after having that promyvion visited or mission completed)
-    elseif
-        player:getCurrentMission(ROV) == tpz.mission.id.rov.THE_PATH_UNTRAVELED and
-        player:getRank() >= 3
-    then
-        player:startEvent(3)
-    elseif player:getCurrentMission(ROV) == tpz.mission.id.rov.A_LAND_AFTER_TIME then
-        player:startEvent(4)
+
+    -- Default Message
     else
         player:messageSpecial(ID.text.TELEPOINT_HAS_BEEN_SHATTERED)
     end
-
 end
 
 function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-    if csid == 912 then
-        player:setCharVar("cspromy2", 0)
-        player:setCharVar("cs2ndpromy", 1)
-        player:setPos(185.891, 0, -52.331, 128, 18) -- To Promyvion Dem
-    elseif csid == 913 and option == 0 then
-        player:setPos(-267.194, -40.634, -280.019, 0, 14) -- To Hall of Transference {R}
-    elseif csid == 3 then
+    -- RoV Missions
+    if csid == 3 then
         player:completeMission(ROV, tpz.mission.id.rov.THE_PATH_UNTRAVELED)
         player:addMission(ROV, tpz.mission.id.rov.AT_THE_HEAVENS_DOOR)
     elseif csid == 4 then
@@ -61,5 +57,13 @@ function onEventFinish(player, csid, option)
         player:addItem(10159) -- Cipher: Lion II
         player:completeMission(ROV, tpz.mission.id.rov.A_LAND_AFTER_TIME)
         player:addMission(ROV, tpz.mission.id.rov.FATES_CALL)
+
+    -- CoP Missions
+    elseif csid == 912 then
+        player:setCharVar("cspromy2", 0)
+        player:setCharVar("cs2ndpromy", 1)
+        player:setPos(185.891, 0, -52.331, 128, 18) -- To Promyvion Dem
+    elseif csid == 913 and option == 0 then
+        player:setPos(-267.194, -40.634, -280.019, 0, 14) -- To Hall of Transference {R}
     end
 end

--- a/scripts/zones/La_Theine_Plateau/npcs/Shattered_Telepoint.lua
+++ b/scripts/zones/La_Theine_Plateau/npcs/Shattered_Telepoint.lua
@@ -10,45 +10,40 @@ require("scripts/globals/npc_util")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-
-    if (player:getCurrentMission(COP) == tpz.mission.id.cop.BELOW_THE_ARKS and player:getCharVar("PromathiaStatus") == 1) then
-        player:startEvent(202,0,0,1); -- first time in promy -> have you made your preparations cs
-    elseif (player:getCurrentMission(COP) == tpz.mission.id.cop.THE_MOTHERCRYSTALS and (player:hasKeyItem(tpz.ki.LIGHT_OF_MEA) or player:hasKeyItem(tpz.ki.LIGHT_OF_DEM))) then
-        if (player:getCharVar("cspromy2") == 1) then
-            player:startEvent(201);  -- cs you get nearing second promyvion
-        else
-            player:startEvent(202)
-        end
-    elseif (player:getCurrentMission(COP) > tpz.mission.id.cop.THE_MOTHERCRYSTALS or player:hasCompletedMission(COP,tpz.mission.id.cop.THE_LAST_VERSE) or (player:getCurrentMission(COP) == tpz.mission.id.cop.BELOW_THE_ARKS and player:getCharVar("PromathiaStatus") > 1)) then
-        player:startEvent(202); -- normal cs (third promyvion and each entrance after having that promyvion visited or mission completed)
-    elseif
-        player:getCurrentMission(ROV) == tpz.mission.id.rov.THE_PATH_UNTRAVELED and
-        player:getRank() >= 3
-    then
+    -- RoV Missions
+    if player:getCurrentMission(ROV) == tpz.mission.id.rov.THE_PATH_UNTRAVELED and player:getRank() >= 3 then
         player:startEvent(14)
     elseif player:getCurrentMission(ROV) == tpz.mission.id.rov.A_LAND_AFTER_TIME then
         player:startEvent(15)
+
+    -- CoP Missions
+    elseif player:getCurrentMission(COP) == tpz.mission.id.cop.BELOW_THE_ARKS and player:getCharVar("PromathiaStatus") == 1 then
+        player:startEvent(202,0,0,1) -- first time in promy -> have you made your preparations cs
+    elseif player:getCurrentMission(COP) == tpz.mission.id.cop.THE_MOTHERCRYSTALS and (player:hasKeyItem(tpz.ki.LIGHT_OF_MEA) or player:hasKeyItem(tpz.ki.LIGHT_OF_DEM)) then
+        if player:getCharVar("cspromy2") == 1 then
+            player:startEvent(201)  -- cs you get nearing second promyvion
+        else
+            player:startEvent(202)
+        end
+    elseif player:getCurrentMission(COP) > tpz.mission.id.cop.THE_MOTHERCRYSTALS or player:hasCompletedMission(COP,tpz.mission.id.cop.THE_LAST_VERSE) or (player:getCurrentMission(COP) == tpz.mission.id.cop.BELOW_THE_ARKS and player:getCharVar("PromathiaStatus") > 1) then
+        player:startEvent(202) -- normal cs (third promyvion and each entrance after having that promyvion visited or mission completed)
+
+    -- Default Message
     else
-        player:messageSpecial(ID.text.TELEPOINT_HAS_BEEN_SHATTERED);
+        player:messageSpecial(ID.text.TELEPOINT_HAS_BEEN_SHATTERED)
     end
 
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-
-    if (csid == 201) then
-        player:setCharVar("cspromy2",0);
-        player:setCharVar("cs2ndpromy",1);
-        player:setPos(92.033, 0, 80.380, 255, 16); -- To Promyvion Holla
-    elseif (csid == 202 and option == 0) then
-        player:setPos(-266.76, -0.635, 280.058, 0, 14); -- To Hall of Transference {R}
-    elseif csid == 14 then
+    -- RoV Missions
+    if csid == 14 then
         player:completeMission(ROV, tpz.mission.id.rov.THE_PATH_UNTRAVELED)
         player:addMission(ROV, tpz.mission.id.rov.AT_THE_HEAVENS_DOOR)
     elseif csid == 15 then
@@ -56,6 +51,13 @@ function onEventFinish(player,csid,option)
         player:addItem(10159) -- Cipher: Lion II
         player:completeMission(ROV, tpz.mission.id.rov.A_LAND_AFTER_TIME)
         player:addMission(ROV, tpz.mission.id.rov.FATES_CALL)
-    end
 
-end;
+    -- CoP Missions
+    elseif csid == 201 then
+        player:setCharVar("cspromy2",0)
+        player:setCharVar("cs2ndpromy",1)
+        player:setPos(92.033, 0, 80.380, 255, 16) -- To Promyvion Holla
+    elseif csid == 202 and option == 0 then
+        player:setPos(-266.76, -0.635, 280.058, 0, 14) -- To Hall of Transference {R}
+    end
+end

--- a/scripts/zones/Tahrongi_Canyon/npcs/Shattered_Telepoint.lua
+++ b/scripts/zones/Tahrongi_Canyon/npcs/Shattered_Telepoint.lua
@@ -13,7 +13,14 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-    if player:getCurrentMission(COP) == tpz.mission.id.cop.BELOW_THE_ARKS and player:getCharVar("PromathiaStatus") == 1 then
+    -- RoV Missions
+    if  player:getCurrentMission(ROV) == tpz.mission.id.rov.THE_PATH_UNTRAVELED and player:getRank() >= 3 then
+        player:startEvent(41)
+    elseif player:getCurrentMission(ROV) == tpz.mission.id.rov.A_LAND_AFTER_TIME then
+        player:startEvent(42)
+
+    -- CoP Missions
+    elseif player:getCurrentMission(COP) == tpz.mission.id.cop.BELOW_THE_ARKS and player:getCharVar("PromathiaStatus") == 1 then
         player:startEvent(913, 0, 0, 1) -- first time in promy -> have you made your preparations cs
     elseif player:getCurrentMission(COP) == tpz.mission.id.cop.THE_MOTHERCRYSTALS and (player:hasKeyItem(tpz.ki.LIGHT_OF_HOLLA) or player:hasKeyItem(tpz.ki.LIGHT_OF_DEM)) then
         if player:getCharVar("cspromy2") == 1 then
@@ -23,13 +30,8 @@ function onTrigger(player, npc)
         end
     elseif player:getCurrentMission(COP) > tpz.mission.id.cop.THE_MOTHERCRYSTALS or player:hasCompletedMission(COP, tpz.mission.id.cop.THE_LAST_VERSE) or (player:getCurrentMission(COP) == tpz.mission.id.cop.BELOW_THE_ARKS and player:getCharVar("PromathiaStatus") > 1) then
         player:startEvent(913) -- normal cs (third promyvion and each entrance after having that promyvion visited or mission completed)
-    elseif
-        player:getCurrentMission(ROV) == tpz.mission.id.rov.THE_PATH_UNTRAVELED and
-        player:getRank() >= 3
-    then
-        player:startEvent(41)
-    elseif player:getCurrentMission(ROV) == tpz.mission.id.rov.A_LAND_AFTER_TIME then
-        player:startEvent(42)
+
+    -- Default Message
     else
         player:messageSpecial(ID.text.TELEPOINT_HAS_BEEN_SHATTERED)
     end
@@ -40,13 +42,8 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-    if csid == 912 then
-        player:setCharVar("cspromy2", 0)
-        player:setCharVar("cs2ndpromy", 1)
-        player:setPos(-93.268, 0, 170.749, 162, 20) -- To Promyvion Mea
-    elseif csid == 913 and option == 0 then
-        player:setPos(280.066, -80.635, -67.096, 191, 14) -- To Hall of Transference {R}
-    elseif csid == 41 then
+    -- RoV Missions
+    if csid == 41 then
         player:completeMission(ROV, tpz.mission.id.rov.THE_PATH_UNTRAVELED)
         player:addMission(ROV, tpz.mission.id.rov.AT_THE_HEAVENS_DOOR)
     elseif csid == 42 then
@@ -54,5 +51,13 @@ function onEventFinish(player, csid, option)
         player:addItem(10159) -- Cipher: Lion II
         player:completeMission(ROV, tpz.mission.id.rov.A_LAND_AFTER_TIME)
         player:addMission(ROV, tpz.mission.id.rov.FATES_CALL)
+
+    -- CoP Missions
+    elseif csid == 912 then
+        player:setCharVar("cspromy2", 0)
+        player:setCharVar("cs2ndpromy", 1)
+        player:setPos(-93.268, 0, 170.749, 162, 20) -- To Promyvion Mea
+    elseif csid == 913 and option == 0 then
+        player:setPos(280.066, -80.635, -67.096, 191, 14) -- To Hall of Transference {R}
     end
 end


### PR DESCRIPTION
Change RoV to take precedence over CoP missions
Removed not needed ";", "(", and ")"
Added Comments for easy understanding
Moved also OnEventFinish to match the same order as onTrigger

Thank you Cyrianna(Canaria Server) @ibm2431  and @ffxijuggalo 

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

