### PR TITLE
Adjust NPC script for Sandy 6-2 "Ranperre's Final Rest"

### DIFF
--- a/scripts/zones/Chateau_dOraguille/npcs/Perfaumand.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/Perfaumand.lua
@@ -4,31 +4,40 @@
 -- Involved in Quest: Lure of the Wildcat (San d'Oria)
 -- !pos -39 -3 69 233
 -----------------------------------
-require("scripts/globals/quests");
+require("scripts/globals/quests")
+require("scripts/globals/missions")
+require("scripts/globals/keyitems")
 -----------------------------------
 
 function onTrade(player,npc,trade)
 end;
 
 function onTrigger(player,npc)
+    local WildcatSandy = player:getCharVar("WildcatSandy")
+    local currentMission = player:getCurrentMission(SANDORIA)
+    local missionStatus = player:getCharVar("MissionStatus")
 
-    local WildcatSandy = player:getCharVar("WildcatSandy");
-
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and player:getMaskBit(WildcatSandy,18) == false) then
-        player:startEvent(560);
+    if currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:hasKeyItem(tpz.ki.ANCIENT_SANDORIAN_BOOK) then
+        player:startEvent(49) -- Optional 6-2 CS
+    elseif currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and missionStatus == 5 then
+        player:startEvent(50) -- Optional 6-2 CS
+    elseif currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and missionStatus == 6 then
+        player:startEvent(79) -- Optional 6-2 CS
+    elseif player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and player:getMaskBit(WildcatSandy,18) == false then
+        player:startEvent(560)
     else
-        player:startEvent(522);
+        player:startEvent(522)
     end
 
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
 
-    if (csid == 560) then
-        player:setMaskBit(player:getCharVar("WildcatSandy"),"WildcatSandy",18,true);
+    if csid == 560 then
+        player:setMaskBit(player:getCharVar("WildcatSandy"),"WildcatSandy",18,true)
     end
 
-end;
+end

--- a/scripts/zones/Chateau_dOraguille/npcs/Perfaumand.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/Perfaumand.lua
@@ -17,11 +17,11 @@ function onTrigger(player,npc)
     local currentMission = player:getCurrentMission(SANDORIA)
     local missionStatus = player:getCharVar("MissionStatus")
 
-    if currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:hasKeyItem(tpz.ki.ANCIENT_SANDORIAN_BOOK) then
+    if currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and ((player:hasKeyItem(tpz.ki.ANCIENT_SANDORIAN_BOOK) and missionStatus == 3) or missionStatus == 4 or missionStatus == 5) then
         player:startEvent(49) -- Optional 6-2 CS
-    elseif currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and missionStatus == 5 then
-        player:startEvent(50) -- Optional 6-2 CS
     elseif currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and missionStatus == 6 then
+        player:startEvent(50) -- Optional 6-2 CS
+    elseif currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and missionStatus == 7 then
         player:startEvent(79) -- Optional 6-2 CS
     elseif player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and player:getMaskBit(WildcatSandy,18) == false then
         player:startEvent(560)

--- a/scripts/zones/Chateau_dOraguille/npcs/_6h0.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/_6h0.lua
@@ -21,11 +21,8 @@ end;
 function onTrigger(player,npc)
 
     local currentMission = player:getCurrentMission(SANDORIA);
-    local MissionStatus = player:getCharVar("MissionStatus");
+    local missionStatus = player:getCharVar("MissionStatus");
     local infiltrateDavoi = player:hasCompletedMission(SANDORIA,tpz.mission.id.sandoria.INFILTRATE_DAVOI);
-
-    local Wait1DayRanperre = player:getCharVar("Wait1DayForRanperre_date");
-    local osdate = tonumber(os.date("%j"));
 
     if (player:getCharVar("aBoysDreamCS") == 8) then
         player:startEvent(88);
@@ -33,27 +30,26 @@ function onTrigger(player,npc)
         player:startEvent(90);
     elseif (player:getCharVar("UnderOathCS") == 8) then
         player:startEvent(89);
