### PR TITLE
Fix double-free errors in exit/crash

### DIFF
--- a/src/common/taskmgr.cpp
+++ b/src/common/taskmgr.cpp
@@ -24,15 +24,24 @@
 #include "../common/timer.h"
 #include "../common/taskmgr.h"
 
-CTaskMgr* CTaskMgr::_instance = NULL;
+CTaskMgr* CTaskMgr::_instance = nullptr;
 
 CTaskMgr* CTaskMgr::getInstance()
 {
-	if( _instance == NULL )
+	if( _instance == nullptr )
 	{
 		_instance = new CTaskMgr();
 	}
 	return _instance;
+}
+
+void CTaskMgr::delInstance()
+{
+    if(_instance)
+    {
+        delete _instance;
+        _instance = nullptr;
+    }
 }
 
 CTaskMgr::CTask *CTaskMgr::AddTask(std::string InitName, time_point InitTick, std::any InitData,TASKTYPE InitType,TaskFunc_t InitFunc,duration InitInterval)

--- a/src/common/taskmgr.h
+++ b/src/common/taskmgr.h
@@ -68,6 +68,7 @@ public:
     void    RemoveTask(std::string TaskName);
 
     static CTaskMgr * getInstance();
+    static void delInstance();
 
     ~CTaskMgr() {};
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -186,9 +186,13 @@ namespace luautils
 
     int32 free()
     {
-        ShowStatus(CL_WHITE"luautils::free" CL_RESET":lua free...");
-        lua_close(LuaHandle);
-        ShowMessage("\t - " CL_GREEN"[OK]" CL_RESET"\n");
+        if(LuaHandle)
+        {
+            ShowStatus(CL_WHITE"luautils::free" CL_RESET":lua free...");
+            lua_close(LuaHandle);
+            LuaHandle = nullptr;
+            ShowMessage("\t - " CL_GREEN"[OK]" CL_RESET"\n");
+        }
         return 0;
     }
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -260,7 +260,9 @@ int32 do_init(int32 argc, char** argv)
 void do_final(int code)
 {
     delete[] g_PBuff;
+    g_PBuff = nullptr;
     delete[] PTempBuff;
+    PTempBuff = nullptr;
 
     itemutils::FreeItemList();
     battleutils::FreeWeaponSkillsList();
@@ -275,10 +277,11 @@ void do_final(int code)
         messageThread.join();
     }
 
-    delete CTaskMgr::getInstance();
-    delete CVanaTime::getInstance();
+    CTaskMgr::delInstance();
+    CVanaTime::delInstance();
 
     Sql_Free(SqlHandle);
+    SqlHandle = nullptr;
 
     timer_final();
     socket_final();

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -271,6 +271,8 @@ namespace battleutils
         for (int32 SkillId = 0; SkillId < MAX_WEAPONSKILL_ID; ++SkillId)
         {
             delete g_PWeaponSkillList[SkillId];
+            g_PWeaponSkillList[SkillId] = nullptr;
+
         }
     }
 
@@ -279,9 +281,10 @@ namespace battleutils
     ************************************************************************/
     void FreeMobSkillList()
     {
-        for (auto mobskill : g_PMobSkillList)
+        for (auto& mobskill : g_PMobSkillList)
         {
             delete mobskill;
+            mobskill = nullptr;
         }
     }
 

--- a/src/map/utils/itemutils.cpp
+++ b/src/map/utils/itemutils.cpp
@@ -552,11 +552,13 @@ namespace itemutils
         for(int32 ItemID = 0; ItemID < MAX_ITEMID; ++ItemID)
         {
             delete g_pItemList[ItemID];
+            g_pItemList[ItemID] = nullptr;
         }
 
         for(int32 DropID = 0; DropID < MAX_DROPID; ++DropID)
         {
             delete g_pDropList[DropID];
+            g_pDropList[DropID] = nullptr;
         }
     }
 }; // namespace itemutils

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -1022,7 +1022,9 @@ void FreeZoneList()
     {
         delete PZone.second;
     }
+    g_PZoneList.clear();
     delete g_PTrigger;
+    g_PTrigger = nullptr;
 }
 
 void ForEachZone(std::function<void(CZone*)> func)

--- a/src/map/vana_time.cpp
+++ b/src/map/vana_time.cpp
@@ -42,6 +42,15 @@ CVanaTime* CVanaTime::getInstance()
     return _instance;
 }
 
+void CVanaTime::delInstance()
+{
+    if(_instance)
+    {
+        delete _instance;
+        _instance = nullptr;
+    }
+}
+
 uint32 CVanaTime::getDate()
 {
     return m_vanaDate;

--- a/src/map/vana_time.h
+++ b/src/map/vana_time.h
@@ -60,6 +60,7 @@ class CVanaTime
 public:
 
 	static	CVanaTime * getInstance();
+	static  void delInstance();
 
 	TIMETYPE SyncTime();
 	TIMETYPE GetCurrentTOTD();


### PR DESCRIPTION
do_final was written in such a way that it was only ever intended to be called once. However, since the signal_handler calls do_abort and do_final in response to various error states, this means do_final could be (and often is) called multiple times if that signal/error occurs during (or as a result of) the shutdown process itself. This is a problem since there weren't any safeguards against memory attempting to be de-allocated a second time.

This PR ensures that called shutdown procedures are safe (or at least, resistant) against double-freeing. It should also reduce the chance do_final gets caught in a recursive error loop.

This will hopefully lend insight into the real sources of some difficult-to-reproduce crashes, since the recursive double-frees after an error were often trampling over the stack and obfuscating the original cause in those cases.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

