### PR TITLE
Fixes pet not despawning in combat when master dies.

### DIFF
--- a/src/map/ai/controllers/pet_controller.cpp
+++ b/src/map/ai/controllers/pet_controller.cpp
@@ -36,21 +36,17 @@ CPetController::CPetController(CPetEntity* _PPet) :
 
 void CPetController::Tick(time_point tick)
 {
-    if (PPet->isCharmed && tick > PPet->charmTime)
+    if ((PPet->isCharmed && tick > PPet->charmTime) || ((PPet->PMaster == nullptr || PPet->PMaster->isDead()) && PPet->isAlive()))
     {
         petutils::DespawnPet(PPet->PMaster);
         return;
     }
+    
     CMobController::Tick(tick);
 }
 
 void CPetController::DoRoamTick(time_point tick)
 {
-    if ((PPet->PMaster == nullptr || PPet->PMaster->isDead()) && PPet->isAlive()) {
-        PPet->Die();
-        return;
-    }
-
     //automaton, wyvern
     if (PPet->getPetType() == PETTYPE_WYVERN || PPet->getPetType() == PETTYPE_AUTOMATON) {
         if (PetIsHealing()) {


### PR DESCRIPTION
Co-contribution credit for diagnosis and fix to cocosolos!

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

DoRoamTick is where the original despawn pet code was when the master dies, this doesn't fire as intended while the pet is in combat.  It's been improved and moved to on Tick so that it's always being checked, regardless of pet combat status.

Tested with BST charmed/jug, shiva, puppet, and wyvern.