### PR TITLE
Entity positioning

### DIFF
--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -392,6 +392,188 @@ bool CPathFind::FindClosestPath(const position_t& start, const position_t& end)
     return true;
 }
 
+void CPathFind::PathBehindTarget(const position_t& pos, uint16 modelSize)
+{
+    position_t entityPos = m_PTarget->loc.p;
+    uint16 offset = modelSize + 4;
+    float rotation = ((float)pos.rotation / 256) * 2 * (float)M_PI;
+
+    rotation += (float)M_PI;
+
+    position_t newPos;
+    newPos.x = pos.x + cosf(2 * (float)M_PI - rotation) * offset;
+    newPos.y = pos.y;
+    newPos.z = pos.z + sinf(2 * (float)M_PI - rotation) * offset;
+
+    PathTo(newPos, PATHFLAG_SCRIPT, false);
+    m_PTarget->updatemask |= UPDATE_POS;
+}
+
+void CPathFind::PathInfrontTarget(const position_t& pos, uint16 modelSize)
+{
+    position_t entityPos = m_PTarget->loc.p;
+    uint16 offset = modelSize + 4;
+    float rotation = ((float)pos.rotation / 256) * 2 * (float)M_PI;
+
+    position_t newPos;
+    newPos.x = pos.x + cosf(2 * (float)M_PI - rotation) * offset;
+    newPos.y = pos.y;
+    newPos.z = pos.z + sinf(2 * (float)M_PI - rotation) * offset;
+
+    PathTo(newPos, PATHFLAG_SCRIPT, false);
+    m_PTarget->updatemask |= UPDATE_POS;
+}
+
+void CPathFind::PathToSafeDistance(const position_t& pos, uint16 modelSize)
+{
+    position_t entityPos = m_PTarget->loc.p;
+    uint16 offset = modelSize + 22;
+    position_t newPos;
+
+    if (isNavMeshEnabled())
+    {
+        newPos = m_PTarget->loc.zone->m_navMesh->findRandomPosition(pos, (float)offset).second;
+    }
+    else
+    {
+        newPos.x = pos.x + cosf(2 * (float)M_PI) * offset;
+        newPos.y = pos.y;
+        newPos.z = pos.z + sinf(2 * (float)M_PI) * offset;
+    }
+
+    float dx = pos.x - m_PTarget->loc.p.x;
+    float dz = pos.z - m_PTarget->loc.p.z;
+    float distance = sqrt(dx * dx + dz * dz);
+
+    if (distance < offset)
+    {
+        if (ValidPosition(newPos))
+        {
+            PathTo(newPos, PATHFLAG_SCRIPT, false);
+            m_PTarget->updatemask |= UPDATE_POS;
+        }
+    }  
+}
+
+void CPathFind::PathToMeeleRange(const position_t& pos, uint16 modelSize)
+{
+    position_t entityPos = m_PTarget->loc.p;
+    uint16 offset = modelSize + 4;
+    position_t newPos;
+    newPos.x = pos.x + cosf(2 * (float)M_PI) * offset;
+    newPos.y = pos.y;
+    newPos.z = pos.z + sinf(2 * (float)M_PI) * offset;
+
+    float dx = pos.x - m_PTarget->loc.p.x;
+    float dz = pos.z - m_PTarget->loc.p.z;
+    float distance = sqrt(dx * dx + dz * dz);
+
+    if (distance > offset)
+    {
+        PathTo(newPos, PATHFLAG_SCRIPT, false);
+        m_PTarget->updatemask |= UPDATE_POS;
+    }
+}
+
+void CPathFind::PathToCastingRange(const position_t& pos, uint16 modelSize)
+{
+    position_t entityPos = m_PTarget->loc.p;
+    uint16 offset = modelSize + 18;
+    position_t newPos;
+
+    if (isNavMeshEnabled())
+    {
+        newPos = m_PTarget->loc.zone->m_navMesh->findRandomPosition(pos, (float)offset).second;
+    }
+    else
+    {
+        newPos.x = pos.x + cosf(2 * (float)M_PI) * offset;
+        newPos.y = pos.y;
+        newPos.z = pos.z + sinf(2 * (float)M_PI) * offset;
+    }
+
+    float dx = pos.x - m_PTarget->loc.p.x;
+    float dz = pos.z - m_PTarget->loc.p.z;
+    float distance = sqrt(dx * dx + dz * dz);
+
+    if (distance < modelSize + 10 || distance > offset)
+    {
+        if (ValidPosition(newPos))
+        {
+            PathTo(newPos, PATHFLAG_SCRIPT, false);
+            m_PTarget->updatemask |= UPDATE_POS;
+        }
+    }
+}
+
+void CPathFind::PathToSongRollRange(const position_t& pos, uint16 modelSize)
+{
+    position_t entityPos = m_PTarget->loc.p;
+    uint16 offset = modelSize + 2;
+    position_t newPos;
+    newPos.x = pos.x + cosf(2 * (float)M_PI) * offset;
+    newPos.y = pos.y;
+    newPos.z = pos.z + sinf(2 * (float)M_PI) * offset;
+
+    float dx = pos.x - m_PTarget->loc.p.x;
+    float dz = pos.z - m_PTarget->loc.p.z;
+    float distance = sqrt(dx * dx + dz * dz);
+
+    if (distance > offset)
+    {
+        PathTo(newPos, PATHFLAG_SCRIPT, false);
+        m_PTarget->updatemask |= UPDATE_POS;
+    }
+}
+
+void CPathFind::PathToRangedRange(const position_t& pos, uint16 modelSize)
+{
+    position_t entityPos = m_PTarget->loc.p;
+    uint16 offset = modelSize + 15;
+    position_t newPos;
+
+    if (isNavMeshEnabled())
+    {
+        newPos = m_PTarget->loc.zone->m_navMesh->findRandomPosition(pos, (float)offset).second;
+    }
+    else
+    {
+        newPos.x = pos.x + cosf(2 * (float)M_PI) * offset;
+        newPos.y = pos.y;
+        newPos.z = pos.z + sinf(2 * (float)M_PI) * offset;
+    }
+
+    float dx = pos.x - m_PTarget->loc.p.x;
+    float dz = pos.z - m_PTarget->loc.p.z;
+    float distance = sqrt(dx * dx + dz * dz);
+
+    if (distance > offset || distance < modelSize + 5)
+    {
+        if (ValidPosition(newPos))
+        {
+            PathTo(newPos, PATHFLAG_SCRIPT, false);
+            m_PTarget->updatemask |= UPDATE_POS;
+        } 
+    } 
+}
+
+void CPathFind::PathToCoverTarget(const position_t& pos, const position_t& coverPos)
+{
+    position_t entityPos = m_PTarget->loc.p;
+    float rotation = ((float)pos.rotation / 256) * 2 * (float)M_PI;
+    float dx = pos.x - coverPos.x;
+    float dz = pos.z - coverPos.z;
+    float midpoint = sqrt(dx * dx + dz * dz) / 2;
+
+    position_t newPos;
+    newPos.x = pos.x + cosf(2 * (float)M_PI - rotation) * midpoint;
+    newPos.y = pos.y;
+    newPos.z = pos.z + sinf(2 * (float)M_PI - rotation) * midpoint;
+
+    PathTo(newPos, PATHFLAG_SCRIPT, false);
+    m_PTarget->updatemask |= UPDATE_POS;
+}
+
 void CPathFind::LookAt(const position_t& point)
 {
     // don't look if i'm at that point

--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -455,7 +455,7 @@ void CPathFind::PathToSafeDistance(const position_t& pos, uint16 modelSize)
     }  
 }
 
