### PR TITLE
Trust Advanced Gambits

### DIFF
--- a/scripts/globals/gambits.lua
+++ b/scripts/globals/gambits.lua
@@ -36,6 +36,11 @@ ai.condition =
     SC_AVAILABLE       = 11,
     NOT_SC_AVAILABLE   = 12,
     MB_AVAILABLE       = 13,
+    READYING_WS        = 14,
+    READYING_MS        = 15,
+    READYING_JA        = 16,
+    CASTING_MA         = 17,
+    RANDOM             = 18,
 }
 ai.c = ai.condition
 

--- a/scripts/globals/gambits.lua
+++ b/scripts/globals/gambits.lua
@@ -48,6 +48,7 @@ ai.reaction =
     JA     = 3,
     WS     = 4,
     MS     = 5,
+    MSG    = 6,
 }
 ai.r = ai.reaction
 
@@ -59,5 +60,15 @@ ai.select =
     SPECIFIC   = 2,
     RANDOM     = 3,
     MB_ELEMENT = 4,
+    SPECIAL_AYAME = 5,
 }
 ai.s = ai.select
+
+-- TP Move Trigger
+ai.tp = 
+{
+    ASAP   = 0,
+    RANDOM = 1,
+    OPENER = 2,
+    CLOSER = 3,
+}

--- a/scripts/globals/mobskills/king_cobra_clamp.lua
+++ b/scripts/globals/mobskills/king_cobra_clamp.lua
@@ -1,0 +1,26 @@
+---------------------------------------------------
+-- King Cobra Clamp
+-- Damage varies with TP.
+-- Type: Magical
+-- Utsusemi/Blink absorb: Ignores shadows
+-- Skillchain Properties: Fragmentation-IconFragmentation
+---------------------------------------------------
+require("scripts/globals/settings")
+require("scripts/globals/status")
+require("scripts/globals/monstertpmoves")
+---------------------------------------------------
+
+function onMobSkillCheck(target, mob, skill)
+    return 0
+end
+
+function onMobWeaponSkill(target, mob, skill)
+    local numhits = 1
+    local accmod = 1
+    local dmgmod = 3.0
+    local info = MobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, TP_NO_EFFECT)
+    local dmg = MobFinalAdjustments(info.dmg, mob, skill, target, tpz.attackType.PHYSICAL, tpz.damageType.SLASHING, info.hitslanded)
+
+    target:takeDamage(dmg, mob, tpz.attackType.MAGICAL, tpz.damageType.SLASHING)
+    return dmg
+end

--- a/scripts/globals/spells/trust/ajido-marujido.lua
+++ b/scripts/globals/spells/trust/ajido-marujido.lua
@@ -1,8 +1,8 @@
 -----------------------------------------
 -- Trust: Ajido-Marujido
 -----------------------------------------
-require("scripts/globals/magic")
 require("scripts/globals/gambits")
+require("scripts/globals/magic")
 require("scripts/globals/status")
 require("scripts/globals/trust")
 -----------------------------------------

--- a/scripts/globals/spells/trust/ayame.lua
+++ b/scripts/globals/spells/trust/ayame.lua
@@ -24,16 +24,43 @@ function onMobSpawn(mob)
     })
 
     mob:addSimpleGambit(ai.t.SELF, ai.c.NOT_STATUS, tpz.effect.HASSO,
-                        ai.r.JA, ai.s.SPECIFIC, tpz.ja.HASSO)
+        ai.r.JA, ai.s.SPECIFIC, tpz.ja.HASSO)
 
     mob:addSimpleGambit(ai.t.SELF, ai.c.HAS_TOP_ENMITY, 0,
-                        ai.r.JA, ai.s.SPECIFIC, tpz.ja.THIRD_EYE)
+        ai.r.JA, ai.s.SPECIFIC, tpz.ja.THIRD_EYE)
+        
+    mob:addFullGambit({
+        ['predicates'] =
+        {
+            {
+                ['target'] = ai.t.SELF, ['condition'] = ai.c.TP_LT, ['argument'] = 1000,
+            },
+            {
+                ['target'] = ai.t.MASTER, ['condition'] = ai.c.TP_GTE, ['argument'] = 1000,
+            },
+        },
+        ['actions'] = 
+        {
+            {
+                ['reaction'] = ai.r.JA, ['select'] = ai.s.SPECIFIC, ['argument'] = tpz.ja.MEDITATE,
+            },
+        },
+    })
 
-    mob:addSimpleGambit(ai.t.SELF, ai.c.TP_LT, 1000,
-                        ai.r.JA, ai.s.SPECIFIC, tpz.ja.MEDITATE)
-
-    mob:addSimpleGambit(ai.t.SELF, ai.c.TP_GTE, 1000,
-                        ai.r.WS, ai.s.SPECIFIC, tpz.ws.TACHI_ENPI)
+    mob:setTPSkills({
+        ['skills'] = {
+            { ai.r.WS, tpz.ws.TACHI_ENPI, 0 },
+            { ai.r.WS, tpz.ws.TACHI_HOBAKU, 0 },
+            { ai.r.WS, tpz.ws.TACHI_GOTEN, 0 },
+            { ai.r.WS, tpz.ws.TACHI_KAGERO, 0 },
+            { ai.r.WS, tpz.ws.TACHI_JINPU, 0 },
+            { ai.r.WS, tpz.ws.TACHI_YUKIKAZE, 0 },
+            { ai.r.WS, tpz.ws.TACHI_GEKKO, 60 },
+            { ai.r.WS, tpz.ws.TACHI_KASHA, 60 },
+        },
+        ['mode'] = ai.tp.CLOSER,
+        ['skill_select'] = ai.s.HIGHEST,
+    })
 end
 
 function onMobDespawn(mob)

--- a/scripts/globals/spells/trust/curilla.lua
+++ b/scripts/globals/spells/trust/curilla.lua
@@ -34,8 +34,15 @@ function onMobSpawn(mob)
     mob:addSimpleGambit(ai.t.PARTY, ai.c.HPP_LT, 75,
                         ai.r.MA, ai.s.HIGHEST, tpz.magic.spellFamily.CURE)
 
