### PR TITLE
Full Speed Ahead completion check

### DIFF
--- a/scripts/zones/Upper_Jeuno/npcs/Mapitoto.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Mapitoto.lua
@@ -12,8 +12,12 @@ require("scripts/globals/status")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    -- The Fenrir (10057) and Omega (10067) items and mounts have their own questlines, so they aren't valid trades here
-    if trade:getSlotCount() == 1 and not (npcUtil.tradeHasExactly(trade, 10057) or npcUtil.tradeHasExactly(trade, 10067)) then
+    if
+        player:hasKeyItem(tpz.ki.TRAINERS_WHISTLE) and
+        trade:getSlotCount() == 1 and
+        -- The Fenrir (10057) and Omega (10067) items and mounts have their own questlines, so they aren't valid trades here
+        not (npcUtil.tradeHasExactly(trade, 10057) or npcUtil.tradeHasExactly(trade, 10067))
+    then
         local item = trade:getItemId(0)
         local mount = item - 10050
         if item == 15533 then


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [🤞 ] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

As suggested by ibm: 
Check player has TRAINERS_WHISTLE (completed the quest) before accepting mount item trades