-void CPathFind::PathToMeeleRange(const position_t& pos, uint16 modelSize)
+void CPathFind::PathToMeleeRange(const position_t& pos, uint16 modelSize)
 {
     position_t entityPos = m_PTarget->loc.p;
     uint16 offset = modelSize + 4;

--- a/src/map/ai/helpers/pathfind.h
+++ b/src/map/ai/helpers/pathfind.h
@@ -88,6 +88,22 @@ class CPathFind
     // tells entity to take one step towards position
     void StepTo(const position_t& pos, bool run = false);
 
+    void PathBehindTarget(const position_t& pos, uint16 modelSize);
+
+    void PathInfrontTarget(const position_t& pos, uint16 modelSize);
+
+    void PathToSafeDistance(const position_t& pos, uint16 modelSize);
+
+    void PathToMeeleRange(const position_t& pos, uint16 modelSize);
+
+    void PathToCastingRange(const position_t& pos, uint16 modelSize);
+
+    void PathToSongRollRange(const position_t& pos, uint16 modelSize);
+
+    void PathToRangedRange(const position_t& pos, uint16 modelSize);
+
+    void PathToCoverTarget(const position_t& pos, const position_t& coverPos);
+
     // checks if mob is currently following a path
     bool IsFollowingPath();
     bool IsFollowingScriptedPath();

--- a/src/map/ai/helpers/pathfind.h
+++ b/src/map/ai/helpers/pathfind.h
@@ -94,7 +94,7 @@ class CPathFind
 
     void PathToSafeDistance(const position_t& pos, uint16 modelSize);
 
-    void PathToMeeleRange(const position_t& pos, uint16 modelSize);
+    void PathToMeleeRange(const position_t& pos, uint16 modelSize);
 
     void PathToCastingRange(const position_t& pos, uint16 modelSize);
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -1904,7 +1904,7 @@ inline int32 CLuaBaseEntity::pathToSafeDistance(lua_State* L)
 *  Example : mob:pathToMeeleRange(mob:getTarget())
 *  Notes   : keep calling this function to keep the position
 ************************************************************************/
-inline int32 CLuaBaseEntity::pathToMeeleRange(lua_State* L)
+inline int32 CLuaBaseEntity::pathToMeleeRange(lua_State* L)
 {
     TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
     TPZ_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_PC);
@@ -14443,7 +14443,7 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,pathBehindTarget),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,pathInfrontTarget),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,pathToSafeDistance),
-    LUNAR_DECLARE_METHOD(CLuaBaseEntity,pathToMeeleRange),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,pathToMeleeRange),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,pathToCastingRange),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,pathToSongRollRange),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,pathToRangedRange),

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -1812,6 +1812,240 @@ inline int32 CLuaBaseEntity::pathTo(lua_State* L)
 }
 
 /************************************************************************
+*  Function: pathBehindTarget()
+*  Purpose : Makes a non-PC move behind a target without changing action
+*  Example : mob:pathBehindTarget(mob:getTarget())
+*  Notes   : keep calling this function to keep the position
+************************************************************************/
+inline int32 CLuaBaseEntity::pathBehindTarget(lua_State* L)
+{
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_PC);
+    TPZ_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isuserdata(L, 1));
+
+    if (m_PBaseEntity != nullptr)
+    {
+        CLuaBaseEntity* PLuaBaseEntity = Lunar<CLuaBaseEntity>::check(L, 1);
+        CBattleEntity* PEntity = (CBattleEntity*)PLuaBaseEntity->GetBaseEntity();
+
+        if (PEntity != nullptr)
+        {
+            if (m_PBaseEntity->PAI->PathFind)
+            {
+                m_PBaseEntity->PAI->PathFind->PathBehindTarget(PEntity->loc.p, PEntity->m_ModelSize);
+            }
+        }
+    }
+    
+    return 0;
+}
+
+/************************************************************************
+*  Function: pathInfrontTarget()
+*  Purpose : Makes a non-PC move infront of a target without changing action
+*  Example : mob:pathInfrontTarget(mob:getTarget())
+*  Notes   : keep calling this function to keep the position
+************************************************************************/
+inline int32 CLuaBaseEntity::pathInfrontTarget(lua_State* L)
+{
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_PC);
+    TPZ_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isuserdata(L, 1));
+
+    if (m_PBaseEntity != nullptr)
+    {
+        CLuaBaseEntity* PLuaBaseEntity = Lunar<CLuaBaseEntity>::check(L, 1);
+        CBattleEntity* PEntity = (CBattleEntity*)PLuaBaseEntity->GetBaseEntity();
+
+        if (PEntity != nullptr)
+        {
+            if (m_PBaseEntity->PAI->PathFind)
+            {
+                m_PBaseEntity->PAI->PathFind->PathInfrontTarget(PEntity->loc.p, PEntity->m_ModelSize);
+            }
+        }
+    }
+    
+    return 0;
+}
+
+/************************************************************************
+*  Function: pathToSafeDistance()
+*  Purpose : Makes a non-PC move to a safe distance away from a target
+*  Example : mob:pathToSafeDistance(mob:getTarget())
+*  Notes   : keep calling this function to keep the position
+************************************************************************/
+inline int32 CLuaBaseEntity::pathToSafeDistance(lua_State* L)
+{
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_PC);
+    TPZ_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isuserdata(L, 1));
+
+    if (m_PBaseEntity != nullptr)
+    {
+        CLuaBaseEntity* PLuaBaseEntity = Lunar<CLuaBaseEntity>::check(L, 1);
+        CBattleEntity* PEntity = (CBattleEntity*)PLuaBaseEntity->GetBaseEntity();
+
+        if (PEntity != nullptr)
+        {
+            if (m_PBaseEntity->PAI->PathFind)
+            {
+                m_PBaseEntity->PAI->PathFind->PathToSafeDistance(PEntity->loc.p, PEntity->m_ModelSize);
+            }
+        }
+    }
+    
+    return 0;
+}
+
+/************************************************************************
+*  Function: pathToMeeleRange()
+*  Purpose : Makes a non-PC move or keep within meele range of a target
+*  Example : mob:pathToMeeleRange(mob:getTarget())
+*  Notes   : keep calling this function to keep the position
+************************************************************************/
+inline int32 CLuaBaseEntity::pathToMeeleRange(lua_State* L)
+{
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_PC);
+    TPZ_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isuserdata(L, 1));
+
+    if (m_PBaseEntity != nullptr)
+    {
+        CLuaBaseEntity* PLuaBaseEntity = Lunar<CLuaBaseEntity>::check(L, 1);
+        CBattleEntity* PEntity = (CBattleEntity*)PLuaBaseEntity->GetBaseEntity();
+
+        if (PEntity != nullptr)
+        {
+            if (m_PBaseEntity->PAI->PathFind)
+            {
+                m_PBaseEntity->PAI->PathFind->PathToMeeleRange(PEntity->loc.p, PEntity->m_ModelSize);
+            }
+        }
+    }
+    
+    return 0;
+}
+
+/************************************************************************
+*  Function: pathToCastingRange()
+*  Purpose : Makes a non-PC move or keep within casting range of a target
+*  Example : mob:pathToCastingRange(mob:getTarget())
+*  Notes   : keep calling this function to keep the position
+************************************************************************/
+inline int32 CLuaBaseEntity::pathToCastingRange(lua_State* L)
+{
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_PC);
+    TPZ_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isuserdata(L, 1));
+
+    if (m_PBaseEntity != nullptr)
+    {
+        CLuaBaseEntity* PLuaBaseEntity = Lunar<CLuaBaseEntity>::check(L, 1);
+        CBattleEntity* PEntity = (CBattleEntity*)PLuaBaseEntity->GetBaseEntity();
+
+        if (PEntity != nullptr)
+        {
+            if (m_PBaseEntity->PAI->PathFind)
+            {
+                m_PBaseEntity->PAI->PathFind->PathToCastingRange(PEntity->loc.p, PEntity->m_ModelSize);
+            }
+        }
+    }
+    
+    return 0;
+}
+
+/************************************************************************
+*  Function: pathToSongRollRange()
+*  Purpose : Makes a non-PC move or keep within song/cor roll range of a target
+*  Example : mob:pathToSongRollRange(mob:getTarget())
+*  Notes   : keep calling this function to keep the position
+************************************************************************/
+inline int32 CLuaBaseEntity::pathToSongRollRange(lua_State* L)
+{
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_PC);
+    TPZ_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isuserdata(L, 1));
+
+    if (m_PBaseEntity != nullptr)
+    {
+        CLuaBaseEntity* PLuaBaseEntity = Lunar<CLuaBaseEntity>::check(L, 1);
+        CBattleEntity* PEntity = (CBattleEntity*)PLuaBaseEntity->GetBaseEntity();
+
+        if (PEntity != nullptr)
+        {
+            if (m_PBaseEntity->PAI->PathFind)
+            {
+                m_PBaseEntity->PAI->PathFind->PathToSongRollRange(PEntity->loc.p, PEntity->m_ModelSize);
+            }
+        }
+    }
+    
+    return 0;
+}
+
+/************************************************************************
+*  Function: pathToRangedRange()
+*  Purpose : Makes a non-PC move or keep within ranged attack range of a target
+*  Example : mob:pathToRangedRange(mob:getTarget())
+*  Notes   : keep calling this function to keep the position
+************************************************************************/
+inline int32 CLuaBaseEntity::pathToRangedRange(lua_State* L)
+{
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_PC);
+    TPZ_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isuserdata(L, 1));
+
+    if (m_PBaseEntity != nullptr)
+    {
+        CLuaBaseEntity* PLuaBaseEntity = Lunar<CLuaBaseEntity>::check(L, 1);
+        CBattleEntity* PEntity = (CBattleEntity*)PLuaBaseEntity->GetBaseEntity();
+
+        if (PEntity != nullptr)
+        {
+            if (m_PBaseEntity->PAI->PathFind)
+            {
+                m_PBaseEntity->PAI->PathFind->PathToRangedRange(PEntity->loc.p, PEntity->m_ModelSize);
+            }
+        }
+    }
+    
+    return 0;
+}
+
+/************************************************************************
+*  Function: pathToCoverTarget()
+*  Purpose : Makes a non-PC move to a position between a two targets
+*  Example : pet:pathToCoverTarget(mob:getTarget(), player)
+*  Notes   : keep calling this function to keep the position
+************************************************************************/
+inline int32 CLuaBaseEntity::pathToCoverTarget(lua_State* L)
+{
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_PC);
+    TPZ_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isuserdata(L, 1));
+
+    if (m_PBaseEntity != nullptr)
+    {
+        CLuaBaseEntity* PLuaBaseEntity = Lunar<CLuaBaseEntity>::check(L, 1);
+        CLuaBaseEntity* CoverEntity = Lunar<CLuaBaseEntity>::check(L, 2);
+        CBattleEntity* PEntity = (CBattleEntity*)PLuaBaseEntity->GetBaseEntity();
+        CBattleEntity* PTarget = (CBattleEntity*)CoverEntity->GetBaseEntity();
+
+        if (PTarget != nullptr && PEntity != nullptr)
+        {
+            if (m_PBaseEntity->PAI->PathFind)
+            {
+                m_PBaseEntity->PAI->PathFind->PathToCoverTarget(PEntity->loc.p, PTarget->loc.p);
+            }
+        } 
+    }
+    
+    return 0;
+}
+
+/************************************************************************
 *  Function: pathThrough()
 *  Purpose : Makes an Entity follow a given set of points
 *  Example : mob:pathThrough(pathfind.first(path), PATHFLAG_RUN)
@@ -14206,6 +14440,14 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,clearPath),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,checkDistance),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,wait),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,pathBehindTarget),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,pathInfrontTarget),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,pathToSafeDistance),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,pathToMeeleRange),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,pathToCastingRange),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,pathToSongRollRange),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,pathToRangedRange),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,pathToCoverTarget),
 
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,openDoor),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,closeDoor),

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -1899,9 +1899,9 @@ inline int32 CLuaBaseEntity::pathToSafeDistance(lua_State* L)
 }
 
 /************************************************************************
-*  Function: pathToMeeleRange()
-*  Purpose : Makes a non-PC move or keep within meele range of a target
-*  Example : mob:pathToMeeleRange(mob:getTarget())
+*  Function: pathToMeleeRange()
+*  Purpose : Makes a non-PC move or keep within melee range of a target
+*  Example : mob:pathToMeleeRange(mob:getTarget())
 *  Notes   : keep calling this function to keep the position
 ************************************************************************/
 inline int32 CLuaBaseEntity::pathToMeleeRange(lua_State* L)