-    mob:addSimpleGambit(ai.t.SELF, ai.c.TP_GTE, 1000,
-                        ai.r.WS, ai.s.SPECIFIC, tpz.ws.RED_LOTUS_BLADE)
+    mob:setTPSkills({
+        ['skills'] = {
+            { ai.r.WS, tpz.ws.RED_LOTUS_BLADE, 0 },
+            { ai.r.WS, tpz.ws.SERAPH_BLADE, 0 },
+            { ai.r.WS, tpz.ws.SWIFT_BLADE, 60 },
+        },
+        ['mode'] = ai.tp.ASAP,
+        ['skill_select'] = ai.s.RANDOM,
+    })
 end
 
 function onMobDespawn(mob)

--- a/scripts/globals/spells/trust/excenmille.lua
+++ b/scripts/globals/spells/trust/excenmille.lua
@@ -39,8 +39,15 @@ function onMobSpawn(mob)
     mob:addSimpleGambit(ai.t.PARTY, ai.c.HPP_LT, 75,
                         ai.r.MA, ai.s.HIGHEST, tpz.magic.spellFamily.CURE)
 
-    mob:addSimpleGambit(ai.t.SELF, ai.c.TP_GTE, 1000,
-                        ai.r.WS, ai.s.SPECIFIC, tpz.ws.DOUBLE_THRUST)
+    mob:setTPSkills({
+        ['skills'] = {
+            { ai.r.WS, tpz.ws.DOUBLE_THRUST, 0 },
+            { ai.r.WS, tpz.ws.LEG_SWEEP, 0 },
+            { ai.r.WS, tpz.ws.PENTA_THRUST, 30 },
+        },
+        ['mode'] = ai.tp.ASAP,
+        ['skill_select'] = ai.s.RANDOM,
+    })
 
     mob:addMod(tpz.mod.STORETP, 25)
 end

--- a/scripts/globals/spells/trust/iron_eater.lua
+++ b/scripts/globals/spells/trust/iron_eater.lua
@@ -25,8 +25,15 @@ function onMobSpawn(mob)
     mob:addSimpleGambit(ai.t.MASTER, ai.c.HPP_LT, 50,
                         ai.r.JA, ai.s.SPECIFIC, tpz.ja.PROVOKE)
 
-    mob:addSimpleGambit(ai.t.SELF, ai.c.TP_GTE, 1000,
-                        ai.r.WS, ai.s.SPECIFIC, tpz.ws.SHIELD_BREAK)
+    mob:setTPSkills({
+        ['skills'] = {
+            { ai.r.WS, tpz.ws.SHIELD_BREAK, 0 },
+            { ai.r.WS, tpz.ws.ARMOR_BREAK, 0 },
+            { ai.r.WS, tpz.ws.STEEL_CYCLONE, 60 },
+        },
+        ['mode'] = ai.tp.ASAP,
+        ['skill_select'] = ai.s.RANDOM,
+    })
 end
 
 function onMobDespawn(mob)

--- a/scripts/globals/spells/trust/kupipi.lua
+++ b/scripts/globals/spells/trust/kupipi.lua
@@ -59,7 +59,14 @@ function onMobSpawn(mob)
 
     mob:addSimpleGambit(ai.t.TARGET, ai.c.NOT_STATUS, tpz.effect.FLASH, ai.r.MA, ai.s.SPECIFIC, tpz.magic.spell.FLASH, 60)
 
-    mob:addSimpleGambit(ai.t.SELF, ai.c.TP_GTE, 1000, ai.r.WS, ai.s.SPECIFIC, tpz.ws.STARLIGHT)
+    mob:setTPSkills({
+        ['skills'] = {
+            { ai.r.WS, tpz.ws.STARLIGHT, 0 },
+            { ai.r.WS, tpz.ws.MOONLIGHT, 0 },
+        },
+        ['mode'] = ai.tp.ASAP,
+        ['skill_select'] = ai.s.RANDOM,
+    })
 end
 
 function onMobDespawn(mob)

--- a/scripts/globals/spells/trust/naji.lua
+++ b/scripts/globals/spells/trust/naji.lua
@@ -33,8 +33,15 @@ function onMobSpawn(mob)
     mob:addSimpleGambit(ai.t.SELF, ai.c.NOT_HAS_TOP_ENMITY, 0,
                         ai.r.JA, ai.s.SPECIFIC, tpz.ja.PROVOKE)
 
-    mob:addSimpleGambit(ai.t.SELF, ai.c.TP_GTE, 1000,
-                        ai.r.WS, ai.s.SPECIFIC, tpz.ws.BURNING_BLADE)
+    mob:setTPSkills({
+        ['skills'] = {
+            { ai.r.WS, tpz.ws.BURNING_BLADE, 0 },
+            { ai.r.WS, tpz.ws.RED_LOTUS_BLADE, 0 },
+            { ai.r.WS, tpz.ws.VORPAL_BLADE, 60 },
+        },
+        ['mode'] = ai.tp.ASAP,
+        ['skill_select'] = ai.s.RANDOM,
+    })
 end
 
 function onMobDespawn(mob)

--- a/scripts/globals/spells/trust/nanaa_mihgo.lua
+++ b/scripts/globals/spells/trust/nanaa_mihgo.lua
@@ -17,6 +17,9 @@ function onSpellCast(caster, target, spell)
 end
 
 function onMobSpawn(mob)
+    -- TODO: Table me
+    local KING_COBRA_CLAMP = 3189
+    
     tpz.trust.teamworkMessage(mob, {
         [tpz.magic.spell.ROMAA_MIHGO] = tpz.trust.message_offset.TEAMWORK_1,
     })
@@ -24,8 +27,16 @@ function onMobSpawn(mob)
     mob:addSimpleGambit(ai.t.TARGET, ai.c.ALWAYS, 0,
                         ai.r.JA, ai.s.SPECIFIC, tpz.ja.DESPOIL)
 