-    elseif (currentMission == tpz.mission.id.sandoria.INFILTRATE_DAVOI and infiltrateDavoi == false and MissionStatus == 0) then
+    elseif (currentMission == tpz.mission.id.sandoria.INFILTRATE_DAVOI and infiltrateDavoi == false and missionStatus == 0) then
         player:startEvent(553,0,tpz.ki.ROYAL_KNIGHTS_DAVOI_REPORT);
-    elseif (currentMission == tpz.mission.id.sandoria.INFILTRATE_DAVOI and MissionStatus == 4) then
+    elseif (currentMission == tpz.mission.id.sandoria.INFILTRATE_DAVOI and missionStatus == 4) then
         player:startEvent(554,0,tpz.ki.ROYAL_KNIGHTS_DAVOI_REPORT);
-    elseif (currentMission == tpz.mission.id.sandoria.THE_SHADOW_LORD and MissionStatus == 1) then
+    elseif (currentMission == tpz.mission.id.sandoria.THE_SHADOW_LORD and missionStatus == 1) then
         player:startEvent(547);
-    elseif (currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and MissionStatus == 0) then
+    elseif currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and missionStatus == 0 then
         player:startEvent(81);
-    elseif (currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and MissionStatus == 4 and Wait1DayRanperre ~= osdate) then -- Ready now.
+    elseif currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and missionStatus == 4 then
         player:startEvent(21);
-    elseif (currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and MissionStatus == 7) then
-        player:startEvent(21);
+    elseif currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and missionStatus == 6 then
+        player:startEvent(79) -- Optional 6-2 CS
     elseif (player:hasCompletedMission(SANDORIA,tpz.mission.id.sandoria.LIGHTBRINGER) and player:getRank() == 9 and player:getCharVar("Cutscenes_8-2") == 0) then
         player:startEvent(63);
     else
         player:startEvent(522);
     end
 
-    return 1;
-
-end;
+    return 1
+end
 
 function onEventUpdate(player,csid,option)
 end;
@@ -97,8 +93,7 @@ function onEventFinish(player,csid,option)
     elseif (csid == 81) then
         player:setCharVar("MissionStatus",1);
     elseif (csid == 21) then
-        player:setCharVar("Wait1DayForRanperre_date",0);
-        player:setCharVar("MissionStatus",8);
+        player:setCharVar("MissionStatus",5);
     elseif (csid == 63) then
         player:setCharVar("Cutscenes_8-2",1)
     end

--- a/scripts/zones/Chateau_dOraguille/npcs/_6h0.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/_6h0.lua
@@ -38,9 +38,9 @@ function onTrigger(player,npc)
         player:startEvent(547);
     elseif currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and missionStatus == 0 then
         player:startEvent(81);
-    elseif currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and missionStatus == 4 then
+    elseif currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and missionStatus == 5 then
         player:startEvent(21);
-    elseif currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and missionStatus == 6 then
+    elseif currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and missionStatus == 7 then
         player:startEvent(79) -- Optional 6-2 CS
     elseif (player:hasCompletedMission(SANDORIA,tpz.mission.id.sandoria.LIGHTBRINGER) and player:getRank() == 9 and player:getCharVar("Cutscenes_8-2") == 0) then
         player:startEvent(63);
@@ -93,7 +93,7 @@ function onEventFinish(player,csid,option)
     elseif (csid == 81) then
         player:setCharVar("MissionStatus",1);
     elseif (csid == 21) then
-        player:setCharVar("MissionStatus",5);
+        player:setCharVar("MissionStatus",6);
     elseif (csid == 63) then
         player:setCharVar("Cutscenes_8-2",1)
     end

--- a/scripts/zones/King_Ranperres_Tomb/mobs/Corrupted_Soffeil.lua
+++ b/scripts/zones/King_Ranperres_Tomb/mobs/Corrupted_Soffeil.lua
@@ -19,10 +19,10 @@ end
 
 function onMobDeath(mob, player, isKiller)
     if