@@ -1919,7 +1919,7 @@ inline int32 CLuaBaseEntity::pathToMeleeRange(lua_State* L)
         {
             if (m_PBaseEntity->PAI->PathFind)
             {
-                m_PBaseEntity->PAI->PathFind->PathToMeeleRange(PEntity->loc.p, PEntity->m_ModelSize);
+                m_PBaseEntity->PAI->PathFind->PathToMeleeRange(PEntity->loc.p, PEntity->m_ModelSize);
             }
         }
     }

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -110,6 +110,14 @@ public:
 
     int32 atPoint(lua_State* L);             // is at given point
     int32 pathTo(lua_State* L);              // set new path to point without changing action
+    int32 pathBehindTarget(lua_State* L);    // moves an entity directly behind a target
+    int32 pathInfrontTarget(lua_State* L);   // moves an entity directly infront of a target
+    int32 pathToSafeDistance(lua_State* L);  // moves an entity to a safe distance from a target
+    int32 pathToMeeleRange(lua_State* L);    // moves an entity within meele distance of a target
+    int32 pathToCastingRange(lua_State* L);  // moves an entity into casting range of a target
+    int32 pathToSongRollRange(lua_State* L); // moves an entity into song/cor roll range of a target
+    int32 pathToRangedRange(lua_State* L);   // moves an entity into ranged attack range of a target 
+    int32 pathToCoverTarget(lua_State* L);   // moves an entity directly between a target and a cover target 
     int32 pathThrough(lua_State* L);         // walk at normal speed through the given points
     int32 isFollowingPath(lua_State* L);     // checks if the entity is following a path
     int32 clearPath(lua_State* L);           // removes current pathfind and stops moving

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -113,7 +113,7 @@ public:
     int32 pathBehindTarget(lua_State* L);    // moves an entity directly behind a target
     int32 pathInfrontTarget(lua_State* L);   // moves an entity directly infront of a target
     int32 pathToSafeDistance(lua_State* L);  // moves an entity to a safe distance from a target
