### PR TITLE
Full Speed Ahead: Various Improvements

### DIFF
--- a/scripts/globals/effects/full_speed_ahead.lua
+++ b/scripts/globals/effects/full_speed_ahead.lua
@@ -9,13 +9,13 @@ require("scripts/globals/status")
 -----------------------------------
 
 function onEffectGain(target,effect)
-    tpz.fsa.onEffectGain(target)
+    tpz.fsa.onEffectGain(target, effect)
 end
 
 function onEffectTick(target,effect)
-    tpz.fsa.tick(target)
+    tpz.fsa.tick(target, effect)
 end
 
 function onEffectLose(target,effect)
-    tpz.fsa.onEffectLose(target)
+    tpz.fsa.onEffectLose(target, effect)
 end

--- a/scripts/globals/quests.lua
+++ b/scripts/globals/quests.lua
@@ -481,6 +481,8 @@ tpz.quest.id =
         VW_OP_115_VALKURM_DUSTER        = 168,
         VW_OP_118_BUBURIMU_SQUALL       = 169,
         PRELUDE_TO_PUISSANCE            = 170,
+
+        FULL_SPEED_AHEAD                = 179, -- + --
     },
 
     -----------------------------------

--- a/scripts/quests/full_speed_ahead.lua
+++ b/scripts/quests/full_speed_ahead.lua
@@ -3,7 +3,24 @@
 -----------------------------------
 local ID = require("scripts/zones/Batallia_Downs/IDs")
 require("scripts/globals/status")
+require("scripts/globals/utils")
+require("scripts/globals/zone")
 -----------------------------------
+
+--[[
+Debugging:
+Reset: !delquest 3 179
+
+CharVar: [QUEST]FullSpeedAhead == ...
+1 : Starting minigame on Normal Mode
+2 : Starting minigame on Easy Mode
+3 : Minigame active/playable
+4 : Minigame complete, time to hand in
+
+FULL_SPEED_AHEAD effect power:
+0 : Normal Mode
+1 : Easy Mode
+]]--
 
 tpz = tpz or {}
 tpz.full_speed_ahead = tpz.full_speed_ahead or {}
@@ -13,25 +30,30 @@ tpz.full_speed_ahead.motivation_decay = 2
 tpz.full_speed_ahead.motivation_food_bonus = 15
 tpz.full_speed_ahead.pep_growth = 1
 
-tpz.full_speed_ahead.onEffectGain = function(player)
+tpz.full_speed_ahead.onEffectGain = function(player, effect)
     player:setLocalVar("FSA_Time", os.time() + tpz.full_speed_ahead.duration)
     player:setLocalVar("FSA_Motivation", 100)
     player:setLocalVar("FSA_Pep", 0)
     player:setLocalVar("FSA_Food", 0xFF)
     player:setLocalVar("FSA_FoodCount", 0)
-    player:addStatusEffect(tpz.effect.MOUNTED, tpz.mount.QUEST_RAPTOR, 2, 0)
-    player:setCharVar("[QUEST]FullSpeedAhead", 2)
+    player:addStatusEffect(tpz.effect.MOUNTED, tpz.mount.QUEST_RAPTOR, 3, 0)
+    player:setCharVar("[QUEST]FullSpeedAhead", 3)
 end
 
-tpz.full_speed_ahead.onEffectLose = function(player)
+tpz.full_speed_ahead.onEffectLose = function(player, effect)
     player:delStatusEffectSilent(tpz.effect.MOUNTED)
     player:countdown(0) 
     player:enableEntities({})
+
+    -- If in Batallia Downs and didn't get the completion flag (failed/dismounted)
+    if player:getZoneID() == tpz.zone.BATALLIA_DOWNS and player:getCharVar("[QUEST]FullSpeedAhead") ~= 4 then
+        player:startEvent(26, 0, effect:getPower())
+    end
 end
 
-tpz.full_speed_ahead.tick = function(player)
-    player:setLocalVar("FSA_Motivation", player:getLocalVar("FSA_Motivation") - tpz.full_speed_ahead.motivation_decay)
-    player:setLocalVar("FSA_Pep", player:getLocalVar("FSA_Pep") + tpz.full_speed_ahead.pep_growth)
+tpz.full_speed_ahead.tick = function(player, effect)
+    player:setLocalVar("FSA_Motivation", player:getLocalVar("FSA_Motivation") - tpz.full_speed_ahead.motivation_decay + effect:getPower())
+    player:setLocalVar("FSA_Pep", player:getLocalVar("FSA_Pep") + tpz.full_speed_ahead.pep_growth + effect:getPower())
 
     local timeLeft = player:getLocalVar("FSA_Time") - os.time()
     local motivation = player:getLocalVar("FSA_Motivation")
@@ -49,7 +71,6 @@ tpz.full_speed_ahead.tick = function(player)
 
     if motivation <= 0 or timeLeft <= 0 or not player:hasStatusEffect(tpz.effect.MOUNTED) then
         player:delStatusEffectSilent(tpz.effect.FULL_SPEED_AHEAD)
