### PR TITLE
Adds "All in the Cards" repeatable quest to Chululu

### DIFF
--- a/scripts/zones/Lower_Jeuno/npcs/Chululu.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Chululu.lua
@@ -5,159 +5,145 @@
 -- Optional Cutscene at end of Quest: Searching for the Right Words
 -- !pos -13 -6 -42 245
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/titles");
-require("scripts/globals/keyitems");
-require("scripts/globals/shop");
-require("scripts/globals/quests");
-local ID = require("scripts/zones/Lower_Jeuno/IDs");
+require("scripts/globals/settings")
+require("scripts/globals/titles")
+require("scripts/globals/keyitems")
+require("scripts/globals/shop")
+require("scripts/globals/quests")
+local ID = require("scripts/zones/Lower_Jeuno/IDs")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    if (player:getQuestStatus(JEUNO,tpz.quest.id.jeuno.COLLECT_TARUT_CARDS) == QUEST_ACCEPTED) then
+    if player:getQuestStatus(JEUNO,tpz.quest.id.jeuno.COLLECT_TARUT_CARDS) == QUEST_ACCEPTED then
         if (trade:hasItemQty(558,1) == true and trade:hasItemQty(559,1) == true and trade:hasItemQty(561,1) == true and trade:hasItemQty(562,1) == true and trade:getItemCount() == 4) then
-            player:startEvent(200); -- Finish quest "Collect Tarut Cards"
+            player:startEvent(200) -- Finish quest "Collect Tarut Cards"
         end
     end
-    if (player:getQuestStatus(JEUNO,tpz.quest.id.jeuno.ALL_IN_THE_CARDS) >= QUEST_ACCEPTED) then
-	if npcUtil.tradeHas(trade, {558, 559, 561, 562}, true) then
-		player:startEvent(10114) -- Finish quest "All in the Cards"
-	end
-
-
-    end	
-end;
+    if player:getQuestStatus(JEUNO,tpz.quest.id.jeuno.ALL_IN_THE_CARDS) >= QUEST_ACCEPTED then
+        if npcUtil.tradeHas(trade, {558, 559, 561, 562}, true) then
+            player:startEvent(10114) -- Finish quest "All in the Cards"
+        end
+    end
+end
 
 function onTrigger(player,npc)
-    local CollectTarutCards = player:getQuestStatus(JEUNO,tpz.quest.id.jeuno.COLLECT_TARUT_CARDS);
-    local RubbishDay = player:getQuestStatus(JEUNO,tpz.quest.id.jeuno.RUBBISH_DAY);
-    local SearchingForTheRightWords = player:getQuestStatus(JEUNO,tpz.quest.id.jeuno.SEARCHING_FOR_THE_RIGHT_WORDS);
-    local AllInTheCards = player:getQuestStatus(JEUNO,tpz.quest.id.jeuno.ALL_IN_THE_CARDS);
-    local cdate = player:getCharVar("AllInTheCards_date");
+    local CollectTarutCards = player:getQuestStatus(JEUNO,tpz.quest.id.jeuno.COLLECT_TARUT_CARDS)
+    local RubbishDay = player:getQuestStatus(JEUNO,tpz.quest.id.jeuno.RUBBISH_DAY)
+    local SearchingForTheRightWords = player:getQuestStatus(JEUNO,tpz.quest.id.jeuno.SEARCHING_FOR_THE_RIGHT_WORDS)
+    local AllInTheCards = player:getQuestStatus(JEUNO,tpz.quest.id.jeuno.ALL_IN_THE_CARDS)
+    local cdate = player:getCharVar("AllInTheCards_date")
 
-    if (player:getFameLevel(JEUNO) >= 3 and CollectTarutCards == QUEST_AVAILABLE) then
-        player:startEvent(28); -- Start quest "Collect Tarut Cards" with option
-    elseif (CollectTarutCards == QUEST_ACCEPTED) then
-        player:startEvent(27); -- During quest "Collect Tarut Cards"
-    elseif (CollectTarutCards == QUEST_COMPLETED and RubbishDay == QUEST_AVAILABLE and player:getCharVar("RubbishDay_day") ~= VanadielDayOfTheYear()) then
---      prog = player:getCharVar("RubbishDay_prog");
+    if player:getFameLevel(JEUNO) >= 3 and CollectTarutCards == QUEST_AVAILABLE then
+        player:startEvent(28) -- Start quest "Collect Tarut Cards" with option
+    elseif CollectTarutCards == QUEST_ACCEPTED then
+        player:startEvent(27) -- During quest "Collect Tarut Cards"
+    elseif CollectTarutCards == QUEST_COMPLETED and RubbishDay == QUEST_AVAILABLE and player:getCharVar("RubbishDay_day") ~= VanadielDayOfTheYear() then
+--      prog = player:getCharVar("RubbishDay_prog")
 --      if (prog <= 2) then