-    int32 pathToMeeleRange(lua_State* L);    // moves an entity within meele distance of a target
+    int32 pathToMeleeRange(lua_State* L);    // moves an entity within meele distance of a target
     int32 pathToCastingRange(lua_State* L);  // moves an entity into casting range of a target
     int32 pathToSongRollRange(lua_State* L); // moves an entity into song/cor roll range of a target
     int32 pathToRangedRange(lua_State* L);   // moves an entity into ranged attack range of a target 

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -113,7 +113,7 @@ public:
     int32 pathBehindTarget(lua_State* L);    // moves an entity directly behind a target
     int32 pathInfrontTarget(lua_State* L);   // moves an entity directly infront of a target
     int32 pathToSafeDistance(lua_State* L);  // moves an entity to a safe distance from a target
-    int32 pathToMeleeRange(lua_State* L);    // moves an entity within meele distance of a target
+    int32 pathToMeleeRange(lua_State* L);    // moves an entity within melee distance of a target
     int32 pathToCastingRange(lua_State* L);  // moves an entity into casting range of a target
     int32 pathToSongRollRange(lua_State* L); // moves an entity into song/cor roll range of a target
     int32 pathToRangedRange(lua_State* L);   // moves an entity into ranged attack range of a target 


### PR DESCRIPTION
This PR adds the ability to send commands to an entity to automatically position themselves according to the type used.

path types added:
• PathBehindTarget
• PathInfrontTarget
• PathToSafeDistance
• PathToMeeleRange
• PathToCastingRange
• PathToSongRollRange
• PathToRangedRange
• PathToCoverTarget

All pathing types can be continuously be sent to keep the desired position.

can be called directly or through lua binding.

video here of using lua commands to move a pet to positions
https://youtu.be/6BAt60HyeJ0

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [X] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [X] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