-        GetMobByID(ID.mob.CORRUPTED_YORGOS):isDead() and
-        GetMobByID(ID.mob.CORRUPTED_ULBRIG):isDead() and
         player:getCurrentMission(SANDORIA) == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and
-        player:getCharVar("MissionStatus") == 1
+        player:getCharVar("MissionStatus") == 1 and
+        GetMobByID(ID.mob.CORRUPTED_YORGOS):isDead() and
+        GetMobByID(ID.mob.CORRUPTED_ULBRIG):isDead()
     then
         player:setCharVar("MissionStatus", 2)
     end

--- a/scripts/zones/King_Ranperres_Tomb/mobs/Corrupted_Soffeil.lua
+++ b/scripts/zones/King_Ranperres_Tomb/mobs/Corrupted_Soffeil.lua
@@ -24,6 +24,6 @@ function onMobDeath(mob, player, isKiller)
         player:getCurrentMission(SANDORIA) == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and
         player:getCharVar("MissionStatus") == 1
     then
-        player:setCharVar("Mission6-2MobKilled", 1)
+        player:setCharVar("MissionStatus", 2)
     end
 end

--- a/scripts/zones/King_Ranperres_Tomb/mobs/Corrupted_Ulbrig.lua
+++ b/scripts/zones/King_Ranperres_Tomb/mobs/Corrupted_Ulbrig.lua
@@ -24,6 +24,6 @@ function onMobDeath(mob, player, isKiller)
         player:getCurrentMission(SANDORIA) == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and
         player:getCharVar("MissionStatus") == 1
     then
-        player:setCharVar("Mission6-2MobKilled", 1)
+        player:setCharVar("MissionStatus", 2)
     end
 end

--- a/scripts/zones/King_Ranperres_Tomb/mobs/Corrupted_Ulbrig.lua
+++ b/scripts/zones/King_Ranperres_Tomb/mobs/Corrupted_Ulbrig.lua
@@ -18,11 +18,11 @@ function onMobSpawn(mob)
 end
 
 function onMobDeath(mob, player, isKiller)
-    if
-        GetMobByID(ID.mob.CORRUPTED_YORGOS):isDead() and
-        GetMobByID(ID.mob.CORRUPTED_SOFFEIL):isDead() and
+    if        
         player:getCurrentMission(SANDORIA) == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and
-        player:getCharVar("MissionStatus") == 1
+        player:getCharVar("MissionStatus") == 1 and
+        GetMobByID(ID.mob.CORRUPTED_YORGOS):isDead() and
+        GetMobByID(ID.mob.CORRUPTED_SOFFEIL):isDead()
     then
         player:setCharVar("MissionStatus", 2)
     end

--- a/scripts/zones/King_Ranperres_Tomb/mobs/Corrupted_Yorgos.lua
+++ b/scripts/zones/King_Ranperres_Tomb/mobs/Corrupted_Yorgos.lua
@@ -19,10 +19,10 @@ end
 
 function onMobDeath(mob, player, isKiller)
     if
-        GetMobByID(ID.mob.CORRUPTED_SOFFEIL):isDead() and
-        GetMobByID(ID.mob.CORRUPTED_ULBRIG):isDead() and
         player:getCurrentMission(SANDORIA) == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and
-        player:getCharVar("MissionStatus") == 1
+        player:getCharVar("MissionStatus") == 1 and
+        GetMobByID(ID.mob.CORRUPTED_SOFFEIL):isDead() and
+        GetMobByID(ID.mob.CORRUPTED_ULBRIG):isDead()
     then
         player:setCharVar("MissionStatus", 2)
     end

--- a/scripts/zones/King_Ranperres_Tomb/mobs/Corrupted_Yorgos.lua
+++ b/scripts/zones/King_Ranperres_Tomb/mobs/Corrupted_Yorgos.lua
@@ -24,6 +24,6 @@ function onMobDeath(mob, player, isKiller)
         player:getCurrentMission(SANDORIA) == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and
         player:getCharVar("MissionStatus") == 1
     then