---          player:startEvent(199); -- Required to get compatibility 3x on 3 diff game days before quest is kicked off
+--          player:startEvent(199) -- Required to get compatibility 3x on 3 diff game days before quest is kicked off
 --      elseif (prog == 3) then
-            player:startEvent(198); -- Start quest "Rubbish Day" with option
+            player:startEvent(198) -- Start quest "Rubbish Day" with option
 --      end
-    elseif (CollectTarutCards == QUEST_COMPLETED and RubbishDay == QUEST_AVAILABLE) then
-        player:startEvent(57); -- Standard dialog between 2 quests
-    elseif (RubbishDay == QUEST_ACCEPTED and player:getCharVar("RubbishDayVar") == 0) then
-        player:startEvent(49); -- During quest "Rubbish Day"
-    elseif (RubbishDay == QUEST_ACCEPTED and player:getCharVar("RubbishDayVar") == 1) then
-        player:startEvent(197); -- Finish quest "Rubbish Day"
-		
-		
-    elseif (player:getFameLevel(JEUNO) >= 4 and CollectTarutCards == QUEST_COMPLETED and AllInTheCards == QUEST_AVAILABLE) then
-        player:startEvent(10110); -- Start quest "All in the Cards" with option
-	elseif (AllInTheCards == QUEST_ACCEPTED and cdate >= os.time()) then
-		player:startEvent(10111); -- During quest "All in the Cards" and same AllInTheCards_date value		
-	elseif (AllInTheCards == QUEST_ACCEPTED and cdate ~= os.time()) then
-		player:startEvent(10112); -- During quest "All in the Cards"  THIS ONE GIVES ANOTHER BATCH
-	elseif (CollectTarutCards == QUEST_COMPLETED and AllInTheCards == QUEST_COMPLETED) then
-		player:startEvent(10113); -- Start quest "All in the Cards"	repeat with option		
-
-    elseif (SearchingForTheRightWords == QUEST_COMPLETED) then
-        if (player:getCharVar("SearchingForRightWords_postcs") < -1) then
-            player:startEvent(56);
-        else
-            player:startEvent(57); -- final state, after all quests complete
+    elseif CollectTarutCards == QUEST_COMPLETED and RubbishDay == QUEST_AVAILABLE then
+        player:startEvent(57) -- Standard dialog between 2 quests
+    elseif RubbishDay == QUEST_ACCEPTED and player:getCharVar("RubbishDayVar") == 0 then
+        player:startEvent(49) -- During quest "Rubbish Day"
+    elseif RubbishDay == QUEST_ACCEPTED and player:getCharVar("RubbishDayVar") == 1 then
+        player:startEvent(197) -- Finish quest "Rubbish Day"
+    elseif player:getFameLevel(JEUNO) >= 4 and CollectTarutCards == QUEST_COMPLETED and AllInTheCards == QUEST_AVAILABLE then
+        player:startEvent(10110) -- Start quest "All in the Cards" with option
+    elseif AllInTheCards >= QUEST_ACCEPTED and player:getLocalVar("Cardstemp") == 0 then
+        if cdate >= os.time() then
+            player:startEvent(10111) -- During quest "All in the Cards" and same AllInTheCards_date value
+        elseif cdate == 0 then
+            player:startEvent(10113) -- Start quest "All in the Cards"	repeat with option
+        elseif cdate < os.time() then
+            player:startEvent(10112) -- During quest "All in the Cards"  THIS ONE GIVES ANOTHER BATCH
         end
-		
-
-
-
-
-    elseif (RubbishDay == QUEST_COMPLETED) then
-        player:startEvent(57); -- New standard dialog
-
+    elseif SearchingForTheRightWords == QUEST_COMPLETED then
+        if player:getCharVar("SearchingForRightWords_postcs") < -1 then
+            player:startEvent(56)
+        else
+            player:startEvent(57) -- final state, after all quests complete
+        end
+    elseif RubbishDay == QUEST_COMPLETED then
+        player:startEvent(57) -- New standard dialog
     else