-        player:messageSpecial(ID.text.RAPTOR_SPEEDS_OFF)
     else
         player:countdown(timeLeft, "Motivation", motivation, "Pep", pep)
         player:enableEntities(food_data)
@@ -61,20 +82,25 @@ tpz.full_speed_ahead.onRegionEnter = function(player, index)
     local food_count = player:getLocalVar("FSA_FoodCount")
     local motivation = player:getLocalVar("FSA_Motivation")
 
-    if index == 8 and food_count >= 5 then -- Syrillia
+    if index == 9 and food_count >= 5 then -- Syrillia
         player:startEvent(24) -- End CS and teleport
     elseif bit.band(food_byte, bit.lshift(1, index - 1)) > 0 then
         local new_food_byte = food_byte - bit.lshift(1, index - 1)
         player:setLocalVar("FSA_Food", new_food_byte)
         player:setLocalVar("FSA_FoodCount", food_count + 1)
 
-        local new_motivation = motivation + tpz.full_speed_ahead.motivation_food_bonus
+        local new_food_count = player:getLocalVar("FSA_FoodCount")
+        local new_motivation = utils.clamp(motivation + tpz.full_speed_ahead.motivation_food_bonus, 0, 100)
         player:setLocalVar("FSA_Motivation", new_motivation)
         
         -- Hearts
         player:independantAnimation(player, 251, 4)
 
-        player:messageSpecial(ID.text.RAPTOR_OVERCOME_MUNCHIES, player:getLocalVar("FSA_FoodCount"), 5)
+        player:messageSpecial(ID.text.RAPTOR_OVERCOME_MUNCHIES, new_food_count, 5)
+
+        if new_food_count == 5 then
+            player:messageSpecial(ID.text.MEET_SYRILLIA)
+        end
     end
 end
 
@@ -83,7 +109,7 @@ tpz.full_speed_ahead.onCheer = function(player)
     local motivation = player:getLocalVar("FSA_Motivation")
     local pep = player:getLocalVar("FSA_Pep")
 
-    local new_motivation = motivation + pep
+    local new_motivation = utils.clamp(motivation + (pep / 2), 0, 100)
 
     player:setLocalVar("FSA_Motivation", new_motivation)
     player:setLocalVar("FSA_Pep", 0)
@@ -97,8 +123,8 @@ tpz.full_speed_ahead.onCheer = function(player)
 end
 
 tpz.full_speed_ahead.completeGame = function(player)
+    player:setCharVar("[QUEST]FullSpeedAhead", 4)
     player:delStatusEffectSilent(tpz.effect.FULL_SPEED_AHEAD)
-    player:setCharVar("[QUEST]FullSpeedAhead", 3)
     player:setPos(-104.5, 0, 187.4, 64, 244)
 end
 

--- a/scripts/zones/Batallia_Downs/Zone.lua
+++ b/scripts/zones/Batallia_Downs/Zone.lua
@@ -34,19 +34,22 @@ function onInitialize(zone)
     for i = 0, 7 do
         registerRegionAroundNPC(zone, ID.npc.RAPTOR_FOOD_BASE + i, i + 1)
     end
-    registerRegionAroundNPC(zone, ID.npc.SYRILLIA, 8)
+    registerRegionAroundNPC(zone, ID.npc.SYRILLIA, 9)
 end
 
 function onZoneIn(player, prevZone)
     local cs = -1;
 
-    if player:getCharVar("[QUEST]FullSpeedAhead") == 1 then
+    if player:getCharVar("[QUEST]FullSpeedAhead") == 1 then -- Normal Mode
         player:addStatusEffect(tpz.effect.FULL_SPEED_AHEAD, 0, 3, tpz.fsa.duration)
+        return -1
+    elseif player:getCharVar("[QUEST]FullSpeedAhead") == 2 then -- Easy Mode
+        player:addStatusEffect(tpz.effect.FULL_SPEED_AHEAD, 1, 3, tpz.fsa.duration)
         return -1
     end
 
     if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
-        player:setPos( -693.609, -14.583, 173.59, 30);
+        player:setPos(-693.609, -14.583, 173.59, 30);
     end
 
     if (triggerLightCutscene(player)) then -- Quest: I Can Hear A Rainbow
@@ -85,5 +88,11 @@ function onEventFinish(player, csid, option)
         end
     elseif csid == 24 then
         tpz.fsa.completeGame(player)
+    elseif csid == 26 and option == 0 then
+        player:setCharVar("[QUEST]FullSpeedAhead", 1)
+        player:setPos(475, 8.8, -159, 128, 105)
+    elseif csid == 26 and option == 1 then
+        player:setCharVar("[QUEST]FullSpeedAhead", 2)
+        player:setPos(475, 8.8, -159, 128, 105)
     end
 end;