-        player:setCharVar("Mission6-2MobKilled", 1)
+        player:setCharVar("MissionStatus", 2)
     end
 end

--- a/scripts/zones/King_Ranperres_Tomb/npcs/Tombstone.lua
+++ b/scripts/zones/King_Ranperres_Tomb/npcs/Tombstone.lua
@@ -32,7 +32,7 @@ function onTrigger(player, npc)
         else
             player:startEvent(2)
         end
-    elseif currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and missionStatus == 3 then
+    elseif currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and missionStatus == 3 and not player:hasKeyItem(tpz.ki.ANCIENT_SANDORIAN_BOOK) then
         player:startEvent(8)
     end
 

--- a/scripts/zones/King_Ranperres_Tomb/npcs/Tombstone.lua
+++ b/scripts/zones/King_Ranperres_Tomb/npcs/Tombstone.lua
@@ -22,18 +22,17 @@ end
 
 function onTrigger(player, npc)
     local currentMission = player:getCurrentMission(SANDORIA)
-    local MissionStatus = player:getCharVar("MissionStatus")
-    local BatHuntCompleted = player:hasCompletedMission(SANDORIA, tpz.mission.id.sandoria.BAT_HUNT) -- quest repeatable and clicking tombstone should not produce cutscene on repeat
+    local missionStatus = player:getCharVar("MissionStatus")
     local X = npc:getXPos()
     local Z = npc:getZPos()
 
     if X >= -1 and X <= 1 and Z >= -106 and Z <= -102 then
-        if currentMission == tpz.mission.id.sandoria.BAT_HUNT and MissionStatus <= 1 then
+        if currentMission == tpz.mission.id.sandoria.BAT_HUNT and missionStatus <= 1 then
             player:startEvent(4)
         else
             player:startEvent(2)
         end
-    elseif currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and MissionStatus == 2 then
+    elseif currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and missionStatus == 3 then
         player:startEvent(8)
     end
 
@@ -57,7 +56,6 @@ function onEventFinish(player, csid, option)
         player:confirmTrade()
         player:setCharVar("OfferingWaterOK", 1)
     elseif csid == 8 then
-        player:setCharVar("MissionStatus", 3)
         npcUtil.giveKeyItem(player, tpz.ki.ANCIENT_SANDORIAN_BOOK)
     end
 end

--- a/scripts/zones/King_Ranperres_Tomb/npcs/_5a0.lua
+++ b/scripts/zones/King_Ranperres_Tomb/npcs/_5a0.lua
@@ -12,30 +12,28 @@ end
 
 function onTrigger(player, npc)
     local currentMission = player:getCurrentMission(SANDORIA)
-    local MissionStatus = player:getCharVar("MissionStatus")
+    local missionStatus = player:getCharVar("MissionStatus")
 
     if
         currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and
-        MissionStatus == 1 and
+        missionStatus == 1 and
         not GetMobByID(ID.mob.CORRUPTED_YORGOS):isSpawned() and
         not GetMobByID(ID.mob.CORRUPTED_SOFFEIL):isSpawned() and
         not GetMobByID(ID.mob.CORRUPTED_ULBRIG):isSpawned()
     then
-        if player:getCharVar("Mission6-2MobKilled") == 1 then
-            player:setCharVar("Mission6-2MobKilled", 0)
-            player:setCharVar("MissionStatus", 2)
-        else
-            SpawnMob(ID.mob.CORRUPTED_YORGOS)
-            SpawnMob(ID.mob.CORRUPTED_SOFFEIL)
-            SpawnMob(ID.mob.CORRUPTED_ULBRIG)
-        end
-    elseif currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and MissionStatus == 2 then
-        player:startEvent(6)
-    elseif currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and MissionStatus == 3 then
-        player:startEvent(7)
-    elseif currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and MissionStatus == 8 then
+        SpawnMob(ID.mob.CORRUPTED_YORGOS)
+        SpawnMob(ID.mob.CORRUPTED_SOFFEIL)
+        SpawnMob(ID.mob.CORRUPTED_ULBRIG)
+    end
+    if currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and missionStatus == 2 then -- NMs killed
+        player:setCharVar("MissionStatus", 3)
+    elseif currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and missionStatus == 3 and player:getXPos() > -39.019 then -- standing outside
+        player:startEvent(6) -- enter cutscene
+    elseif currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and missionStatus == 3 then -- inside
+        player:startEvent(7) -- exit cutscene
+    elseif currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and missionStatus == 5 then
         player:startEvent(5)
