### PR TITLE
tpz.zone referenced in casket_loot

### DIFF
--- a/scripts/globals/casket_loot.lua
+++ b/scripts/globals/casket_loot.lua
@@ -4,6 +4,9 @@
 -- this is because some zones have high mobs and low mobs,
 -- and the drops are level dependant.
 -----------------------------------------------------------
+
+require("scripts/globals/zone")
+
 tpz = tpz or {}
 tpz.casket_loot = tpz.casket_loot or {}
 


### PR DESCRIPTION
casket_loot.lua should require zone global with its usage of tpz.zone.  I only recently saw this error crop up on a mutli-server setup.  Something must behave differently when running on a single server that the log does not spam errors when loading a zone eligible for caskets.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