--- a/scripts/zones/Upper_Jeuno/IDs.lua
+++ b/scripts/zones/Upper_Jeuno/IDs.lua
@@ -41,6 +41,7 @@ zones[tpz.zone.UPPER_JEUNO] =
     },
     npc =
     {
+        MAPITOTO = 17776895,
     },
 }
 

--- a/scripts/zones/Upper_Jeuno/npcs/Mapitoto.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Mapitoto.lua
@@ -8,6 +8,7 @@ local ID = require("scripts/zones/Upper_Jeuno/IDs")
 require("scripts/globals/chocobo")
 require("scripts/globals/keyitems")
 require("scripts/globals/npc_util")
+require("scripts/globals/quests")
 require("scripts/globals/status")
 -----------------------------------
 
@@ -31,15 +32,15 @@ function onTrade(player,npc,trade)
 end
 
 function onTrigger(player,npc)
+    local fsaQuest = player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.FULL_SPEED_AHEAD) 
     local fullSpeedAheadStatus = player:getCharVar("[QUEST]FullSpeedAhead")
-    local hasTrainersWhistle = player:hasKeyItem(tpz.ki.TRAINERS_WHISTLE)
 
-    if hasTrainersWhistle then
+    if fsaQuest == QUEST_COMPLETED then
         player:startEvent(10226)
-    elseif fullSpeedAheadStatus == 2 then -- Retry
-        player:startEvent(10224, 1)
     elseif fullSpeedAheadStatus == 3 then -- Complete
-        player:startEvent(10225, tpz.ki.TRAINERS_WHISTLE)
+        player:startEvent(10225, tpz.ki.TRAINERS_WHISTLE, 15533, ID.npc.MAPITOTO)
+    elseif fsaQuest == QUEST_ACCEPTED then -- Retry
+        player:startEvent(10224, 1)
     elseif
       player:hasKeyItem(tpz.ki.CHOCOBO_LICENSE) and
       player:getMainLvl() >= 20 and
@@ -56,11 +57,15 @@ end
 
 function onEventFinish(player,csid,option)
     if (csid == 10223 or csid == 10224) and option == 1 then
+        player:addQuest(JEUNO, tpz.quest.id.jeuno.FULL_SPEED_AHEAD)
         player:setCharVar("[QUEST]FullSpeedAhead", 1) -- Flag to start minigame
         player:setPos(475, 8.8, -159, 128, 105)
+    elseif csid == 10223 and option == 2 then
+        player:addQuest(JEUNO, tpz.quest.id.jeuno.FULL_SPEED_AHEAD)
     elseif csid == 10225 then
         -- Complete quest
         player:setCharVar("[QUEST]FullSpeedAhead", 0)
+        player:completeQuest(JEUNO, tpz.quest.id.jeuno.FULL_SPEED_AHEAD)
         npcUtil.giveKeyItem(player, tpz.ki.TRAINERS_WHISTLE)
         npcUtil.giveKeyItem(player, tpz.ki.RAPTOR_COMPANION)
     elseif csid == 10227 then

--- a/scripts/zones/Upper_Jeuno/npcs/Mapitoto.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Mapitoto.lua
@@ -37,7 +37,7 @@ function onTrigger(player,npc)
 
     if fsaQuest == QUEST_COMPLETED then
         player:startEvent(10226)
-    elseif fullSpeedAheadStatus == 3 then -- Complete
+    elseif fullSpeedAheadStatus == 4 then -- Complete
         player:startEvent(10225, tpz.ki.TRAINERS_WHISTLE, 15533, ID.npc.MAPITOTO)
     elseif fsaQuest == QUEST_ACCEPTED then -- Retry
         player:startEvent(10224, 1)


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Tested a bunch, I'm getting pretty good at the minigame...

**New:**
Added tracking via Quest Log
Fixed missing Item and NPC IDs in completion CS
Changed motivation/pep relationship
Added clamping to motivation and pep to fix any weirdness with the bar rendering
Added failure CS when you dismount or run out of motivation, which lets you enable easy mode (or not)
Added easy mode: tracked through the effect's power (acts as a modifier for motivation decay and pep growth)
Fixed bug where the final Raptor Food region was acting like it was Syrillia's region
Added MEET_SYRILLIA text when you've eaten 5 foods

**Not doing in this PR:**
Additional Raptor animations
Varying pep and speed depending on terrain slope etc.
Best time tracking

**Once this PR goes in, I think it would be fair to open two new issues:**
**- [Good First Issue] Quest: Full Speed Ahead! doesn't track server best time**
Using `Get/SetServerVariable`

**- [Good First Issue][Core] Quest: Full Speed Ahead! raptor doesn't slow down as it runs out of pep**
Mount speed is hard-coded, and needs to be modifiable (through mods or otherwise) for Full Speed Ahead!

`battleentity.cpp`
```
uint8 CBattleEntity::GetSpeed()
{
    return (isMounted() ? 50 + map_config.speed_mod : std::clamp<uint16>(speed * (100 + getMod(Mod::MOVE)) / 100, std::numeric_limits<uint8>::min(), std::numeric_limits<uint8>::max()));
}
```