### PR TITLE
Implement crafting skill limitation and various other fixes

### DIFF
--- a/conf/default/map.conf
+++ b/conf/default/map.conf
@@ -111,13 +111,14 @@ craft_chance_multiplier: 1.0
 skillup_amount_multiplier: 1
 craft_amount_multiplier: 1
 
+#Craft level limit from witch specialization points beging to count. (Retail: 700; Level 75 era:600)
+craft_common_cap: 700
+
+#Amount of points allowed in crafts over the level defined above. Points are shared across all crafting skills. (Retail: 400; All skills can go to max: 3200)
+craft_specialization_points: 400
+
 #Enable/disable skill-ups from bloodpacts
 skillup_bloodpact: 1
-
-#Crafting Factors. DO NOT change defaults without verifiable proof that your change IS how retail does it. Myths need to be optional.
-craft_day_matters: 0
-craft_moonphase_matters: 0
-craft_direction_matters: 0
 
 #Adjust rate of TP gain for mobs and players. Acts as a multiplier, so default is 1.
 mob_tp_multiplier:    1.0

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -967,9 +967,8 @@ int32 map_config_default()
     map_config.craft_chance_multiplier = 2.6f;
     map_config.skillup_amount_multiplier = 1;
     map_config.craft_amount_multiplier = 1;
-    map_config.craft_day_matters = 1;
-    map_config.craft_moonphase_matters = 0;
-    map_config.craft_direction_matters = 0;
+    map_config.craft_common_cap = 700;
+    map_config.craft_specialization_points = 400;
     map_config.mob_tp_multiplier = 1.0f;
     map_config.player_tp_multiplier = 1.0f;
     map_config.nm_hp_multiplier = 1.0f;
@@ -1253,17 +1252,13 @@ int32 map_config_read(const int8* cfgName)
         {
             map_config.craft_amount_multiplier = (float)atof(w2);
         }
-        else if (strcmp(w1, "craft_day_matters") == 0)
+        else if (strcmp(w1, "craft_common_cap") == 0)
         {
-            map_config.craft_day_matters = atof(w2);
+            map_config.craft_common_cap = atoi(w2);
         }
