### PR TITLE
Double-up cooldown adjustments

### DIFF
--- a/scripts/globals/ability.lua
+++ b/scripts/globals/ability.lua
@@ -467,7 +467,7 @@ function corsairSetup(caster, ability, action, effect, job)
     caster:setLocalVar("corsairRollTotal", roll)
     action:speceffect(caster:getID(), roll)
     if (checkForElevenRoll(caster)) then
-        action:recast(action:recast()/2)
+        action:recast(action:recast()/2) -- halves phantom roll recast timer for all rolls while under the effects of an 11 (upon first hitting 11, phantom roll cooldown is reset in double-up.lua)
     end
     checkForJobBonus(caster, job)
 end

--- a/scripts/globals/ability.lua
+++ b/scripts/globals/ability.lua
@@ -470,7 +470,6 @@ function corsairSetup(caster, ability, action, effect, job)
         action:recast(action:recast()/2)
     end
     checkForJobBonus(caster, job)
-    caster:addRecast(tpz.recast.ABILITY, 194, 8)
 end
 
 function atMaxCorsairBusts(caster)

--- a/sql/abilities.sql
+++ b/sql/abilities.sql
@@ -144,7 +144,7 @@ INSERT INTO `abilities` VALUES (103,'casters_roll',17,79,1,60,193,420,0,119,2000
 INSERT INTO `abilities` VALUES (104,'coursers_roll',17,81,1,60,193,420,0,120,2000,0,6,8.0,1,1,80,0,8,'ABYSSEA');
 INSERT INTO `abilities` VALUES (105,'blitzers_roll',17,83,1,60,193,420,0,121,2000,0,6,8.0,1,1,80,0,8,'ABYSSEA');
 INSERT INTO `abilities` VALUES (106,'tacticians_roll',17,86,1,60,193,420,0,122,2000,0,6,8.0,1,1,80,0,8,'ABYSSEA');
-INSERT INTO `abilities` VALUES (107,'double-up',17,5,1,8,194,424,0,116,2000,0,6,8.0,1,1,80,0,0,'TOAU');
+INSERT INTO `abilities` VALUES (107,'double-up',17,5,1,5,194,424,0,116,2000,0,6,8.0,1,1,80,0,0,'TOAU');
 INSERT INTO `abilities` VALUES (108,'quick_draw',17,40,1,1,0,0,0,0,2000,0,6,18.0,0,0,0,1410,0,'TOAU');
 INSERT INTO `abilities` VALUES (109,'fire_shot',17,40,4,1,195,110,0,125,2000,0,6,18.0,0,0,0,1410,0,'TOAU');
 INSERT INTO `abilities` VALUES (110,'ice_shot',17,40,4,1,195,110,0,126,2000,0,6,18.0,0,0,0,1410,0,'TOAU');


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Removes the cooldown added to double-up after a corsair uses a roll.  Also reduces the cooldown on double-up in line with the retail change to 5 seconds.