-    mob:addSimpleGambit(ai.t.SELF, ai.c.TP_GTE, 1000,
-                        ai.r.WS, ai.s.SPECIFIC, tpz.ws.WASP_STING)
+    mob:setTPSkills({
+        ['skills'] = {
+            { ai.r.WS, tpz.ws.WASP_STING, 0 },
+            { ai.r.WS, tpz.ws.DANCING_EDGE, 0 },
+
+            { ai.r.MS, KING_COBRA_CLAMP, 0 },
+        },
+        ['mode'] = ai.tp.OPENER,
+        ['skill_select'] = ai.s.HIGHEST,
+    })
 end
 
 function onMobDespawn(mob)

--- a/scripts/globals/spells/trust/shantotto.lua
+++ b/scripts/globals/spells/trust/shantotto.lua
@@ -26,9 +26,28 @@ function onMobSpawn(mob)
 
     mob:addSimpleGambit(ai.t.TARGET, ai.c.NOT_SC_AVAILABLE, 0, ai.r.MA, ai.s.HIGHEST, tpz.magic.spellFamily.NONE, 30)
 
+    mob:addFullGambit({
+        ['predicates'] =
+        {
+            {
+                ['target'] = ai.t.TARGET, ['condition'] = ai.c.MB_AVAILABLE, ['argument'] = 0,
+            }
+        },
+        ['actions'] = 
+        {
+            {
+                ['reaction'] = ai.r.MA, ['select'] = ai.s.HIGHEST, ['argument'] = tpz.magic.spellFamily.NONE,
+            },
+            {
+                ['reaction'] = ai.r.MSG, ['select'] = ai.s.SPECIFIC, ['argument'] = tpz.trust.message_offset.SPECIAL_MOVE_1, -- Ohohoho!
+            },
+        },
+    })
+
     local power = mob:getMainLvl() / 5
     mob:addMod(tpz.mod.MATT, power)
     mob:addMod(tpz.mod.MACC, power)
+    mob:addMod(tpz.mod.HASTE_MAGIC, 10)
     mob:SetAutoAttackEnabled(false)
 end
 

--- a/scripts/globals/spells/trust/shantotto_ii.lua
+++ b/scripts/globals/spells/trust/shantotto_ii.lua
@@ -1,13 +1,36 @@
 -----------------------------------------
 -- Trust: Shantotto II
 -----------------------------------------
+require("scripts/globals/gambits")
+require("scripts/globals/magic")
 require("scripts/globals/trust")
 -----------------------------------------
 
 function onMagicCastingCheck(caster, target, spell)
-    return tpz.trust.canCast(caster, spell, 896)
+    return tpz.trust.canCast(caster, spell, tpz.magic.spell.SHANTOTTO)
 end
 
 function onSpellCast(caster, target, spell)
     return tpz.trust.spawn(caster, spell)
+end
+
+function onMobSpawn(mob)
+    tpz.trust.message(mob, tpz.trust.message_offset.SPAWN)
+
+    mob:addSimpleGambit(ai.t.TARGET, ai.c.MB_AVAILABLE, 0, ai.r.MA, ai.s.MB_ELEMENT, tpz.magic.spellFamily.NONE)
+    mob:addSimpleGambit(ai.t.TARGET, ai.c.NOT_SC_AVAILABLE, 0, ai.r.MA, ai.s.HIGHEST, tpz.magic.spellFamily.NONE, 30)
+
+    local power = mob:getMainLvl() 
+    mob:addMod(tpz.mod.MATT, power)
+    mob:addMod(tpz.mod.MACC, power)
+    mob:addMod(tpz.mod.HASTE_MAGIC, 20)
+    mob:SetAutoAttackEnabled(false)
+end
+
+function onMobDespawn(mob)
+    tpz.trust.message(mob, tpz.trust.message_offset.DESPAWN)
+end
+
+function onMobDeath(mob)
+    tpz.trust.message(mob, tpz.trust.message_offset.DEATH)
 end

--- a/scripts/globals/spells/trust/trion.lua
+++ b/scripts/globals/spells/trust/trion.lua
@@ -33,6 +33,9 @@ function onMobSpawn(mob)
     mob:addSimpleGambit(ai.t.PARTY, ai.c.HPP_LT, 75,
                         ai.r.MA, ai.s.HIGHEST, tpz.magic.spellFamily.CURE)
 