-    elseif currentMission == tpz.mission.id.sandoria.THE_HEIR_TO_THE_LIGHT and MissionStatus == 6 then
+    elseif currentMission == tpz.mission.id.sandoria.THE_HEIR_TO_THE_LIGHT and missionStatus == 6 then
         player:startEvent(14)
     else
         player:messageSpecial(ID.text.HEAVY_DOOR)
@@ -47,7 +45,7 @@ end
 
 function onEventFinish(player, csid, option)
     if csid == 5 then
-        player:setCharVar("MissionStatus", 9)
+        player:setCharVar("MissionStatus", 6)
     elseif csid == 14 then
         player:setCharVar("MissionStatus", 7)
         -- at this point 3 optional cs are available and open until watched (add 3 var to char?)

--- a/scripts/zones/King_Ranperres_Tomb/npcs/_5a0.lua
+++ b/scripts/zones/King_Ranperres_Tomb/npcs/_5a0.lua
@@ -31,7 +31,7 @@ function onTrigger(player, npc)
         player:startEvent(6) -- enter cutscene
     elseif currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and missionStatus == 3 then -- inside
         player:startEvent(7) -- exit cutscene
-    elseif currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and missionStatus == 5 then
+    elseif currentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and missionStatus == 6 then
         player:startEvent(5)
     elseif currentMission == tpz.mission.id.sandoria.THE_HEIR_TO_THE_LIGHT and missionStatus == 6 then
         player:startEvent(14)
@@ -45,7 +45,7 @@ end
 
 function onEventFinish(player, csid, option)
     if csid == 5 then
-        player:setCharVar("MissionStatus", 6)
+        player:setCharVar("MissionStatus", 7)
     elseif csid == 14 then
         player:setCharVar("MissionStatus", 7)
         -- at this point 3 optional cs are available and open until watched (add 3 var to char?)

--- a/scripts/zones/Northern_San_dOria/npcs/Grilau.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Grilau.lua
@@ -60,13 +60,15 @@ function onTrigger(player,npc)
             end
         elseif (pRank == 1 and player:hasCompletedMission(SANDORIA,tpz.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS) == false) then
             player:startEvent(1000); -- Start First Mission "Smash the Orcish scouts"
-        elseif (player:hasKeyItem(tpz.ki.ANCIENT_SANDORIAN_BOOK)) then
+        elseif CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:hasKeyItem(tpz.ki.ANCIENT_SANDORIAN_BOOK) then
             player:startEvent(1035);