-        player:startEvent(26); -- Standard dialog
+        player:startEvent(26) -- Standard dialog
     end
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-
-    if (csid == 28 and option == 0) then
-        local rand = math.random(1,4);
-        local card = 0;
+    if csid == 28 and option == 0 then
+        local rand = math.random(1,4)
+        local card = 0
 
         if (rand == 1) then
-            card = 559; -- Tarut: Death
+            card = 559 -- Tarut: Death
         elseif (rand == 2) then
-            card = 562; -- Tarut: Hermit
+            card = 562 -- Tarut: Hermit
         elseif (rand == 3) then
-            card = 561; -- Tarut: King
+            card = 561 -- Tarut: King
         else
-            card = 558; -- Tarut: Fool
+            card = 558 -- Tarut: Fool
         end
 
-        if (player:getFreeSlotsCount() == 0) then
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED,card);
+        if player:getFreeSlotsCount() == 0 then
+            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED,card)
         else
-            player:addQuest(JEUNO,tpz.quest.id.jeuno.COLLECT_TARUT_CARDS);
-            player:addItem(card,5);
-            player:messageSpecial(ID.text.ITEM_OBTAINED,card);
+            player:addQuest(JEUNO,tpz.quest.id.jeuno.COLLECT_TARUT_CARDS)
+            player:addItem(card,5)
+            player:messageSpecial(ID.text.ITEM_OBTAINED,card)
         end
     elseif (csid == 200) then
-        player:addTitle(tpz.title.CARD_COLLECTOR);
-        player:addFame(JEUNO, 30);
-        player:tradeComplete();
-        player:completeQuest(JEUNO,tpz.quest.id.jeuno.COLLECT_TARUT_CARDS);
+        player:addTitle(tpz.title.CARD_COLLECTOR)
+        player:addFame(JEUNO, 30)
+        player:tradeComplete()
+        player:completeQuest(JEUNO,tpz.quest.id.jeuno.COLLECT_TARUT_CARDS)
     elseif (csid == 199 and option == 0) then
-        player:addCharVar("RubbishDay_prog", 1);
-        player:setCharVar("RubbishDay_day", VanadielDayOfTheYear()); -- new vanadiel day
+        player:addCharVar("RubbishDay_prog", 1)
+        player:setCharVar("RubbishDay_day", VanadielDayOfTheYear()) -- new vanadiel day
     elseif (csid == 198 and option == 0) then
-        player:addQuest(JEUNO,tpz.quest.id.jeuno.RUBBISH_DAY);
-        player:addKeyItem(tpz.ki.MAGIC_TRASH);
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED,tpz.ki.MAGIC_TRASH);
-        player:setCharVar("RubbishDay_prog",0);
-        player:setCharVar("RubbishDay_day",VanadielDayOfTheYear());
+        player:addQuest(JEUNO,tpz.quest.id.jeuno.RUBBISH_DAY)
+        player:addKeyItem(tpz.ki.MAGIC_TRASH)
+        player:messageSpecial(ID.text.KEYITEM_OBTAINED,tpz.ki.MAGIC_TRASH)
+        player:setCharVar("RubbishDay_prog",0)
+        player:setCharVar("RubbishDay_day",VanadielDayOfTheYear())
 	elseif (csid == 10110 or csid == 10112 or csid == 10113) and option == 0 then -- ALL_IN_THE_CARDS started, repeated, or additional cards given
-        local rand = math.random(1,4);
-        local card = 0;
+        local rand = math.random(1,4)
+        local card = 0
 
         if (rand == 1) then
-            card = 559; -- Tarut: Death
+            card = 559 -- Tarut: Death
         elseif (rand == 2) then
-            card = 562; -- Tarut: Hermit
+            card = 562 -- Tarut: Hermit
         elseif (rand == 3) then
-            card = 561; -- Tarut: King
+            card = 561 -- Tarut: King
         else
-            card = 558; -- Tarut: Fool
+            card = 558 -- Tarut: Fool
         end
 
 		if npcUtil.giveItem(player, {{card, 5}}) then
-            player:addQuest(JEUNO,tpz.quest.id.jeuno.ALL_IN_THE_CARDS);
+            player:addQuest(JEUNO,tpz.quest.id.jeuno.ALL_IN_THE_CARDS)
 		player:setCharVar("AllInTheCards_date", getMidnight())
+        player:setLocalVar("Cardstemp", 1)
 		end
 