+    -- TODO: Table me
+    local ROYAL_BASH = 3193
+    local ROYAL_SAVIOUR = 3194
     mob:setTPSkills({
         ['skills'] = {
             { ai.r.MS, ROYAL_BASH, 0 },

--- a/scripts/globals/spells/trust/trion.lua
+++ b/scripts/globals/spells/trust/trion.lua
@@ -33,8 +33,18 @@ function onMobSpawn(mob)
     mob:addSimpleGambit(ai.t.PARTY, ai.c.HPP_LT, 75,
                         ai.r.MA, ai.s.HIGHEST, tpz.magic.spellFamily.CURE)
 
-    mob:addSimpleGambit(ai.t.SELF, ai.c.TP_GTE, 1000,
-                        ai.r.WS, ai.s.SPECIFIC, tpz.ws.RED_LOTUS_BLADE)
+    mob:setTPSkills({
+        ['skills'] = {
+            { ai.r.MS, ROYAL_BASH, 0 },
+            { ai.r.MS, ROYAL_SAVIOUR, 0 },
+
+            { ai.r.WS, tpz.ws.RED_LOTUS_BLADE, 0 },
+            { ai.r.WS, tpz.ws.FLAT_BLADE, 0 },
+            { ai.r.WS, tpz.ws.SAVAGE_BLADE, 60 },
+        },
+        ['mode'] = ai.tp.ASAP,
+        ['skill_select'] = ai.s.RANDOM,
+    })
 end
 
 function onMobDespawn(mob)

--- a/scripts/globals/spells/trust/volker.lua
+++ b/scripts/globals/spells/trust/volker.lua
@@ -27,8 +27,16 @@ function onMobSpawn(mob)
     mob:addSimpleGambit(ai.t.MASTER, ai.c.HPP_LT, 50,
                         ai.r.JA, ai.s.SPECIFIC, tpz.ja.PROVOKE)
 
-    mob:addSimpleGambit(ai.t.SELF, ai.c.TP_GTE, 1000,
-                        ai.r.WS, ai.s.SPECIFIC, tpz.ws.RED_LOTUS_BLADE)
+    mob:setTPSkills({
+        ['skills'] = {
+            { ai.r.WS, tpz.ws.RED_LOTUS_BLADE, 0 },
+            { ai.r.WS, tpz.ws.SPIRIT_WITHIN, 0 },
+            { ai.r.WS, tpz.ws.VORPAL_BLADE, 60 },
+            { ai.r.WS, tpz.ws.SAVAGE_BLADE, 60 },
+        },
+        ['mode'] = ai.tp.ASAP,
+        ['skill_select'] = ai.s.RANDOM,
+    })
 end
 
 function onMobDespawn(mob)

--- a/scripts/globals/spells/trust/zeid_ii.lua
+++ b/scripts/globals/spells/trust/zeid_ii.lua
@@ -1,7 +1,12 @@
 -----------------------------------------
 -- Trust: Zeid II
 -----------------------------------------
+require("scripts/globals/ability")
+require("scripts/globals/gambits")
+require("scripts/globals/magic")
+require("scripts/globals/status")
 require("scripts/globals/trust")
+require("scripts/globals/weaponskillids")
 -----------------------------------------
 
 function onMagicCastingCheck(caster, target, spell)
@@ -10,4 +15,42 @@ end
 
 function onSpellCast(caster, target, spell)
     return tpz.trust.spawn(caster, spell)
+end
+
+function onMobSpawn(mob)
+    -- Stun all the things!
+    mob:addSimpleGambit(ai.t.TARGET, ai.c.READYING_WS, 0,
+                        ai.r.MA, ai.s.SPECIFIC, tpz.magic.spell.STUN)
+
+    mob:addSimpleGambit(ai.t.TARGET, ai.c.READYING_MS, 0,
+                        ai.r.MA, ai.s.SPECIFIC, tpz.magic.spell.STUN)
+
+    mob:addSimpleGambit(ai.t.TARGET, ai.c.READYING_JA, 0,
+                        ai.r.MA, ai.s.SPECIFIC, tpz.magic.spell.STUN)
+
+    mob:addSimpleGambit(ai.t.TARGET, ai.c.CASTING_MA, 0,
+                        ai.r.MA, ai.s.SPECIFIC, tpz.magic.spell.STUN)
+
+    -- Non-stun things
+    mob:addSimpleGambit(ai.t.SELF, ai.c.ALWAYS, 0,
+                        ai.r.JA, ai.s.SPECIFIC, tpz.ja.SOULEATER)
+
+    mob:addSimpleGambit(ai.t.SELF, ai.c.ALWAYS, 0,
+                        ai.r.JA, ai.s.SPECIFIC, tpz.ja.LAST_RESORT)
+
+    mob:setTPSkills({
+        ['skills'] = {
+            { ai.r.WS, tpz.ws.GROUND_STRIKE, 0 },
+        },
+        ['mode'] = ai.tp.CLOSER,
+        ['skill_select'] = ai.s.RANDOM,
+    })
+end
+
+function onMobDespawn(mob)
+    tpz.trust.message(mob, tpz.trust.message_offset.DESPAWN)
+end
+
+function onMobDeath(mob)
+    tpz.trust.message(mob, tpz.trust.message_offset.DEATH)
 end

--- a/scripts/globals/spells/trust/zeid_ii.lua
+++ b/scripts/globals/spells/trust/zeid_ii.lua
@@ -18,6 +18,8 @@ function onSpellCast(caster, target, spell)
 end
 
 function onMobSpawn(mob)
+    tpz.trust.message(mob, tpz.trust.message_offset.SPAWN)
+
     -- Stun all the things!
     mob:addSimpleGambit(ai.t.TARGET, ai.c.READYING_WS, 0,
                         ai.r.MA, ai.s.SPECIFIC, tpz.magic.spell.STUN)

--- a/src/map/ai/controllers/trust_controller.cpp
+++ b/src/map/ai/controllers/trust_controller.cpp
@@ -110,20 +110,27 @@ void CTrustController::DoCombatTick(time_point tick)
             std::unique_ptr<CBasicPacket> err;
             if (!POwner->CanAttack(PTarget, err) && POwner->speed > 0)
             {
-                if (currentDistance < WarpDistance)
+                if (currentDistance > WarpDistance)
                 {
-                    POwner->PAI->PathFind->PathTo(PTarget->loc.p, PATHFLAG_RUN | PATHFLAG_WALLHACK);
+                    POwner->PAI->PathFind->WarpTo(PTarget->loc.p);
                 }
-                else
+                else if (currentDistance > RoamDistance)
                 {
-                    POwner->PAI->PathFind->WarpTo(PMaster->loc.p, RoamDistance);
+                    if (currentDistance < RoamDistance * 3.0f && POwner->PAI->PathFind->PathAround(PTarget->loc.p, RoamDistance, PATHFLAG_RUN | PATHFLAG_WALLHACK))
+                    {
+                        POwner->PAI->PathFind->FollowPath();
+                    }
+                    else if (POwner->GetSpeed() > 0)
+                    {
+                        POwner->PAI->PathFind->StepTo(PTarget->loc.p, true);
+                    }
                 }
             }
             else
             {
                 for (auto POtherTrust : PMaster->PTrusts)
                 {
-                    if (POtherTrust != POwner && !POtherTrust->PAI->PathFind->IsFollowingPath() && distance(POtherTrust->loc.p, POwner->loc.p) < 1.0f)
+                    if (POtherTrust != POwner && !POtherTrust->PAI->PathFind->IsFollowingPath() && distance(POtherTrust->loc.p, POwner->loc.p) < 2.0f)
                     {
                         auto angle = getangle(POwner->loc.p, PTarget->loc.p) + 64;
                         auto amount = (currentPartyPos % 2) ? 1.0f : -1.0f;
@@ -187,15 +194,19 @@ void CTrustController::DoRoamTick(time_point tick)
         }
     }
 
-    if (currentDistance > RoamDistance)
+    if (currentDistance > WarpDistance)
     {
-        if (currentDistance < WarpDistance && POwner->PAI->PathFind->PathAround(PFollowTarget->loc.p, RoamDistance, PATHFLAG_RUN | PATHFLAG_WALLHACK))
+        POwner->PAI->PathFind->WarpTo(PFollowTarget->loc.p);
+    }
+    else if (currentDistance > RoamDistance)
+    {
+        if (currentDistance < RoamDistance * 3.0f && POwner->PAI->PathFind->PathAround(PFollowTarget->loc.p, RoamDistance, PATHFLAG_RUN | PATHFLAG_WALLHACK))
         {
             POwner->PAI->PathFind->FollowPath();
         }
         else if (POwner->GetSpeed() > 0)
         {
-            POwner->PAI->PathFind->WarpTo(PFollowTarget->loc.p, RoamDistance);
+            POwner->PAI->PathFind->StepTo(PFollowTarget->loc.p, true);
         }
     }
 

--- a/src/map/ai/controllers/trust_controller.cpp
+++ b/src/map/ai/controllers/trust_controller.cpp
@@ -110,11 +110,11 @@ void CTrustController::DoCombatTick(time_point tick)
             std::unique_ptr<CBasicPacket> err;
             if (!POwner->CanAttack(PTarget, err) && POwner->speed > 0)
             {
-                if (currentDistance < WarpDistance && POwner->PAI->PathFind->PathAround(PTarget->loc.p, PATHFLAG_RUN | PATHFLAG_WALLHACK))
+                if (currentDistance < WarpDistance)
                 {
-                    POwner->PAI->PathFind->FollowPath();
+                    POwner->PAI->PathFind->PathTo(PTarget->loc.p, PATHFLAG_RUN | PATHFLAG_WALLHACK);
                 }
-                else if (POwner->GetSpeed() > 0)
+                else
                 {
                     POwner->PAI->PathFind->WarpTo(PMaster->loc.p, RoamDistance);
                 }

--- a/src/map/ai/helpers/gambits_container.cpp
+++ b/src/map/ai/helpers/gambits_container.cpp
@@ -474,6 +474,7 @@ bool CGambitsContainer::TryTrustSkill()
                 }
                 break;
             }
+            default: { break; }
         }
     }
 

--- a/src/map/ai/helpers/gambits_container.h
+++ b/src/map/ai/helpers/gambits_container.h
@@ -167,6 +167,8 @@ public:
     G_SELECT tp_select;
 
 private:
+    bool TryTrustSkill();
+
     CTrustEntity* POwner;
     time_point m_lastAction;
     std::vector<Gambit_t> gambits;

--- a/src/map/ai/helpers/gambits_container.h
+++ b/src/map/ai/helpers/gambits_container.h
@@ -38,6 +38,11 @@ enum class G_CONDITION : uint16
     SC_AVAILABLE       = 11,
     NOT_SC_AVAILABLE   = 12,
     MB_AVAILABLE       = 13,
+    READYING_WS        = 14,
+    READYING_MS        = 15,
+    READYING_JA        = 16,
+    CASTING_MA         = 17,
+    RANDOM             = 18,
 };
 
 enum class G_REACTION : uint16

