### PR TITLE
Linkshell fixes

### DIFF
--- a/src/map/linkshell.cpp
+++ b/src/map/linkshell.cpp
@@ -29,6 +29,7 @@
 #include "packets/inventory_finish.h"
 #include "packets/inventory_item.h"
 #include "packets/linkshell_equip.h"
+#include "packets/message_standard.h"
 #include "packets/message_system.h"
 
 #include "utils/zoneutils.h"
@@ -236,7 +237,7 @@ void CLinkshell::ChangeMemberRank(int8* MemberName, uint8 toSack)
 *                                                                       *
 ************************************************************************/
 
-void CLinkshell::RemoveMemberByName(int8* MemberName, uint8 kickerRank)
+void CLinkshell::RemoveMemberByName(int8* MemberName, uint8 kickerRank, bool breakLinkshell)
 {
     uint32 lsid = m_id;
 	for (uint32 i = 0; i < members.size(); ++i)
@@ -302,7 +303,15 @@ void CLinkshell::RemoveMemberByName(int8* MemberName, uint8 kickerRank)
 
             PMember->pushPacket(new CInventoryFinishPacket());
             PMember->pushPacket(new CCharUpdatePacket(PMember));
-            PMember->pushPacket(new CMessageSystemPacket(0,0,109));
+            if (breakLinkshell)
+            {
+                PMember->pushPacket(new CMessageStandardPacket(MsgStd::LinkshellNoLongerExists));
+            }
+            else
+            {
+                PMember->pushPacket(new CMessageStandardPacket(MsgStd::LinkshellKicked));
+            }
+            
 			return;
 		}
 	}
@@ -323,7 +332,7 @@ void CLinkshell::BreakLinkshell(int8* lsname, bool gm)
     // break logged in and equipped members
 	while (members.size() > 0)
 	{
-        RemoveMemberByName((int8*)members.at(0)->GetName(), LSTYPE_LINKSHELL);
+        RemoveMemberByName((int8*)members.at(0)->GetName(), LSTYPE_LINKSHELL, true);
     }
     // set the linkshell as broken
     Sql_Query(SqlHandle, "UPDATE linkshells SET broken = 1 WHERE linkshellid = %u LIMIT 1", lsid);
@@ -496,7 +505,7 @@ namespace linkshell
 
     bool IsValidLinkshellName(const int8* name)
     {
-        auto ret = Sql_Query(SqlHandle, "SELECT linkshellid FROM linkshells WHERE name = '%s';", name);
+        auto ret = Sql_Query(SqlHandle, "SELECT linkshellid FROM linkshells WHERE name = '%s' AND broken != 1;", name);
         return ret == SQL_ERROR || Sql_NumRows(SqlHandle) == 0;
     }
 

--- a/src/map/linkshell.h
+++ b/src/map/linkshell.h
@@ -58,7 +58,7 @@ public:
     bool        DelMember(CCharEntity* PChar);
 
     void        BreakLinkshell(int8* lsname, bool gm);