-    elseif (csid == 10114) then
+    elseif csid == 10114 then
 		if npcUtil.completeQuest(player, JEUNO, tpz.quest.id.jeuno.ALL_IN_THE_CARDS, {
         gil = 600,
         title = tpz.title.CARD_COLLECTOR,
         var = {"AllInTheCards_date"} })
 		then
-		trade:confirm()	
+		trade:confirm()
 		end
-    elseif (csid == 197) then
-        if (player:getFreeSlotsCount() == 0) then
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED,13083);
-        else
-			npcUtil.completeQuest(player, JEUNO, tpz.quest.id.jeuno.RUBBISH_DAY, {
-			gil = 6000,
-			item = 13083,
-			var = {"RubbishDayVar"} })
-			
-        end
+    elseif csid == 197 then
+		npcUtil.completeQuest(player, JEUNO, tpz.quest.id.jeuno.RUBBISH_DAY, {
+		gil = 6000,
+		item = 13083,
+		var = {"RubbishDayVar"} })
     end
-end;
+end

--- a/scripts/zones/Lower_Jeuno/npcs/Chululu.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Chululu.lua
@@ -130,7 +130,8 @@ function onEventFinish(player,csid,option)
             player:setCharVar("AllInTheCards_date", getMidnight())
             player:setLocalVar("Cardstemp", 1)
 		end
-
+    elseif csid == 10111 then -- same day, have to return later
+            player:setLocalVar("Cardstemp", 1)
     elseif csid == 10114 then
 		if npcUtil.completeQuest(player, JEUNO, tpz.quest.id.jeuno.ALL_IN_THE_CARDS, {
         gil = 600,

--- a/scripts/zones/Lower_Jeuno/npcs/Chululu.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Chululu.lua
@@ -18,8 +18,7 @@ function onTrade(player,npc,trade)
         if (trade:hasItemQty(558,1) == true and trade:hasItemQty(559,1) == true and trade:hasItemQty(561,1) == true and trade:hasItemQty(562,1) == true and trade:getItemCount() == 4) then
             player:startEvent(200) -- Finish quest "Collect Tarut Cards"
         end
-    end
-    if player:getQuestStatus(JEUNO,tpz.quest.id.jeuno.ALL_IN_THE_CARDS) >= QUEST_ACCEPTED then
+    elseif player:getQuestStatus(JEUNO,tpz.quest.id.jeuno.ALL_IN_THE_CARDS) >= QUEST_ACCEPTED then
         if npcUtil.tradeHas(trade, {558, 559, 561, 562}, true) then
             player:startEvent(10114) -- Finish quest "All in the Cards"
         end
@@ -128,8 +127,8 @@ function onEventFinish(player,csid,option)
 
 		if npcUtil.giveItem(player, {{card, 5}}) then
             player:addQuest(JEUNO,tpz.quest.id.jeuno.ALL_IN_THE_CARDS)
-		player:setCharVar("AllInTheCards_date", getMidnight())
-        player:setLocalVar("Cardstemp", 1)
+            player:setCharVar("AllInTheCards_date", getMidnight())
+            player:setLocalVar("Cardstemp", 1)
 		end
 
     elseif csid == 10114 then

--- a/scripts/zones/Lower_Jeuno/npcs/Chululu.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Chululu.lua
@@ -15,7 +15,7 @@ local ID = require("scripts/zones/Lower_Jeuno/IDs")
 
 function onTrade(player,npc,trade)
     if player:getQuestStatus(JEUNO,tpz.quest.id.jeuno.COLLECT_TARUT_CARDS) == QUEST_ACCEPTED then
-        if (trade:hasItemQty(558,1) == true and trade:hasItemQty(559,1) == true and trade:hasItemQty(561,1) == true and trade:hasItemQty(562,1) == true and trade:getItemCount() == 4) then
+        if npcUtil.tradeHas(trade, {558, 559, 561, 562}, true) then
             player:startEvent(200) -- Finish quest "Collect Tarut Cards"
         end
     elseif player:getQuestStatus(JEUNO,tpz.quest.id.jeuno.ALL_IN_THE_CARDS) >= QUEST_ACCEPTED then


### PR DESCRIPTION
Adds "All in the Cards" repeatable quest to Chululu to help increase server supply of Tarut Cards used in the "Collect Taru Cards" pre-req quest for Sleepga II quest line."

Currently setup to require "All in the Cards" and "Rubbish Day" to be completed first.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [X] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [X] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