--- a/src/map/ai/helpers/gambits_container.h
+++ b/src/map/ai/helpers/gambits_container.h
@@ -1,4 +1,4 @@
-#ifndef _GAMBITSCONTAINER
+﻿#ifndef _GAMBITSCONTAINER
 #define _GAMBITSCONTAINER
 
 #include "../../../common/cbasetypes.h"
@@ -48,6 +48,7 @@ enum class G_REACTION : uint16
     JA     = 3,
     WS     = 4,
     MS     = 5,
+    MSG    = 6,
 };
 
 enum class G_SELECT : uint16
@@ -57,37 +58,98 @@ enum class G_SELECT : uint16
     SPECIFIC   = 2,
     RANDOM     = 3,
     MB_ELEMENT = 4,
+    SPECIAL_AYAME = 5,
+};
+
+enum class G_TP_TRIGGER : uint16
+{
+    ASAP = 0,
+    RANDOM = 1,
+    OPENER = 2,
+    CLOSER = 3,
 };
 
 struct Predicate_t
 {
     G_TARGET target;
     G_CONDITION condition;
-    uint16 condition_arg;
+    uint32 condition_arg = 0;
+
+    bool parseInput(std::string key, uint32 value)
+    {
+        if (key.compare("target") == 0)
+        {
+            target = static_cast<G_TARGET>(value);
+        }
+        else if (key.compare("condition") == 0)
+        {
+            condition = static_cast<G_CONDITION>(value);
+        }
+        else if (key.compare("argument") == 0)
+        {
+            condition_arg = value;
+        }
+        else
+        {
+            // TODO: Log error
+            return false;
+        }
+        return true;
+    }
 };
 
 struct Action_t
 {
     G_REACTION reaction;
     G_SELECT select;
-    uint16 select_arg;
+    uint32 select_arg = 0;
+
+    bool parseInput(std::string key, uint32 value)
+    {
+        if (key.compare("reaction") == 0)
+        {
+            reaction = static_cast<G_REACTION>(value);
+        }
+        else if (key.compare("select") == 0)
+        {
+            select = static_cast<G_SELECT>(value);
+        }
+        else if (key.compare("argument") == 0)
+        {
+            select_arg = value;
+        }
+        else
+        {
+            // TODO: Log error
+            return false;
+        }
+        return true;
+    }
 };
 
 struct Gambit_t
 {
-    Predicate_t predicate;
-    Action_t action;
-
-    // TODO:
-    //std::vector<Predicate_t> predicates;
-    //std::vector<Action_t> actions;
-    uint16 retry_delay;
+    std::vector<Predicate_t> predicates;
+    std::vector<Action_t> actions;
+    uint16 retry_delay = 0;
     time_point last_used;
 };
 