-    void        RemoveMemberByName(int8* MemberName, uint8 kickerRank);
+    void        RemoveMemberByName(int8* MemberName, uint8 kickerRank, bool breakLinkshell = false);
 	void		ChangeMemberRank(int8* MemberName, uint8 toSack);
 
     void        PushPacket(uint32 senderID, CBasicPacket* packet);

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -1262,9 +1262,32 @@ void SmallPacket0x034(map_session_data_t* session, CCharEntity* PChar, CBasicPac
             // If item count is zero.. remove from container..
             if (quantity > 0)
             {
-                ShowNotice(CL_CYAN"%s->%s trade updating trade slot id %d with item %s, quantity %d\n" CL_RESET, PChar->GetName(), PTarget->GetName(), tradeSlotID, PItem->getName(), quantity);
-                PItem->setReserve(quantity + PItem->getReserve());
-                PChar->UContainer->SetItem(tradeSlotID, PItem);
+                if (PItem->isType(ITEM_LINKSHELL))
+                {
+                    CItemLinkshell* PItemLinkshell = static_cast<CItemLinkshell*>(PItem);
+                    CItemLinkshell* PItemLinkshell1 = (CItemLinkshell*)PChar->getEquip(SLOT_LINK1);
+                    CItemLinkshell* PItemLinkshell2 = (CItemLinkshell*)PChar->getEquip(SLOT_LINK2);
+                    if ( (!PItemLinkshell1 && !PItemLinkshell2) ||
+                        ((!PItemLinkshell1 || PItemLinkshell1->GetLSID() != PItemLinkshell->GetLSID()) &&
+                        (!PItemLinkshell2 || PItemLinkshell2->GetLSID() != PItemLinkshell->GetLSID())) )
+                    {
+                        PChar->pushPacket(new CMessageStandardPacket(MsgStd::LinkshellEquipBeforeUsing));
+                        PItem->setReserve(0);
+                        PChar->UContainer->SetItem(tradeSlotID, nullptr);
+                    }
+                    else
+                    {
+                        ShowNotice(CL_CYAN"%s->%s trade updating trade slot id %d with item %s, quantity %d\n" CL_RESET, PChar->GetName(), PTarget->GetName(), tradeSlotID, PItem->getName(), quantity);
+                        PItem->setReserve(quantity + PItem->getReserve());
+                        PChar->UContainer->SetItem(tradeSlotID, PItem);
+                    }
+                }
+                else
+                {
+                    ShowNotice(CL_CYAN"%s->%s trade updating trade slot id %d with item %s, quantity %d\n" CL_RESET, PChar->GetName(), PTarget->GetName(), tradeSlotID, PItem->getName(), quantity);
+                    PItem->setReserve(quantity + PItem->getReserve());
+                    PChar->UContainer->SetItem(tradeSlotID, PItem);
+                }
             }
             else
             {
@@ -4438,12 +4461,12 @@ void SmallPacket0x0C4(map_session_data_t* session, CCharEntity* PChar, CBasicPac
                     Sql_Query(SqlHandle, Query, extra, PChar->id, PItemLinkshell->getLocationID(), PItemLinkshell->getSlotID());
                     PChar->pushPacket(new CInventoryItemPacket(PItemLinkshell, PItemLinkshell->getLocationID(), PItemLinkshell->getSlotID()));
                     PChar->pushPacket(new CInventoryFinishPacket());
-                    PChar->pushPacket(new CMessageSystemPacket(0, 0, 110)); // That linkshell group no longer exists. This item is unusable.
+                    PChar->pushPacket(new CMessageStandardPacket(MsgStd::LinkshellNoLongerExists));
                     return;
                 }
                 if (PItemLinkshell->GetLSID() == 0)
                 {
-                    PChar->pushPacket(new CMessageSystemPacket(0, 0, 110)); // That linkshell group no longer exists. This item is unusable.
+                    PChar->pushPacket(new CMessageStandardPacket(MsgStd::LinkshellNoLongerExists));
                     return;
                 }
                 if (OldLinkshell != nullptr) // switching linkshell group
@@ -4955,7 +4978,7 @@ void SmallPacket0x0E2(map_session_data_t* session, CCharEntity* PChar, CBasicPac
         break;
         }
     }
-    PChar->pushPacket(new CMessageSystemPacket(0, 0, 158)); // You do not have access to those linkshell commands.
+    PChar->pushPacket(new CMessageStandardPacket(MsgStd::LinkshellNoAccess));
     return;
 }
 

--- a/src/map/packets/message_standard.h
+++ b/src/map/packets/message_standard.h
@@ -52,6 +52,9 @@ enum class MsgStd
     PollProposalParty              = 101, // Player Name's proposal to the party (cast vote with command: "/vote ?"):
     PollProposalLinkshell          = 102, // Player Name's proposal to the linkshell group (cast vote with command: "/vote ?"):
     PollProposalSystem             = 103, // Player Name's proposal to everyone (cast vote with command: "/vote ?"):
+    LinkshellEquipBeforeUsing      = 108, // Equip a linkshell, pearlsack, or linkpearl before using that command.
+    LinkshellKicked                = 109, // You have been kicked out of the linkshell group.
+    LinkshellNoLongerExists        = 110, // That linkshell group no longer exists. This item is unusable.
     LinkshellUnavailable           = 112, // The linkshell name you entered is already in use or otherwise unavailable.
     TellNotReceivedOffline         = 125, // Your tell was not received.  The recipient is currently away.
     CurrentPollResultsSystem       = 140, // Player Name's proposal - Current poll results:
@@ -65,6 +68,7 @@ enum class MsgStd
     FinalPollResultsParty          = 152, // Player Name's proposal - Final poll results:
     CurrentPollResultsLinkshell    = 153, // Player Name's proposal - Current poll results:
     FinalPollResultsLinkshell      = 154, // Player Name's proposal - Final poll results:
+    LinkshellNoAccess              = 158, // You do not have access to those linkshell commands.
     ThrowAway                      = 180, // You throw away <item>.
     TellNotReceivedAway            = 181, // Your tell was not received.  The recipient is currently away.
     ItemEx                         = 220, // You cannot possess more than one of that item.


### PR DESCRIPTION
Make linkshell name available again after linkshell breaks.
Require link item to be worn when trading linkpearls.
Table some text ids.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

