### PR TITLE
Fix BRD song overwrite bug

### DIFF
--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -830,7 +830,7 @@ bool CStatusEffectContainer::ApplyBardEffect(CStatusEffect* PStatusEffect, uint8
                 m_StatusEffectList.at(i)->GetStatusID() == PStatusEffect->GetStatusID()) {//remove same tier/type, if one exists
                 DelStatusEffectByTier(PStatusEffect->GetStatusID(), PStatusEffect->GetTier());
             }
-            if (m_StatusEffectList.at(i)->GetSubID() == PStatusEffect->GetSubID()) {//YOUR BRD effect
+            else if (m_StatusEffectList.at(i)->GetSubID() == PStatusEffect->GetSubID()) {//YOUR BRD effect
                 numOfEffects++;
                 if (!oldestSong) {
                     oldestSong = m_StatusEffectList.at(i);

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -827,11 +827,8 @@ bool CStatusEffectContainer::ApplyBardEffect(CStatusEffect* PStatusEffect, uint8
             m_StatusEffectList.at(i)->GetStatusID() <= EFFECT_NOCTURNE) //is a brd effect
         {
             if (m_StatusEffectList.at(i)->GetTier() == PStatusEffect->GetTier() &&
-                m_StatusEffectList.at(i)->GetStatusID() == PStatusEffect->GetStatusID()) {//same tier/type, overwrite
-                    //OVERWRITE
+                m_StatusEffectList.at(i)->GetStatusID() == PStatusEffect->GetStatusID()) {//remove same tier/type, if one exists
                 DelStatusEffectByTier(PStatusEffect->GetStatusID(), PStatusEffect->GetTier());
-                AddStatusEffect(PStatusEffect);
-                return true;
             }
             if (m_StatusEffectList.at(i)->GetSubID() == PStatusEffect->GetSubID()) {//YOUR BRD effect
                 numOfEffects++;


### PR DESCRIPTION
This PR fixes a bug where BRDs are able to keep up many more than the allowed max amount of songs.

With the current implementation, if BRD A overwrites a song of the same tier/type from BRD B, the check for maximum amount of songs allowed for BRD A is never performed, since it just overwrites it immediately.
This leaves BRD B free to sing a new song, since he doesn't own that active song anymore. Rinse and repeat, and you can get as many songs active as the casting time allows with just 2 BRDs.

Example:
```
A sings March1
A sings March2
B sings Minuet1
B sings Minuet2
A overwrites Minuet1
A overwrites Minuet2
[at this point there's 4 songs up, all owned by BRD A]
B sings Madrigal1
B sings Madrigal2
[at this point there's 6 songs up between 2 BRDs]
[rinse and repeat, with BRD A overwriting songs and BRD B singing new songs]
```

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