+// TODO
 struct Chain_t
 {
     std::vector<Gambit_t> gambits;
+};
+
+// TODO: smaller types, make less bad.
+struct TrustSkill_t
+{
+    G_REACTION skill_type;
+    uint32 skill_id;
+    uint32 min_level;
+    uint8 primary;
+    uint8 secondary;
+    uint8 tertiary;
 };
 
 class CGambitsContainer
@@ -98,6 +160,11 @@ public:
 
     void AddGambit(Gambit_t gambit);
     void Tick(time_point tick);
+
+    // TODO: make private
+    std::vector<TrustSkill_t> tp_skills;
+    G_TP_TRIGGER tp_trigger;
+    G_SELECT tp_select;
 
 private:
     CTrustEntity* POwner;

--- a/src/map/ai/helpers/gambits_container.h
+++ b/src/map/ai/helpers/gambits_container.h
@@ -167,6 +167,7 @@ public:
     G_SELECT tp_select;
 
 private:
+    bool CheckTrigger(CBattleEntity* trigger_target, Predicate_t& predicate);
     bool TryTrustSkill();
 
     CTrustEntity* POwner;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -12401,7 +12401,6 @@ inline int32 CLuaBaseEntity::addFullGambit(lua_State* L)
     {
         auto table = lua_gettop(L);
         lua_pushnil(L);
-        int counter = 0;
         while (lua_next(L, table) != 0)
         {
             Predicate_t new_predicate;
@@ -12433,7 +12432,6 @@ inline int32 CLuaBaseEntity::addFullGambit(lua_State* L)
     {
         auto table = lua_gettop(L);
         lua_pushnil(L);
-        int counter = 0;
         while (lua_next(L, table) != 0)
         {
             Action_t new_action;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -12309,7 +12309,7 @@ inline int32 CLuaBaseEntity::trustPartyMessage(lua_State* L)
 
     auto PTrust = static_cast<CTrustEntity*>(m_PBaseEntity);
 
-    auto message_id = lua_tointeger(L, 1);
+    auto message_id = (uint32)lua_tointeger(L, 1);
 
     auto PMaster = static_cast<CCharEntity*>(PTrust->PMaster);
     if (PMaster)

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -12278,7 +12278,6 @@ inline int32 CLuaBaseEntity::clearTrusts(lua_State* L)
     return 0;
 }
 
-
 /************************************************************************
 *  Function: getTrustID()
 *  Purpose :
@@ -12293,6 +12292,36 @@ inline int32 CLuaBaseEntity::getTrustID(lua_State* L)
 
     lua_pushinteger(L, ((CTrustEntity*)m_PBaseEntity)->m_TrustID);
     return 1;
+}
+
+/************************************************************************
+*  Function: trustPartyMessage()
+*  Purpose :
+*  Example : mob:trustPartyMessage(message_id)
+*  Notes   :
+************************************************************************/
+
+inline int32 CLuaBaseEntity::trustPartyMessage(lua_State* L)
+{
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_TRUST);
+    TPZ_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isnumber(L, 1));
+
+    auto PTrust = static_cast<CTrustEntity*>(m_PBaseEntity);
+
+    auto message_id = lua_tointeger(L, 1);
+
+    auto PMaster = static_cast<CCharEntity*>(PTrust->PMaster);
+    if (PMaster)
+    {
+        PMaster->ForParty([&](CBattleEntity* PMember)
+            {
+                auto PCharMember = static_cast<CCharEntity*>(PMember);
+                PCharMember->pushPacket(new CMessageCombatPacket(PTrust, PMember, message_id, 0, 711));
+            });
+    }
+
+    return 0;
 }
 
 /************************************************************************
@@ -12318,11 +12347,11 @@ inline int32 CLuaBaseEntity::addSimpleGambit(lua_State* L)
 
     auto target = static_cast<G_TARGET>(lua_tointeger(L, 1));
     auto condition = static_cast<G_CONDITION>(lua_tointeger(L, 2));
-    auto condition_arg = static_cast<uint16>(lua_tointeger(L, 3));
+    auto condition_arg = static_cast<uint32>(lua_tointeger(L, 3));
 
     auto reaction = static_cast<G_REACTION>(lua_tointeger(L, 4));
     auto selector = static_cast<G_SELECT>(lua_tointeger(L, 5));
-    auto selector_arg = static_cast<uint16>(lua_tointeger(L, 6));
+    auto selector_arg = static_cast<uint32>(lua_tointeger(L, 6));
 
     // Optional
     auto retry_delay = 0;
@@ -12331,7 +12360,9 @@ inline int32 CLuaBaseEntity::addSimpleGambit(lua_State* L)
         retry_delay = (uint16)lua_tointeger(L, 7);
     }
 
-    Gambit_t g{ { target, condition, condition_arg }, { reaction, selector, selector_arg } };
+    Gambit_t g;
+    g.predicates.emplace_back(Predicate_t{ target, condition, condition_arg });
+    g.actions.emplace_back(Action_t{ reaction, selector, selector_arg });
     g.retry_delay = retry_delay;
 
     auto trust = static_cast<CTrustEntity*>(m_PBaseEntity);
@@ -12349,44 +12380,6 @@ inline int32 CLuaBaseEntity::addSimpleGambit(lua_State* L)
 *  Notes   : Adds a behaviour to the gambit system
 ************************************************************************/
 
-inline void build_gambit(lua_State* L, std::vector<int>& nums, int index, int depth = 0)
-{
-    lua_pushvalue(L, index);
-    lua_pushnil(L);
-    while (lua_next(L, -2))
-    {
-        lua_pushvalue(L, -2);
-
-        auto key = lua_tostring(L, -1);
-        auto value = lua_tostring(L, -2);
-        auto type = lua_type(L, -2);
-        auto type_name = lua_typename(L, type);
-
-        printf("(depth: %d, type: %s) %s => %s\n", depth, type_name, key, value);
-
-        // TODO: This is bad.
-        if (depth == 3)
-        {
-            nums.push_back((int)lua_tonumber(L, -2));
-        }
-
-        if (lua_istable(L, -2))
-        {
-            build_gambit(L, nums, -2, ++depth);
-        }
-        else
-        {
-            // TODO: Hack to keep depth constant for numbers
-            ++depth;
-        }
-
-        --depth;
-        lua_pop(L, 2);
-    }
-    lua_pop(L, 1);
-    --depth;
-}
-
 inline int32 CLuaBaseEntity::addFullGambit(lua_State* L)
 {
     TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
@@ -12395,27 +12388,88 @@ inline int32 CLuaBaseEntity::addFullGambit(lua_State* L)
 
     using namespace gambits;
 
-    std::vector<int> nums;
-    build_gambit(L, nums, 1);
+    // ===
 
-    TPZ_DEBUG_BREAK_IF(nums.size() != 6);
+    Gambit_t g;
 
-    if (nums.size() != 6)
+    bool gambit_error = false;
+
+    lua_pushvalue(L, 1); // Push main table onto stack
+
+    lua_getfield(L, 1, "predicates"); // Acts as push
+    if (lua_istable(L, -1)) // Found
     {
-        ShowWarning("Invalid Gambit");
-        return 0;
+        auto table = lua_gettop(L);
+        lua_pushnil(L);
+        int counter = 0;
+        while (lua_next(L, table) != 0)
+        {
+            Predicate_t new_predicate;
+            auto sub_table = lua_gettop(L);
+            lua_pushnil(L);
+            while (lua_next(L, sub_table) != 0)
+            {
+                auto key = std::string(lua_tostring(L, -2));
+                auto value = static_cast<uint32>(lua_tonumber(L, -1));
+                lua_pop(L, 1);
+
+                if (!new_predicate.parseInput(key, value))
+                {
+                    gambit_error = true;
+                }
+            }
+            g.predicates.emplace_back(new_predicate);
+            lua_pop(L, 1);
+        }
+        lua_pop(L, 1);
+    }
+    else // No predicates block found!
+    {
+        gambit_error = true;
     }
 
-    // TODO: don't hardcode this...
-    auto target = static_cast<G_TARGET>(nums[0]);
-    auto condition = static_cast<G_CONDITION>(nums[1]);
-    auto condition_arg = static_cast<uint16>(nums[2]);
+    lua_getfield(L, 1, "actions");
+    if (lua_istable(L, -1))
+    {
+        auto table = lua_gettop(L);
+        lua_pushnil(L);
+        int counter = 0;
+        while (lua_next(L, table) != 0)
+        {
+            Action_t new_action;
+            auto sub_table = lua_gettop(L);
+            lua_pushnil(L);
+            while (lua_next(L, sub_table) != 0)
+            {
+                auto key = std::string(lua_tostring(L, -2));
+                auto value = static_cast<uint32>(lua_tonumber(L, -1));
+                lua_pop(L, 1);
 
-    auto reaction = static_cast<G_REACTION>(nums[3]);
-    auto selector = static_cast<G_SELECT>(nums[4]);
-    auto selector_arg = static_cast<uint16>(nums[5]);
+                if (!new_action.parseInput(key, (uint32)value))
+                {
+                    gambit_error = true;
+                }
+            }
+            g.actions.emplace_back(new_action);
+            lua_pop(L, 1);
+        }
+        lua_pop(L, 1);
+    }
+    else // No actions block found!
+    {
+        gambit_error = true;
+    }
 
-    Gambit_t g{ { target, condition, condition_arg }, { reaction, selector, selector_arg } };
+    lua_pop(L, 1);
+
+    lua_pop(L, 1); // Main table
+
+    if (gambit_error)
+    {
+        ShowWarning("Invalid Gambit");
+    }
+
+    // ===
 
     auto trust = static_cast<CTrustEntity*>(m_PBaseEntity);
     auto controller = static_cast<CTrustController*>(trust->PAI->GetController());
@@ -12425,25 +12479,115 @@ inline int32 CLuaBaseEntity::addFullGambit(lua_State* L)
     return 0;
 }
 
-inline int32 CLuaBaseEntity::trustPartyMessage(lua_State* L)
+/************************************************************************
+*  Function: setTPSkills()
+*  Purpose :
+*  Example : mob:setTPSkills(...)
+*  Notes   :
+************************************************************************/
+
+int32 CLuaBaseEntity::setTPSkills(lua_State* L)
 {
     TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
     TPZ_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_TRUST);
-    TPZ_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isnumber(L, 1));
+    TPZ_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_istable(L, 1));
 