-        elseif (CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus",4) and tonumber(os.date("%j")) == player:getCharVar("Wait1DayForRanperre_date")) then
-            player:startEvent(1037);
-        elseif (CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus") == 6) then
-            player:startEvent(1039);
-        elseif (CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus") == 9) then
+        elseif CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus") == 3 then
+            if player:getLocalVar("RanperresRest") == 1 then -- Requires player to zone.
+                player:startEvent(1037)
+            else
+                player:startEvent(1039)
+            end
+        elseif CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus") == 6 then
             player:startEvent(1033);
         elseif (CurrentMission ~= tpz.mission.id.sandoria.THE_SECRET_WEAPON and pRank == 7 and PresOfPapsqueCompleted == true and getMissionRankPoints(player,19) == 1 and player:getCharVar("SecretWeaponStatus") == 0) then
             player:startEvent(52);
@@ -93,14 +95,10 @@ function onEventFinish(player,csid,option)
 
     finishMissionTimeline(player,1,csid,option);
     if (csid == 1035) then
-        player:setCharVar("MissionStatus",4);
         player:delKeyItem(tpz.ki.ANCIENT_SANDORIAN_BOOK);
-        player:setCharVar("Wait1DayForRanperre_date", os.date("%j"));
-    elseif (csid == 1037) then
-        player:setCharVar("MissionStatus",6);
+        player:setLocalVar("RanperresRest", 1) -- set to require a zone
     elseif (csid == 1039) then
-        player:setCharVar("MissionStatus",7);
-        player:setCharVar("Wait1DayForRanperre_date",0);
+        player:setCharVar("MissionStatus",4)
     elseif (csid == 1033) then
         finishMissionTimeline(player,2,csid,option);
     elseif (csid == 52) then

--- a/scripts/zones/Northern_San_dOria/npcs/Grilau.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Grilau.lua
@@ -62,13 +62,13 @@ function onTrigger(player,npc)
             player:startEvent(1000); -- Start First Mission "Smash the Orcish scouts"
         elseif CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:hasKeyItem(tpz.ki.ANCIENT_SANDORIAN_BOOK) then
             player:startEvent(1035);
-        elseif CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus") == 3 then
+        elseif CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus") == 4 then
             if player:getLocalVar("RanperresRest") == 1 then -- Requires player to zone.
                 player:startEvent(1037)
             else
                 player:startEvent(1039)
             end
-        elseif CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus") == 6 then
+        elseif CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus") == 7 then
             player:startEvent(1033);
         elseif (CurrentMission ~= tpz.mission.id.sandoria.THE_SECRET_WEAPON and pRank == 7 and PresOfPapsqueCompleted == true and getMissionRankPoints(player,19) == 1 and player:getCharVar("SecretWeaponStatus") == 0) then
             player:startEvent(52);
@@ -97,8 +97,9 @@ function onEventFinish(player,csid,option)
     if (csid == 1035) then
         player:delKeyItem(tpz.ki.ANCIENT_SANDORIAN_BOOK);
         player:setLocalVar("RanperresRest", 1) -- set to require a zone
-    elseif (csid == 1039) then
         player:setCharVar("MissionStatus",4)
+    elseif (csid == 1039) then
+        player:setCharVar("MissionStatus",5)
     elseif (csid == 1033) then
         finishMissionTimeline(player,2,csid,option);
     elseif (csid == 52) then

--- a/scripts/zones/Southern_San_dOria/npcs/Ambrotien.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Ambrotien.lua
@@ -62,13 +62,13 @@ function onTrigger(player,npc)
             player:startEvent(2000); -- Start First Mission "Smash the Orcish scouts"
         elseif CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:hasKeyItem(tpz.ki.ANCIENT_SANDORIAN_BOOK) then
             player:startEvent(1036);
-        elseif CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus") == 3 then
+        elseif CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus") == 4 then
             if player:getLocalVar("RanperresRest") == 1 then -- Requires player to zone.
                 player:startEvent(1038)
             else
                 player:startEvent(1040)
             end
-        elseif CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus") == 6 then
+        elseif CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus") == 7 then
             player:startEvent(1034);
         elseif (CurrentMission ~= tpz.mission.id.sandoria.THE_SECRET_WEAPON and pRank == 7 and PresOfPapsqueCompleted == true and getMissionRankPoints(player,19) == 1 and player:getCharVar("SecretWeaponStatus") == 0) then
             player:startEvent(62);
@@ -97,8 +97,9 @@ function onEventFinish(player,csid,option)
     if (csid == 1036) then
         player:delKeyItem(tpz.ki.ANCIENT_SANDORIAN_BOOK);
         player:setLocalVar("RanperresRest", 1) -- set to require a zone
-    elseif (csid == 1040) then
         player:setCharVar("MissionStatus",4)
+    elseif (csid == 1040) then
+        player:setCharVar("MissionStatus",5)
     elseif (csid == 1034) then
         finishMissionTimeline(player,1,csid,option);
     elseif (csid == 62) then

--- a/scripts/zones/Southern_San_dOria/npcs/Ambrotien.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Ambrotien.lua
@@ -60,15 +60,15 @@ function onTrigger(player,npc)
             end
         elseif (pRank == 1 and player:hasCompletedMission(SANDORIA,tpz.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS) == false) then
             player:startEvent(2000); -- Start First Mission "Smash the Orcish scouts"
-        elseif (player:hasKeyItem(tpz.ki.ANCIENT_SANDORIAN_BOOK)) then
+        elseif CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:hasKeyItem(tpz.ki.ANCIENT_SANDORIAN_BOOK) then
             player:startEvent(1036);
-        elseif (CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus",4) and tonumber(os.date("%j")) == player:getCharVar("Wait1DayForRanperre_date")) then -- Not ready yet
-            player:startEvent(1038);
-        elseif (CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus") == 4 and tonumber(os.date("%j")) ~= player:getCharVar("Wait1DayForRanperre_date")) then -- Ready now.
-            player:startEvent(1040);
-        elseif (CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus") == 6) then
-            player:startEvent(1040);
-        elseif (CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus") == 9) then
+        elseif CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus") == 3 then
+            if player:getLocalVar("RanperresRest") == 1 then -- Requires player to zone.
+                player:startEvent(1038)
+            else
+                player:startEvent(1040)
+            end
+        elseif CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus") == 6 then
             player:startEvent(1034);
         elseif (CurrentMission ~= tpz.mission.id.sandoria.THE_SECRET_WEAPON and pRank == 7 and PresOfPapsqueCompleted == true and getMissionRankPoints(player,19) == 1 and player:getCharVar("SecretWeaponStatus") == 0) then
             player:startEvent(62);
@@ -95,14 +95,10 @@ function onEventFinish(player,csid,option)
 
     finishMissionTimeline(player,2,csid,option);
     if (csid == 1036) then
-        player:setCharVar("MissionStatus",4);
         player:delKeyItem(tpz.ki.ANCIENT_SANDORIAN_BOOK);
-        player:setCharVar("Wait1DayForRanperre_date", os.date("%j"));
-    elseif (csid == 1038) then
-        player:setCharVar("MissionStatus",6);
+        player:setLocalVar("RanperresRest", 1) -- set to require a zone
     elseif (csid == 1040) then
-        player:setCharVar("MissionStatus",7);
-        player:setCharVar("Wait1DayForRanperre_date",0);
+        player:setCharVar("MissionStatus",4)
     elseif (csid == 1034) then
         finishMissionTimeline(player,1,csid,option);
     elseif (csid == 62) then

--- a/scripts/zones/Southern_San_dOria/npcs/Endracion.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Endracion.lua
@@ -61,13 +61,13 @@ local PresOfPapsqueCompleted = player:hasCompletedMission(SANDORIA,tpz.mission.i
             player:startEvent(1000); -- Start First Mission "Smash the Orcish scouts"
         elseif CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:hasKeyItem(tpz.ki.ANCIENT_SANDORIAN_BOOK) then
             player:startEvent(1035);
-        elseif CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus") == 3 then
+        elseif CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus") == 4 then
             if player:getLocalVar("RanperresRest") == 1 then -- Requires player to zone.
                 player:startEvent(1037)
             else
                 player:startEvent(1039)
             end
-        elseif CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus") == 6 then
+        elseif CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus") == 7 then
             player:startEvent(1033);
         elseif (CurrentMission ~= tpz.mission.id.sandoria.THE_SECRET_WEAPON and pRank == 7 and PresOfPapsqueCompleted == true and getMissionRankPoints(player,19) == 1 and player:getCharVar("SecretWeaponStatus") == 0) then
             player:startEvent(61);
@@ -96,8 +96,9 @@ function onEventFinish(player,csid,option)
     if (csid == 1035) then
         player:delKeyItem(tpz.ki.ANCIENT_SANDORIAN_BOOK);
         player:setLocalVar("RanperresRest", 1) -- set to require a zone
-    elseif (csid == 1039) then
         player:setCharVar("MissionStatus",4)
+    elseif (csid == 1039) then
+        player:setCharVar("MissionStatus",5)
     elseif (csid == 1033) then
         finishMissionTimeline(player,2,csid,option);
     elseif (csid == 61) then

--- a/scripts/zones/Southern_San_dOria/npcs/Endracion.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Endracion.lua
@@ -59,21 +59,21 @@ local PresOfPapsqueCompleted = player:hasCompletedMission(SANDORIA,tpz.mission.i
             end
         elseif (pRank == 1 and player:hasCompletedMission(SANDORIA,tpz.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS) == false) then
             player:startEvent(1000); -- Start First Mission "Smash the Orcish scouts"
-        elseif (player:hasKeyItem(tpz.ki.ANCIENT_SANDORIAN_BOOK)) then
+        elseif CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:hasKeyItem(tpz.ki.ANCIENT_SANDORIAN_BOOK) then
             player:startEvent(1035);
-        elseif (CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus",4) and tonumber(os.date("%j")) == player:getCharVar("Wait1DayForRanperre_date")) then
-            player:startEvent(1037);
-        elseif (CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus") == 4 and tonumber(os.date("%j")) ~= player:getCharVar("Wait1DayForRanperre_date")) then -- Ready now.
-            player:startEvent(1039);
-        elseif (CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus") == 6) then
-            player:startEvent(1039);
-        elseif (CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus") == 9) then
+        elseif CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus") == 3 then
+            if player:getLocalVar("RanperresRest") == 1 then -- Requires player to zone.
+                player:startEvent(1037)
+            else
+                player:startEvent(1039)
+            end
+        elseif CurrentMission == tpz.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getCharVar("MissionStatus") == 6 then
             player:startEvent(1033);
         elseif (CurrentMission ~= tpz.mission.id.sandoria.THE_SECRET_WEAPON and pRank == 7 and PresOfPapsqueCompleted == true and getMissionRankPoints(player,19) == 1 and player:getCharVar("SecretWeaponStatus") == 0) then
             player:startEvent(61);
         elseif (CurrentMission == tpz.mission.id.sandoria.THE_SECRET_WEAPON and player:getCharVar("SecretWeaponStatus") == 3) then
             player:startEvent(1043);
-        elseif ((CurrentMission ~= tpz.mission.id.sandoria.NONE) and not (player:getCharVar("MissionStatus") == 8)) then
+        elseif (CurrentMission ~= tpz.mission.id.sandoria.NONE) then
             player:startEvent(1001); -- Have mission already activated
         else
             local mission_mask, repeat_mask = getMissionMask(player);
@@ -94,14 +94,10 @@ function onEventFinish(player,csid,option)
 
     finishMissionTimeline(player,1,csid,option);
     if (csid == 1035) then
-        player:setCharVar("MissionStatus",4);
         player:delKeyItem(tpz.ki.ANCIENT_SANDORIAN_BOOK);
-        player:setCharVar("Wait1DayForRanperre_date", os.date("%j"));
-    elseif (csid == 1037) then
-        player:setCharVar("MissionStatus",6);
+        player:setLocalVar("RanperresRest", 1) -- set to require a zone
     elseif (csid == 1039) then
-        player:setCharVar("MissionStatus",7);
-        player:setCharVar("Wait1DayForRanperre_date",0);
+        player:setCharVar("MissionStatus",4)
     elseif (csid == 1033) then
         finishMissionTimeline(player,2,csid,option);
     elseif (csid == 61) then


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Improves some of the code for these three mission giver npcs, and updates Ranperre's final rest to require only a zone.  Closes Issue #724 

These npcs can be further improved, and on this mission some "MissionStatus" vars are skipped (namely 6 was deleted here because it didn't quite make sense), but the quest is in working order.