### PR TITLE
Remove automatic multipliers when mob is marked as an NM

### DIFF
--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -342,14 +342,6 @@ void CalculateStats(CMobEntity * PMob)
         if(PMob->MPmodifier == 0)
         {
             PMob->health.maxmp = (int16)(18.2 * pow(mLvl,1.1075) * scale) + 10;
-            if(isNM)
-            {
-                PMob->health.maxmp = (int32)(PMob->health.maxmp * 1.5f);
-                if(mLvl>75)
-                {
-                    PMob->health.maxmp = (int32)(PMob->health.maxmp * 1.5f);
-                }
-            }
         }
         else
         {
@@ -434,13 +426,13 @@ void CalculateStats(CMobEntity * PMob)
 
     if(isNM)
     {
-        PMob->stats.STR = (uint16)(PMob->stats.STR * 1.5f * map_config.nm_stat_multiplier);
-        PMob->stats.DEX = (uint16)(PMob->stats.DEX * 1.5f * map_config.nm_stat_multiplier);
-        PMob->stats.VIT = (uint16)(PMob->stats.VIT * 1.5f * map_config.nm_stat_multiplier);
-        PMob->stats.AGI = (uint16)(PMob->stats.AGI * 1.5f * map_config.nm_stat_multiplier);
-        PMob->stats.INT = (uint16)(PMob->stats.INT * 1.5f * map_config.nm_stat_multiplier);
-        PMob->stats.MND = (uint16)(PMob->stats.MND * 1.5f * map_config.nm_stat_multiplier);
-        PMob->stats.CHR = (uint16)(PMob->stats.CHR * 1.5f * map_config.nm_stat_multiplier);
+        PMob->stats.STR = (uint16)(PMob->stats.STR * map_config.nm_stat_multiplier);
+        PMob->stats.DEX = (uint16)(PMob->stats.DEX * map_config.nm_stat_multiplier);
+        PMob->stats.VIT = (uint16)(PMob->stats.VIT * map_config.nm_stat_multiplier);
+        PMob->stats.AGI = (uint16)(PMob->stats.AGI * map_config.nm_stat_multiplier);
+        PMob->stats.INT = (uint16)(PMob->stats.INT * map_config.nm_stat_multiplier);
+        PMob->stats.MND = (uint16)(PMob->stats.MND * map_config.nm_stat_multiplier);
+        PMob->stats.CHR = (uint16)(PMob->stats.CHR * map_config.nm_stat_multiplier);
     }
     else
     {

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -278,15 +278,6 @@ void CalculateStats(CMobEntity * PMob)
 
 
         PMob->health.maxhp = (int16)(base * pow(mLvl, growth) * hpScale);
-
-        if(isNM)
-        {
-            PMob->health.maxhp = (int32)(PMob->health.maxhp * 2.0f);
-            if(mLvl > 75){
-                PMob->health.maxhp = (int32)(PMob->health.maxhp * 2.5f);
-            }
-        }
-
     }
     else
     {


### PR DESCRIPTION
This was entirely made up.

NMs which have been CONFIRMED to have HP values that aren't in line with the standard growth scale should have their HP manually set instead.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