-    auto PTrust = static_cast<CTrustEntity*>(m_PBaseEntity);
+    auto trust = static_cast<CTrustEntity*>(m_PBaseEntity);
+    auto controller = static_cast<CTrustController*>(trust->PAI->GetController());
+    auto mLvl = trust->GetMLevel();
 
-    auto message_id = static_cast<int32>(lua_tointeger(L, 1));
+    using namespace gambits;
 
-    auto PMaster = static_cast<CCharEntity*>(PTrust->PMaster);
-    if (PMaster)
+    // TODO: This is all garbage and arcane, can be done better!
+
+    std::vector<uint32> skills_data;
+
+    // skills
+    lua_getfield(L, 1, "skills");
+    if (lua_istable(L, -1))
     {
-        PMaster->ForParty([&](CBattleEntity* PMember)
+        auto table = lua_gettop(L);
+        lua_pushnil(L);
+        while (lua_next(L, table) != 0)
         {
-            auto PCharMember = static_cast<CCharEntity*>(PMember);
-            PCharMember->pushPacket(new CMessageCombatPacket(PTrust, PMember, message_id, 0, 711));
-        });
+            auto sub_table = lua_gettop(L);
+            lua_pushnil(L);
+            while (lua_next(L, sub_table) != 0)
+            {
+                auto value = static_cast<uint32>(lua_tonumber(L, -1));
+                skills_data.emplace_back(value);
+                lua_pop(L, 1);
+            }
+            lua_pop(L, 1);
+        }
     }
