### PR TITLE
Custom epoch for Vana'diel time

### DIFF
--- a/conf/default/map.conf
+++ b/conf/default/map.conf
@@ -76,8 +76,11 @@ exp_loss_rate: 1.0
 exp_party_gap_penalties: 1
 fov_allow_alliance: 1
 
-#Determine when "JP midnight" is.
-vanadiel_time_offset: 0
+#Determines Vana'diel time epoch (886/1/1 Firesday)
+# current timestamp - vanadiel_time_epoch = vana'diel time
+# 0 defaults to SE epoch 1009810800 (JP midnight 1/1/2002)
+#safe range is 1 - current timestamp
+vanadiel_time_epoch: 0
 
 #For old fame calculation use .25
 fame_multiplier: 1.00

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -702,8 +702,8 @@ namespace luautils
         if (!lua_isnil(L, 1) && lua_isnumber(L, 1))
         {
             int32 offset = (int32)lua_tointeger(L, 1);
-
-            CVanaTime::getInstance()->setCustomOffset(offset);
+            int32 custom = CVanaTime::getInstance()->getCustomEpoch();
+            CVanaTime::getInstance()->setCustomEpoch((custom ? custom : VTIME_BASEDATE) - offset);
 
             lua_pushboolean(L, true);
             return 1;

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -229,7 +229,7 @@ int32 do_init(int32 argc, char** argv)
     map_fd = makeBind_udp(map_config.uiMapIp, map_port == 0 ? map_config.usMapPort : map_port);
     ShowMessage("\t - " CL_GREEN"[OK]" CL_RESET"\n");
 
-    CVanaTime::getInstance()->setCustomOffset(map_config.vanadiel_time_offset);
+    CVanaTime::getInstance()->setCustomEpoch(map_config.vanadiel_time_epoch);
 
     zoneutils::InitializeWeather(); // Need VanaTime initialized
 
@@ -983,7 +983,7 @@ int32 map_config_default()
     map_config.player_stat_multiplier = 1.0f;
     map_config.ability_recast_multiplier = 1.0f;
     map_config.blood_pact_shared_timer = 0;
-    map_config.vanadiel_time_offset = 0;
+    map_config.vanadiel_time_epoch = 0;
     map_config.lightluggage_block = 4;
     map_config.max_time_lastupdate = 60000;
     map_config.newstyle_skillups = 7;
@@ -1074,9 +1074,9 @@ int32 map_config_read(const int8* cfgName)
         {
             map_config.max_time_lastupdate = atoi(w2);
         }
-        else if (strcmp(w1, "vanadiel_time_offset") == 0)
+        else if (strcmp(w1, "vanadiel_time_epoch") == 0)
         {
-            map_config.vanadiel_time_offset = atoi(w2);
+            map_config.vanadiel_time_epoch = atoi(w2);
         }
         else if (strcmp(w1, "fame_multiplier") == 0)
         {

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -70,7 +70,7 @@ struct map_config_t
     std::string server_message;
 
     uint32 max_time_lastupdate;       // max interval wait of last update player char
-    int32  vanadiel_time_offset;      // смещение игрового времени относительно реального времени
+    int32  vanadiel_time_epoch;      // current timestamp - vanadiel_time_epoch = vana'diel time
     int32  lightluggage_block;        // если значение отлично от нуля, то персонажи с lightluggage будут удаляться с сервера автоматически
 
     uint16 ah_base_fee_single;        // Base AH fee for single items

--- a/src/map/vana_time.cpp
+++ b/src/map/vana_time.cpp
@@ -30,7 +30,7 @@ CVanaTime* CVanaTime::_instance = nullptr;
 
 CVanaTime::CVanaTime()
 {
-    setCustomOffset(0);
+    setCustomEpoch(0);
 }
 
 CVanaTime* CVanaTime::getInstance()
@@ -119,19 +119,18 @@ uint32 CVanaTime::getSysYearDay()
 
 uint32 CVanaTime::getVanaTime()
 {
-    //if custom offset is re-implemented here is the place to put it
     //all functions/variables for in game time should be derived from this
-    return (uint32)time(nullptr) - VTIME_BASEDATE;
+    return (uint32)time(nullptr) - (m_customEpoch ? m_customEpoch : VTIME_BASEDATE);
 }
 
-int32 CVanaTime::getCustomOffset()
+int32 CVanaTime::getCustomEpoch()
 {
-    return m_customOffset;
+    return m_customEpoch;
 }
 
-void CVanaTime::setCustomOffset(int32 offset)
+void CVanaTime::setCustomEpoch(int32 epoch)
 {
-    m_customOffset = offset;
+    m_customEpoch = epoch;
     m_TimeType = SyncTime();
 }
 

--- a/src/map/vana_time.h
+++ b/src/map/vana_time.h
@@ -82,9 +82,9 @@ public:
 	uint32	 getSysYearDay();						// Number of day since 1st january
 
     uint32   getVanaTime();
-	int32	 getCustomOffset();
+	int32	 getCustomEpoch();
 
-	void	 setCustomOffset(int32 offset);
+	void	 setCustomEpoch(int32 epoch);
 
 	time_point   lastConquestUpdate;
     time_point   lastVHourlyUpdate;
@@ -108,7 +108,7 @@ private:
 
 	TIMETYPE m_TimeType;							// текущий тип времени
 
-	int32	 m_customOffset;						// Смещение игрового времени в игровых минутах
+	int32	 m_customEpoch;						// Custom epoch to use instead of VTIME_BASEDATE
 };
 
 #endif


### PR DESCRIPTION
Rename setting to epoch from offset to hopefully clarify usage.
Adjust luautils function used with GM command.

Fixes issue #552

GM command `!timeoffset <offset>` will let you move around in time. Must zone for client to reflect changes. `!timeoffset 144` will take you an hour ahead, `timeoffset -144` will take you an hour back. Setting the conf setting to 1 will set the epoch to the farthest time back, making the client as far into the future as it can currently go. Setting the conf setting to current timestamp will set the time to 886/1/1 on Firesday. Anything greater than the current timestamp will set the date to 886/1/1 but will result in different day elements until current time is reached, on Firesday.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

