### PR TITLE
Typo in battle_dance.lua throwing a nil error

### DIFF
--- a/scripts/globals/spells/bluemagic/battle_dance.lua
+++ b/scripts/globals/spells/bluemagic/battle_dance.lua
@@ -26,7 +26,7 @@ function onSpellCast(caster,target,spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
     params.tpmod = TPMOD_DURATION
-    parrams.attackType = tpz.attackType.PHYSICAL
+    params.attackType = tpz.attackType.PHYSICAL
     params.damageType = tpz.damageType.SLASHING
     params.scattr = SC_IMPACTION
     params.numhits = 1


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

[24/Jun] [18:00:48] [1;31m[Error] luautils::onSpellCast: scripts/globals/spells/bluemagic/battle_dance.lua:29: attempt to index global 'parrams' (a nil value)

Removed the extra "r" in parrams on line 29, no more errors.