+    else
+    {
+        // No skills, fatal!
+    }
+    lua_pop(L, 1);
+
+    // Handle skills_data
+    for (size_t i = 0; i < skills_data.size(); i += 3)
+    {
+        auto skill_type = skills_data[i];
+        auto skill_id = skills_data[i + 1];
+        auto min_level = skills_data[i + 2];
+
+        TrustSkill_t skill{ static_cast<G_REACTION>(skill_type), skill_id, min_level };
+        if (skill.skill_type == G_REACTION::WS)
+        {
+            CWeaponSkill* PWeaponSkill = battleutils::GetWeaponSkill(skill_id);
+            if (!PWeaponSkill)
+            {
+                ShowWarning("CLuaBaseEntity::setTPSkills: Error loading WeaponSkill id %d for trust %s\n", skill_id, trust->name);
+                break;
+            }
+            skill.primary = PWeaponSkill->getPrimarySkillchain();
+            skill.secondary = PWeaponSkill->getSecondarySkillchain();
+            skill.tertiary = PWeaponSkill->getTertiarySkillchain();
+        }
+        else // MS
+        {
+            CMobSkill* PMobSkill = battleutils::GetMobSkill(skill_id);
+            if (!PMobSkill)
+            {
+                ShowWarning("CLuaBaseEntity::setTPSkills: Error loading MobSkill id %d for trust %s\n", skill_id, trust->name);
+                break;
+            }
+            skill.primary = PMobSkill->getPrimarySkillchain();
+            skill.secondary = PMobSkill->getSecondarySkillchain();
+            skill.tertiary = PMobSkill->getTertiarySkillchain();
+        }
+        
+        if (mLvl >= min_level)
+        {
+            controller->m_GambitsContainer->tp_skills.emplace_back(skill);
+        }
+     }
+
+    // mode
+    uint32 mode = 0;
+    lua_getfield(L, 1, "mode");
+    if (lua_isnumber(L, -1))
+    {
+        mode = static_cast<uint32>(lua_tonumber(L, -1));
+    }
+    lua_pop(L, 1);
+
+    // skill_select
+    uint32 skill_select = 0;
+    lua_getfield(L, 1, "skill_select");
+    if (lua_isnumber(L, -1))
+    {
+        skill_select = static_cast<uint32>(lua_tonumber(L, -1));
+    }
+    lua_pop(L, 1);
+
+    lua_pop(L, 1); // Init state
+
+    controller->m_GambitsContainer->tp_trigger = static_cast<G_TP_TRIGGER>(mode);
+    controller->m_GambitsContainer->tp_select = static_cast<G_SELECT>(skill_select);
 
     return 0;
 }
@@ -14936,6 +15080,8 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,sendReraise),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,sendTractor),
 
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,messageCombat),
+
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,engage),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,isEngaged),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,disengage),
@@ -15099,10 +15245,11 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,spawnTrust),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,clearTrusts),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getTrustID),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,trustPartyMessage),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,addSimpleGambit),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,addFullGambit),
-    LUNAR_DECLARE_METHOD(CLuaBaseEntity,trustPartyMessage),
-
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,setTPSkills),
+  
     // Mob Entity-Specific
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,setMobLevel),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getSystem),

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -588,12 +588,13 @@ public:
     int32 spawnPet(lua_State*);              // Calls Pet
     int32 despawnPet(lua_State*);            // Despawns Pet
 
-    int32 spawnTrust(lua_State*);            // Spawns trust
+    int32 spawnTrust(lua_State*);
     int32 clearTrusts(lua_State*);
     int32 getTrustID(lua_State*);
+    int32 trustPartyMessage(lua_State*);
     int32 addSimpleGambit(lua_State*);
     int32 addFullGambit(lua_State*);
-    int32 trustPartyMessage(lua_State*);
+    int32 setTPSkills(lua_State*);
 
     int32 isJugPet(lua_State*);              // If the entity has a pet, test if it is a jug pet.
     int32 hasValidJugPetItem(lua_State*);


### PR DESCRIPTION
Behold, spaghetti! 

This PR allows multiple predicates and actions inside a single gambit and makes the `addFullGambit` binding usable.

**Ayame Meditate (Multiple Predicates):**
```
    mob:addFullGambit({
        ['predicates'] =
        {
            {
                ['target'] = ai.t.SELF,
                ['condition'] = ai.c.TP_LT,
                ['argument'] = 1000,
            },
            {
                ['target'] = ai.t.MASTER,
                ['condition'] = ai.c.TP_GTE,
                ['argument'] = 1000,
            },
        },
        ['actions'] = 
        {
            {
                ['reaction'] = ai.r.JA,
                ['select'] = ai.s.SPECIFIC,
                ['argument'] = tpz.ja.MEDITATE,
            },
        },
    })
```

**Shantotto Magic Burst (Multiple Actions):**
```
    mob:addFullGambit({
        ['predicates'] =
        {
            {
                ['target'] = ai.t.TARGET,
                ['condition'] = ai.c.MB_AVAILABLE,
            },
        },
        ['actions'] = 
        {
            {
                ['reaction'] = ai.r.MA,
                ['select'] = ai.s.MB_ELEMENT,
            },
            {
                ['reaction'] = ai.r.MESSAGE,
                ['argument'] = tpz.trust.message_offset.SPECIAL_MOVE_1  -- Ohohoho!
            },
        },
    })
```

**Ayame define WSs:**
```lua
mob:setTPSkills({
       ['skills'] = {
            { ai.r.WS, tpz.ws.TACHI_ENPI, 0 },
            { ai.r.WS, tpz.ws.TACHI_HOBAKU, 0 },
            { ai.r.WS, tpz.ws.TACHI_GOTEN, 0 },
            { ai.r.WS, tpz.ws.TACHI_KAGERO, 0 },
            { ai.r.WS, tpz.ws.TACHI_JINPU, 0 },
            { ai.r.WS, tpz.ws.TACHI_YUKIKAZE, 0 },
            { ai.r.WS, tpz.ws.TACHI_GEKKO, 60 },
            { ai.r.WS, tpz.ws.TACHI_KASHA, 60 },
        },
        ['mode'] = ai.tp.CLOSER,
        ['skill_select'] = ai.s.HIGHEST,
    })
```
**TODO:**
Targetting needs to be fixed, it's currently a nightmare.
Action queueing
More helpful gambit parsing errors
Combine Simple and Full gambits into one binding (ie. Make the format for full gambit not crazy)

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

