### PR TITLE
Add var and binding for isDualWielding + remove presumptuous granting of mod to all NIN NMs

### DIFF
--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -248,8 +248,7 @@ function doPhysicalWeaponskill(attacker, target, wsID, wsParams, tp, action, pri
     calcParams.guaranteedHit = calcParams.sneakApplicable or calcParams.trickApplicable
     calcParams.mightyStrikesApplicable = attacker:hasStatusEffect(tpz.effect.MIGHTY_STRIKES)
     calcParams.forcedFirstCrit = calcParams.sneakApplicable or calcParams.assassinApplicable
-    calcParams.extraOffhandHit = (calcParams.weaponDamage[2] ~= 0) and
-                                 (calcParams.weaponDamage[2] > 0 or attack.weaponType == tpz.skill.HAND_TO_HAND)
+    calcParams.extraOffhandHit = attacker:isDualWielding() or attack.weaponType == tpz.skill.HAND_TO_HAND
     calcParams.hybridHit = wsParams.hybridWS
     calcParams.flourishEffect = attacker:getStatusEffect(tpz.effect.BUILDING_FLOURISH)
     calcParams.fencerBonus = fencerBonus(attacker)

--- a/src/map/attackround.cpp
+++ b/src/map/attackround.cpp
@@ -60,8 +60,7 @@ CAttackRound::CAttackRound(CBattleEntity* attacker, CBattleEntity* defender)
         CreateKickAttacks();
     }
 
-    else if ((m_subWeaponType > 0 && m_subWeaponType < 4) ||
-        (attacker->objtype == TYPE_MOB && static_cast<CMobEntity*>(attacker)->getMobMod(MOBMOD_DUAL_WIELD)))
+    else if (attacker->m_dualWield)
     {
         CreateAttacks(dynamic_cast<CItemWeapon*>(attacker->m_Weapons[SLOT_SUB]), LEFTATTACK);
     }

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -60,6 +60,7 @@ CBattleEntity::CBattleEntity()
     m_Weapons[SLOT_SUB] = new CItemWeapon(0);
     m_Weapons[SLOT_RANGED] = new CItemWeapon(0);
     m_Weapons[SLOT_AMMO] = new CItemWeapon(0);
+    m_dualWield = false;
 
     memset(&stats, 0, sizeof(stats));
     memset(&health, 0, sizeof(health));

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -654,7 +654,8 @@ public:
 
     uint8			m_ModelSize;			    // размер модели сущности, для расчета дальности физической атаки
     ECOSYSTEM		m_EcoSystem;			    // эко-система сущности
-    CItemEquipment*	    m_Weapons[4];			    // четыре основных ячейки, используемыж для хранения оружия (только оружия)
+    CItemEquipment* m_Weapons[4];               // четыре основных ячейки, используемыж для хранения оружия (только оружия)
+    bool            m_dualWield;                // True/false depending on if the entity is using two weapons
 
     TraitList_t     TraitList;                  // список постянно активных способностей в виде указателей
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -10015,6 +10015,30 @@ int32 CLuaBaseEntity::checkImbuedItems(lua_State* L)
 }
 
 /************************************************************************
+*  Function: isDualWielding()
+*  Purpose : Returns true if entity is wielding two weapons
+*  Example : if player:isDualWielding() then
+*  Notes   : 
+************************************************************************/
+
+inline int32 CLuaBaseEntity::isDualWielding(lua_State* L)
+{
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+    CBattleEntity* PBattleEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
+    if (PBattleEntity)
+    {
+        lua_pushboolean(L, PBattleEntity->m_dualWield);
+        return 1;
+    }
+    else
+    {
+        lua_pushboolean(L, false);
+        ShowError("lua::isDualWielding :: NPCs don't wield weapons!\n");
+        return 1;
+    }
+}
+
+/************************************************************************
 *  Function: getCE()
 *  Purpose : Returns the current Cumulative Enmity a Mob has against an Entity
 *  Example : local playerCE = target:getCE(player)
@@ -14570,6 +14594,8 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
 
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,recalculateStats),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,checkImbuedItems),
+
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,isDualWielding),
 
     // Enmity
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getCE),

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -485,6 +485,8 @@ public:
     int32 recalculateStats(lua_State* L);
     int32 checkImbuedItems(lua_State* L);
 
+    int32 isDualWielding(lua_State*);          // Checks if the battle entity is dual wielding
+
     // Enmity
     int32 getCE(lua_State*);                   //gets current CE the mob has towards the player
     int32 getVE(lua_State*);                   //gets current VE the mob has towards the player

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1593,6 +1593,7 @@ namespace charutils
                 {
                     CheckUnarmedWeapon(PChar);
                 }
+                PChar->m_dualWield = false;
             }
             PChar->delEquipModifiers(&((CItemEquipment*)PItem)->modList, ((CItemEquipment*)PItem)->getReqLvl(), equipSlotID);
             PChar->PLatentEffectContainer->DelLatentEffects(((CItemEquipment*)PItem)->getReqLvl(), equipSlotID);
@@ -1862,6 +1863,7 @@ namespace charutils
                                     return false;
                                 }
                                 PChar->m_Weapons[SLOT_SUB] = (CItemWeapon*)PItem;
+                                PChar->m_dualWield = true;
                             }
                             break;
                             default:

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -388,6 +388,12 @@ void CalculateStats(CMobEntity * PMob)
         ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->resetDelay();
     }
 
+    // Deprecate MOBMOD_DUAL_WIELD later, replace if check with value from DB
+    if (PMob->getMobMod(MOBMOD_DUAL_WIELD))
+    {
+        PMob->m_dualWield = true;
+    }
+
     uint16 fSTR = GetBaseToRank(PMob->strRank, mLvl);
     uint16 fDEX = GetBaseToRank(PMob->dexRank, mLvl);
     uint16 fVIT = GetBaseToRank(PMob->vitRank, mLvl);
@@ -855,11 +861,6 @@ void SetupNMMob(CMobEntity* PMob)
 
     if(mLvl >= 25)
     {
-        if(mJob == JOB_NIN)
-        {
-            PMob->setMobMod(MOBMOD_DUAL_WIELD, 1);
-        }
-
         if(mJob == JOB_WHM)
         {
             // whm nms have stronger regen effect


### PR DESCRIPTION
As previously discussed, without adding dual wield mobs to the NIN NMs which _should_ have them, this will result in some NIN NMs becoming easier than they should be.

Here is a list of NMs which are currently automatically being given Dual Wield mobmod (note: _not trait_) which will make them _always_ have a second hit:
![github](https://user-images.githubusercontent.com/13112942/84581797-825c9900-add4-11ea-9ff9-69f2029df960.png)

Some of these mobs should always be attacking twice; others should not. Unfortunately, _the mob's model **can not** be used to distinguish which is which_. Some NIN NMs with the _same_ model will always attack twice per round, and others only once. Determining which are "dual wielding" (ie: which will always attack twice per combat round) would require video captures from retail.

**Future selves: The dual wield mobmod is bad, and we need to make it go away.** Mobs don't wield weapons, and the assumption that they do leads to mistakes like the one currently being fixed in this PR (NIN NMs with a great sword model being given "dual wield"). We will need to add some sort of numHits column to the DB which dictates how many hits a mob has per attack round. This is _not_ the same as Double Attack, which procs on weaponskill/TP moves.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