-        else if (strcmp(w1, "craft_moonphase_matters") == 0)
+        else if (strcmp(w1, "craft_specialization_points") == 0)
         {
-            map_config.craft_moonphase_matters = atof(w2);
-        }
-        else if (strcmp(w1, "craft_direction_matters") == 0)
-        {
-            map_config.craft_direction_matters = atof(w2);
+            map_config.craft_specialization_points = atoi(w2);
         }
         else if (strcmp(w1, "mysql_host") == 0)
         {

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -95,9 +95,8 @@ struct map_config_t
     float  craft_chance_multiplier;   // Constant used in the crafting skill-up formula that has a strong effect on skill-up rates
     float  skillup_amount_multiplier; // Used to increase the amount of skill gained during skill up
     float  craft_amount_multiplier;   // Used to increase the amount of skill gained during skill up
-    bool   craft_day_matters;         // Enable/disable Element day factor in synthesis
-    bool   craft_moonphase_matters;   // Enable/disable Moon phase factor in synthesis
-    bool   craft_direction_matters;   // Enable/disable Compass direction factor in synthesis
+    uint16 craft_common_cap;            // Used in crafting, in synthutils.cpp. Defines skill limit before specialization system
+    uint16 craft_specialization_points; // Used in crafting, in synthutils.cpp. Defines the maximum points of the specialization system.
     float  mob_tp_multiplier;         // Multiplies the amount of TP mobs gain on any effect that would grant TP
     float  player_tp_multiplier;      // Multiplies the amount of TP players gain on any effect that would grant TP
     bool   mob_no_despawn;            // Toggle whether mobs roam home or despawn

--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -450,8 +450,8 @@ int32 doSynthSkillUp(CCharEntity* PChar)
             {
                 int32  skillAmount = 1;
 
-                if (charSkill < 600) // no skill ups over 0.1 happen over level 60 https://www.bluegartr.com/threads/57123-Before-you-ask-a-stupid-crafting-question-read-this!
-                {                    // we need more recent confirmation since the "free" level cap was raised to 70
+                if (charSkill < map_config.craft_common_cap) // no skill ups over 0.1 happen over level 60 https://www.bluegartr.com/threads/57123-Before-you-ask-a-stupid-crafting-question-read-this!
+                {                                            // we need more recent confirmation since the "free" level cap was raised to 70
                     int32  satier = 0;
                     double chance = 0;
 

--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -165,11 +165,6 @@ bool isRightRecipe(CCharEntity* PChar)
 
 double getSynthDifficulty(CCharEntity* PChar, uint8 skillID)
 {
-    uint8  ElementDirection = 0;
-    uint8  WeekDay = (uint8)CVanaTime::getInstance()->getWeekday();
-    uint8  crystalElement = PChar->CraftContainer->getType();
-    uint8  direction = (PChar->loc.p.rotation - 16)/32;
-    uint8  strongElement[8] = {2,3,5,4,0,1,7,6};
     Mod ModID = Mod::NONE;
 
     switch (skillID)
@@ -186,55 +181,8 @@ double getSynthDifficulty(CCharEntity* PChar, uint8 skillID)
 
     uint8 charSkill = PChar->RealSkills.skill[skillID]/10;  //player skill level is truncated before synth difficulty is calced
     double difficult = PChar->CraftContainer->getQuantity(skillID-40) - (double)(charSkill + PChar->getMod(ModID));
-    double MoonPhase = (double)CVanaTime::getInstance()->getMoonPhase();
-
-    if (map_config.craft_day_matters == 1)
-    {
-        if (crystalElement == WeekDay)
-            difficult -= 1;
-        else if (strongElement[crystalElement] == WeekDay)
-            difficult += 1;
-        else if (strongElement[WeekDay] == crystalElement)
-            difficult -= 1;
-        else if (WeekDay == LIGHTSDAY)
-            difficult -= 1;
-        else if (WeekDay == DARKSDAY)
-            difficult += 1;
-    }
-
-    if (map_config.craft_moonphase_matters == 1)
-    {
-        difficult -= (MoonPhase - 50)/50;   // full moon reduces difficulty by 1, new moon increases difficulty by 1, 50% moon has 0 effect
-    }
-
-    if (map_config.craft_direction_matters == 1)
-    {
-        switch (direction)
-        {
-            case 0: ElementDirection = ELEMENT_WIND;      break;
-            case 1: ElementDirection = ELEMENT_EARTH;     break;
-            case 2: ElementDirection = ELEMENT_LIGHTNING; break;
-            case 3: ElementDirection = ELEMENT_WATER;     break;
-            case 4: ElementDirection = ELEMENT_FIRE;      break;
-            case 5: ElementDirection = ELEMENT_DARK;      break;
-            case 6: ElementDirection = ELEMENT_LIGHT;     break;
-            case 7: ElementDirection = ELEMENT_ICE;       break;
-        }
-
-        if (crystalElement == ElementDirection)
-        {
-            difficult -= 0.5;
-        }
-        else if (strongElement[crystalElement] == ElementDirection)
-        {
-            difficult += 0.5;
-        }
-    }
 
     #ifdef _TPZ_SYNTH_DEBUG_MESSAGES_
-    ShowDebug(CL_CYAN"Direction = %i\n" CL_RESET, ElementDirection);
-    ShowDebug(CL_CYAN"Day = %i\n" CL_RESET, WeekDay);
-    ShowDebug(CL_CYAN"Moon = %g\n" CL_RESET, MoonPhase);
     ShowDebug(CL_CYAN"Difficulty = %g\n" CL_RESET, difficult);
     #endif
 
@@ -286,11 +234,6 @@ uint8 calcSynthResult(CCharEntity* PChar)
     double success = 0;
     double chance  = 0;
     double random = tpzrand::GetRandomNumber(1.);
-
-    double MoonPhase = (double)CVanaTime::getInstance()->getMoonPhase();
-    uint8  WeekDay = (uint8)CVanaTime::getInstance()->getWeekday();
-    uint8  crystalElement = PChar->CraftContainer->getType();
-    uint8  strongElement[8] = {2,3,5,4,0,1,7,6};
 
     for(uint8 skillID = 49; skillID < 57; ++skillID)
     {
@@ -393,23 +336,6 @@ uint8 calcSynthResult(CCharEntity* PChar)
 
         if(chance > 0 && canHQ) // if there is a chance already and it can HQ, we add myth mods
         {
-            if (map_config.craft_moonphase_matters)
-                chance *= 1.0 - (MoonPhase - 50)/150;  //new moon +33% of base rate bonus to hq chance, full moon -33%, corresponding/weakday/lightsday -33%, opposing/darksday +33%
-
-            if (map_config.craft_day_matters)
-            {
-                if (crystalElement == WeekDay)
-                    chance *= 1.0 - ((double)1 / 3);
-                else if (strongElement[crystalElement] == WeekDay)
-                    chance *= 1.0 + ((double)1 / 3);
-                else if (strongElement[WeekDay] == crystalElement)
-                    chance *= 1.0 - ((double)1 / 3);
-                else if (WeekDay == LIGHTSDAY)
-                    chance *= 1.0 - ((double)1 / 3);
-                else if (WeekDay == DARKSDAY)
-                    chance *= 1.0 + ((double)1 / 3);
-            }
-
             //limit max hq chance
             if (PChar->CraftContainer->getCraftType() ==  1)
                 chance = std::clamp(chance, 0., 0.800);
@@ -480,7 +406,6 @@ uint8 calcSynthResult(CCharEntity* PChar)
 *                                                                   *
 * Do Skill Up                                                       *
 * To Do:                                                            *
-* - Lower chance of skill up if recipe s a desynth                  *
 * - Correct calculations so skill up chance in config file          *
 *   matches retail when value is set to 1.                          *
 *                                                                   *
@@ -502,20 +427,20 @@ int32 doSynthSkillUp(CCharEntity* PChar)
         int32  baseDiff   = PChar->CraftContainer->getQuantity(skillID-40) - charSkill/10; //the 5 lvl difference rule for breaks does NOT consider the effects of image support/gear
 
         if ((baseDiff <= 0) || ((baseDiff > 5) && (PChar->CraftContainer->getQuantity(0) == SYNTHESIS_FAIL))) // synthesis result is stored in the zero cell quantity
-        {
+        {                                                                                                     // if you break a recipe higher than 5 levels, no skill ups
             continue;
         }
 
-        if (charSkill < maxSkill)
+        if (charSkill < maxSkill) // can you even skill?
         {
-            double skillUpChance = ((double)baseDiff*(map_config.craft_chance_multiplier - (log(1.2 + charSkill/100))))/10;
+            double skillUpChance = ((double)baseDiff*(map_config.craft_chance_multiplier - (log(1.2 + charSkill/100))))/10; // needs fixing
 
             // Apply synthesis skill gain rate modifier before synthesis fail modifier
             int16 modSynthSkillGain = PChar->getMod(Mod::SYNTH_SKILL_GAIN);
             skillUpChance += (double)modSynthSkillGain * 0.01;
 
             skillUpChance = skillUpChance/(1 + (PChar->CraftContainer->getQuantity(0) == SYNTHESIS_FAIL)); // synthesis result is stored in the zero cell quantity
-
+                                                                                                           // this means break = half chance
             double random = tpzrand::GetRandomNumber(1.);
             #ifdef _TPZ_SYNTH_DEBUG_MESSAGES_
             ShowDebug(CL_CYAN"Skill up chance: %g  Random: %g\n" CL_RESET, skillUpChance, random);
@@ -523,45 +448,47 @@ int32 doSynthSkillUp(CCharEntity* PChar)
 
             if (random < skillUpChance)
             {
-                int32  satier = 0;
                 int32  skillAmount = 1;
-                double chance = 0;
 
-                if((baseDiff >= 1) && (baseDiff < 3))
-                    satier = 1;
-                else if((baseDiff >= 3) && (baseDiff < 5))
-                    satier = 2;
-                else if((baseDiff >= 5) && (baseDiff < 8))
-                    satier = 3;
-                else if((baseDiff >= 8) && (baseDiff < 10))
-                    satier = 4;
-                else if (baseDiff >= 10)
-                    satier = 5;
+                if (charSkill < 600) // no skill ups over 0.1 happen over level 60 https://www.bluegartr.com/threads/57123-Before-you-ask-a-stupid-crafting-question-read-this!
+                {                    // we need more recent confirmation since the "free" level cap was raised to 70
+                    int32  satier = 0;
+                    double chance = 0;
 
-                for(uint8 i = 0; i < 4; i ++)
-                {
-                    random = tpzrand::GetRandomNumber(1.);
-                    #ifdef _TPZ_SYNTH_DEBUG_MESSAGES_
-                    ShowDebug(CL_CYAN"SkillAmount Tier: %i  Random: %g\n" CL_RESET, satier, random);
-                    #endif
+                    if((baseDiff >= 1) && (baseDiff < 3))       // 1 or 2 over character level
+                        satier = 1;
+                    else if((baseDiff >= 3) && (baseDiff < 5))  // 3 or 4 over character level
+                        satier = 2;
+                    else if((baseDiff >= 5) && (baseDiff < 8))  // 5 to 7 over character level
+                        satier = 3;
+                    else if((baseDiff >= 8) && (baseDiff < 10)) // 8 or 9 over character level
+                        satier = 4;
+                    else if (baseDiff >= 10)                    // 10 or higher over character level
+                        satier = 5;
 
-                    switch(satier)
+                    for(uint8 i = 0; i < 4; i ++) // cicle up to 4 times until cap (0.5 is max skill up) or break. The lower the satier, the more likely it will break
                     {
-                        case 5:  chance = 0.900; break;
-                        case 4:  chance = 0.700; break;
-                        case 3:  chance = 0.500; break;
-                        case 2:  chance = 0.300; break;
-                        case 1:  chance = 0.200; break;
-                        default: chance = 0.000; break;
+                        #ifdef _TPZ_SYNTH_DEBUG_MESSAGES_
+                        ShowDebug(CL_CYAN"SkillAmount Tier: %i  Random: %g\n" CL_RESET, satier, random);
+                        #endif
+
+                        switch(satier)
+                        {
+                            case 5:  chance = 0.900; break;
+                            case 4:  chance = 0.700; break;
+                            case 3:  chance = 0.500; break;
+                            case 2:  chance = 0.300; break;
+                            case 1:  chance = 0.200; break;
+                            default: chance = 0.000; break;
+                        }
+
+                        if(chance < random)
+                            break;
+
+                        skillAmount++; // rise by 1 the skill amount
+                        satier--;      // lower by one the satier rank and repeat cicle
                     }
-
-                    if(chance < random)
-                        break;
-
-                    skillAmount++;
-                    satier--;
                 }
-
                 // Do craft amount multiplier
                 if (map_config.craft_amount_multiplier > 1)
                 {
@@ -572,23 +499,132 @@ int32 doSynthSkillUp(CCharEntity* PChar)
                     }
                 }
 
+                // Cap skill gain if character hits the current cap
                 if((skillAmount + charSkill) > maxSkill)
                 {
                     skillAmount = maxSkill - charSkill;
                 }
 
-                PChar->RealSkills.skill[skillID] += skillAmount;
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, skillID, skillAmount, 38));
-
-                if((charSkill/10) < (charSkill + skillAmount)/10)
+                if (charSkill > 700) // The cap from which you are limited to 400 points
                 {
-                    PChar->WorkingSkills.skill[skillID] += 0x20;
+                    uint16 skillCumulation = 0;
+                    uint8 skillHighest    = 0;
 
-                    PChar->pushPacket(new CCharSkillsPacket(PChar));
-                    PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, skillID, (charSkill + skillAmount)/10, 53));
+                    // we are gonna set which is the OTHER highest skill over lvl 70 and the amount of points we have of the 400 to allocate
+                    if (PChar->RealSkills.skill[49] > 700) // Craft 1
+                    {
+                        skillCumulation += (PChar->RealSkills.skill[49] - 700);
+                        if (skillID != 49 && PChar->RealSkills.skill[49] > skillHighest)
+                            skillHighest = 49;
+                    }
+
+                    if (PChar->RealSkills.skill[50] > 700) // Craft 2
+                    {
+                        skillCumulation += (PChar->RealSkills.skill[50] - 700);
+                        if (skillID != 50 && PChar->RealSkills.skill[50] > skillHighest)
+                            skillHighest = 50;
+                    }
+
+                    if (PChar->RealSkills.skill[51] > 700) // Craft 3
+                    {
+                        skillCumulation += (PChar->RealSkills.skill[51] - 700);
+                        if (skillID != 51 && PChar->RealSkills.skill[51] > skillHighest)
+                            skillHighest = 51;
+                    }
+
+                    if (PChar->RealSkills.skill[52] > 700) // Craft 4
+                    {
+                        skillCumulation += (PChar->RealSkills.skill[52] - 700);
+                        if (skillID != 52 && PChar->RealSkills.skill[52] > skillHighest)
+                            skillHighest = 52;
+                    }
+
+                    if (PChar->RealSkills.skill[53] > 700) // Craft 5
+                    {
+                        skillCumulation += (PChar->RealSkills.skill[53] - 700);
+                        if (skillID != 53 && PChar->RealSkills.skill[53] > skillHighest)
+                            skillHighest = 53;
+                    }
+
+                    if (PChar->RealSkills.skill[54] > 700) // Craft 6
+                    {
+                        skillCumulation += (PChar->RealSkills.skill[54] - 700);
+                        if (skillID != 54 && PChar->RealSkills.skill[54] > skillHighest)
+                            skillHighest = 54;
+                    }
+
+                    if (PChar->RealSkills.skill[55] > 700) // Craft 7
+                    {
+                        skillCumulation += (PChar->RealSkills.skill[55] - 700);
+                        if (skillID != 55 && PChar->RealSkills.skill[55] > skillHighest)
+                            skillHighest = 55;
+                    }
+
+                    if (PChar->RealSkills.skill[56] > 700) // Craft 8
+                    {
+                        skillCumulation += (PChar->RealSkills.skill[56] - 700);
+                        if (skillID != 56 && PChar->RealSkills.skill[56] > skillHighest)
+                            skillHighest = 56;
+                    }
+
+                    // now we check if we have to downgrade the other highest skill or not
+                    if (skillCumulation >= 400)
+                    {
+                        PChar->RealSkills.skill[skillID] += skillAmount;
+                        PChar->RealSkills.skill[skillHighest] -= skillAmount;
+
+                        PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, skillID, skillAmount, 38));
+
+                        if ((charSkill / 10) < (charSkill + skillAmount) / 10)
+                        {
+                            PChar->WorkingSkills.skill[skillID] += 0x20;
+
+                            PChar->pushPacket(new CCharSkillsPacket(PChar));
+                            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, skillID, (charSkill + skillAmount) / 10, 53));
+                        }
+
+                        if ((PChar->RealSkills.skill[skillHighest] / 10) > (PChar->RealSkills.skill[skillHighest] - skillAmount) / 10)
+                        {
+                            PChar->WorkingSkills.skill[skillHighest] -= 0x20;
+
+                            PChar->pushPacket(new CCharSkillsPacket(PChar));
+                            // PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, skillID, (charSkill + skillAmount) / 10, 53)); // do leveled down skills get a message?
+                        }
+
+                        charutils::SaveCharSkills(PChar, skillID);
+                        charutils::SaveCharSkills(PChar, skillHighest);
+                    }
+                    else // Character is under the OTHER cap and there's nothing to worry about
+                    {
+                        PChar->RealSkills.skill[skillID] += skillAmount;
+                        PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, skillID, skillAmount, 38));
+
+                        if ((charSkill / 10) < (charSkill + skillAmount) / 10)
+                        {
+                            PChar->WorkingSkills.skill[skillID] += 0x20;
+
+                            PChar->pushPacket(new CCharSkillsPacket(PChar));
+                            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, skillID, (charSkill + skillAmount) / 10, 53));
+                        }
+
+                        charutils::SaveCharSkills(PChar, skillID);
+                    }
                 }
