### PR TITLE
Updates for nix builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,7 @@ include sources.am
 ## Set up all of our dependency flags
 SRC_ALL                 = $(SRC_TOPAZ)
 CFLAGS_ALL              = $(TOPAZ_CFLAGS) -fsigned-char
-CPPFLAGS_ALL            = $(TOPAZ_CPPFLAGS) -fsigned-char -DFMT_HEADER_ONLY -Wall -Werror -Wfatal-errors
+CPPFLAGS_ALL            = $(TOPAZ_CPPFLAGS) -fsigned-char -DFMT_HEADER_ONLY -Wall -Werror -Wno-class-memaccess -Wno-restrict -Wno-format-overflow -Wno-sizeof-pointer-memaccess -Wno-maybe-uninitialized
 CXXFLAGS_ALL            = $(TOPAZ_CXXFLAGS) -fsigned-char
 LIBS_ALL                = $(TOPAZ_LIBS)
 LDFLAGS_ALL             = $(TOPAZ_LDFLAGS)

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -7,7 +7,7 @@
 add_definitions(-DFMT_HEADER_ONLY)
 
 if(UNIX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -Wall -Werror -Wfatal-errors -fsigned-char")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -Wall -Werror -Wno-class-memaccess -Wno-restrict -Wno-format-overflow -Wno-sizeof-pointer-memaccess -Wno-maybe-uninitialized -fsigned-char")
 else()
     # fix /std:latest once VS2017 CMAKE supports CXX_STANDARD
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++latest /W3 /WX")

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -447,6 +447,7 @@ void EncodeStringLinkshell(int8* signature, int8* target)
     leftover = (leftover == 8 || leftover == 2 ? 6 : leftover);
     packBitsLE(encodedSignature, 0xFF, 6 * chars, leftover);
 
+    // TODO: -Wno-sizeof-pointer-memaccess - sizeof references source not destination
     strncpy((char*)target, (const char*)encodedSignature, sizeof encodedSignature);
 }
 
@@ -480,6 +481,7 @@ void DecodeStringLinkshell(int8* signature, int8* target)
         else
             decodedSignature[currChar] = tempChar;
     }
+    // TODO: -Wno-sizeof-pointer-memaccess - sizeof references source not destination
     strncpy((char*)target, (const char*)decodedSignature, sizeof decodedSignature);
 }
 
@@ -508,6 +510,7 @@ int8* EncodeStringSignature(int8* signature, int8* target)
     //leftover = (leftover == 8 ? 6 : leftover);
     //packBitsLE(encodedSignature,0xFF,6*chars, leftover);
 
+    // TODO: -Wno-sizeof-pointer-memaccess - sizeof references source not destination
     return (int8*)strncpy((char*)target, (const char*)encodedSignature, sizeof encodedSignature);
 }
 
@@ -526,6 +529,7 @@ void DecodeStringSignature(int8* signature, int8* target)
 
         decodedSignature[currChar] = tempChar;
     }
+    // TODO: -Wno-sizeof-pointer-memaccess - sizeof references source not destination
     strncpy((char*)target, (const char*)decodedSignature, sizeof decodedSignature);
 }
 

--- a/src/map/ai/controllers/automaton_controller.cpp
+++ b/src/map/ai/controllers/automaton_controller.cpp
@@ -1446,6 +1446,7 @@ namespace autoSpell
         if(PStatus->GetFlag() & EFFECTFLAG_ERASABLE)
             return SpellID::Erase;
         else
+            // TODO: -Wno-maybe-uninitialized - possible false positive (anonymous may be used)
             return {};
     }
 }

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -110,6 +110,7 @@ CCharEntity::CCharEntity()
     m_Wardrobe4 = std::make_unique<CItemContainer>(LOC_WARDROBE4);
 
     memset(&jobs, 0, sizeof(jobs));
+    // TODO: -Wno-class-memaccess - clearing an object on non-trivial type use assignment or value-init
     memset(&keys, 0, sizeof(keys));
     memset(&equip, 0, sizeof(equip));
     memset(&equipLoc, 0, sizeof(equipLoc));
@@ -118,6 +119,7 @@ CCharEntity::CCharEntity()
     memset(&nameflags, 0, sizeof(nameflags));
     memset(&menuConfigFlags, 0, sizeof(menuConfigFlags));
 
+    // TODO: -Wno-class-memaccess - clearing an object on non-trivial type use assignment or value-init
     memset(&m_SpellList, 0, sizeof(m_SpellList));
     memset(&m_LearnedAbilities, 0, sizeof(m_LearnedAbilities));
     memset(&m_TitleList, 0, sizeof(m_TitleList));

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -165,6 +165,8 @@ void PrintPacket(CBasicPacket data)
 
     for (size_t y = 0; y < data.length(); y++)
     {
+        // TODO: -Wno-restrict - undefined behavior to print and write src into dest
+        // TODO: -Wno-format-overflow - writing between 4 and 53 bytes into destination of 50
         sprintf(message, "%s %02hx", message, *((uint8*)data[(const int)y]));
         if (((y + 1) % 16) == 0)
         {


### PR DESCRIPTION
- Remove -Wfatal-errors to get all errors at once
- Adding error ignores from gcc-8 changes (makefile/cmake)
- Adding above-line TODOs with error to be fixed later

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