+                else // Character is under the cap and there's nothing to worry about
+                {
+                    PChar->RealSkills.skill[skillID] += skillAmount;
+                    PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, skillID, skillAmount, 38));
 
-                charutils::SaveCharSkills(PChar, skillID);
+                    if ((charSkill / 10) < (charSkill + skillAmount) / 10)
+                    {
+                        PChar->WorkingSkills.skill[skillID] += 0x20;
+
+                        PChar->pushPacket(new CCharSkillsPacket(PChar));
+                        PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, skillID, (charSkill + skillAmount) / 10, 53));
+                    }
+
+                    charutils::SaveCharSkills(PChar, skillID);
+                }
             }
         }
     }

--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -505,70 +505,24 @@ int32 doSynthSkillUp(CCharEntity* PChar)
                     skillAmount = maxSkill - charSkill;
                 }
 
-                if (charSkill > 700) // The cap from which you are limited to 400 points
+                if (charSkill > map_config.craft_common_cap) // The cap from which you are limited to 400 points
                 {
                     uint16 skillCumulation = 0;
                     uint8 skillHighest    = 0;
 
                     // we are gonna set which is the OTHER highest skill over lvl 70 and the amount of points we have of the 400 to allocate
-                    if (PChar->RealSkills.skill[49] > 700) // Craft 1
+                    for (int i = SKILL_WOODWORKING; i <= SKILL_COOKING; i++)
                     {
-                        skillCumulation += (PChar->RealSkills.skill[49] - 700);
-                        if (skillID != 49 && PChar->RealSkills.skill[49] > skillHighest)
-                            skillHighest = 49;
-                    }
-
-                    if (PChar->RealSkills.skill[50] > 700) // Craft 2
-                    {
-                        skillCumulation += (PChar->RealSkills.skill[50] - 700);
-                        if (skillID != 50 && PChar->RealSkills.skill[50] > skillHighest)
-                            skillHighest = 50;
-                    }
-
-                    if (PChar->RealSkills.skill[51] > 700) // Craft 3
-                    {
-                        skillCumulation += (PChar->RealSkills.skill[51] - 700);
-                        if (skillID != 51 && PChar->RealSkills.skill[51] > skillHighest)
-                            skillHighest = 51;
-                    }
-
-                    if (PChar->RealSkills.skill[52] > 700) // Craft 4
-                    {
-                        skillCumulation += (PChar->RealSkills.skill[52] - 700);
-                        if (skillID != 52 && PChar->RealSkills.skill[52] > skillHighest)
-                            skillHighest = 52;
-                    }
-
-                    if (PChar->RealSkills.skill[53] > 700) // Craft 5
-                    {
-                        skillCumulation += (PChar->RealSkills.skill[53] - 700);
-                        if (skillID != 53 && PChar->RealSkills.skill[53] > skillHighest)
-                            skillHighest = 53;
-                    }
-
-                    if (PChar->RealSkills.skill[54] > 700) // Craft 6
-                    {
-                        skillCumulation += (PChar->RealSkills.skill[54] - 700);
-                        if (skillID != 54 && PChar->RealSkills.skill[54] > skillHighest)
-                            skillHighest = 54;
-                    }
-
-                    if (PChar->RealSkills.skill[55] > 700) // Craft 7
-                    {
-                        skillCumulation += (PChar->RealSkills.skill[55] - 700);
-                        if (skillID != 55 && PChar->RealSkills.skill[55] > skillHighest)
-                            skillHighest = 55;
-                    }
-
-                    if (PChar->RealSkills.skill[56] > 700) // Craft 8
-                    {
-                        skillCumulation += (PChar->RealSkills.skill[56] - 700);
-                        if (skillID != 56 && PChar->RealSkills.skill[56] > skillHighest)
-                            skillHighest = 56;
+                        if (PChar->RealSkills.skill[i] > map_config.craft_common_cap)
+                        {
+                            skillCumulation += (PChar->RealSkills.skill[i] - map_config.craft_common_cap);
+                            if (skillID != i && PChar->RealSkills.skill[i] > skillHighest)
+                                skillHighest = i;
+                        }
                     }
 
                     // now we check if we have to downgrade the other highest skill or not
-                    if (skillCumulation >= 400)
+                    if (skillCumulation >= map_config.craft_specialization_points)
                     {
                         PChar->RealSkills.skill[skillID] += skillAmount;
                         PChar->RealSkills.skill[skillHighest] -= skillAmount;


### PR DESCRIPTION
Among other things, this implements the limit imposed by retail in wich you can only have a certain amount of levels over level 70 in crafts.

**Main changes**
- *Implements "Craft Sepecialization" System*
   Retail only allows up to 40 levels across all main craft skills combined starting from level 70.
   This makes it imposible to have all skills maxed, forcing players to specialize on 1.

- *New configurable option:* Maximum amount of specialization points.
   This allows server to configure how many crafts can a character maximize.
   By default, 400 points are needed per craft.

- *New configurable option:* Maximum level of crafts before using the Specialization System.
   This is shared across all 8 crafts involved. It cannot be individualy set per craft.
   Retail = 700; Level 75 era = 600; Opt out of the system entirely = 1100;

**Other bugfixes**

- *Limit skill up gains amounts (not the chance of it happening) to 0.1 per level above level 70*
   As per https://www.bluegartr.com/threads/57123-Before-you-ask-a-stupid-crafting-question-read-this!
   This needs confirmation from a more recent era. It may have changed after the raise in level cap.
   For now I made this cap the same as the skill common cap, before the specialization system activates, becouse it made
   sense to me. (Level 70)

- *Fixes a badly placed random call*
   The place it was coded in undesirebly lowered the actual chance of 0.2+ skill ups from happening.

- *Removes crafting myths*
   As per discussion in discord.

- *Fixed skill up chance configuration variable*
   It actually works as a multiplier now and skill ups happen when set at 1.0

- *Lower skill up chance of desynths*

- *Cleaned up coments*

**Related Issues**
#66 #401 

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

