### PR TITLE
Trust Melee Balancing

### DIFF
--- a/scripts/globals/spells/trust/excenmille.lua
+++ b/scripts/globals/spells/trust/excenmille.lua
@@ -40,6 +40,10 @@ function onMobSpawn(mob)
 
     mob:addSimpleGambit(ai.t.SELF, ai.c.TP_GTE, 1000,
                         ai.r.WS, ai.s.SPECIFIC, tpz.ws.DOUBLE_THRUST)
+
+    -- Excenmille is a PLD who uses a Polearm, so raise his MAIN_DMG_RATING (up from 1H Sword levels)
+    local increase_damage_by_percent = 1.2
+    mob:addMod(tpz.mod.MAIN_DMG_RATING, mob:getWeaponDmg() * increase_damage_by_percent)
 end
 
 function onMobDespawn(mob)

--- a/scripts/globals/spells/trust/excenmille.lua
+++ b/scripts/globals/spells/trust/excenmille.lua
@@ -42,8 +42,8 @@ function onMobSpawn(mob)
                         ai.r.WS, ai.s.SPECIFIC, tpz.ws.DOUBLE_THRUST)
 
     -- Excenmille is a PLD who uses a Polearm, so raise his MAIN_DMG_RATING (up from 1H Sword levels)
-    local increase_damage_by_percent = 1.2
-    mob:addMod(tpz.mod.MAIN_DMG_RATING, mob:getWeaponDmg() * increase_damage_by_percent)
+    local increase_damage_by_percent = 30
+    mob:addMod(tpz.mod.MAIN_DMG_RATING, mob:getWeaponDmg() * (1.0 + (increase_damage_by_percent / 100)))
 end
 
 function onMobDespawn(mob)

--- a/scripts/globals/spells/trust/naji.lua
+++ b/scripts/globals/spells/trust/naji.lua
@@ -30,6 +30,10 @@ function onMobSpawn(mob)
 
     mob:addSimpleGambit(ai.t.SELF, ai.c.TP_GTE, 1000,
                         ai.r.WS, ai.s.SPECIFIC, tpz.ws.BURNING_BLADE)
+
+    -- Naji is a WAR who uses a 1H Sword, so lower his MAIN_DMG_RATING (down from G.Axe levels)
+    local reduce_damage_by_percent = 0.3
+    mob:addMod(tpz.mod.MAIN_DMG_RATING, mob:getWeaponDmg() * reduce_damage_by_percent * -1.0)
 end
 
 function onMobDespawn(mob)

--- a/scripts/globals/spells/trust/naji.lua
+++ b/scripts/globals/spells/trust/naji.lua
@@ -32,8 +32,8 @@ function onMobSpawn(mob)
                         ai.r.WS, ai.s.SPECIFIC, tpz.ws.BURNING_BLADE)
 
     -- Naji is a WAR who uses a 1H Sword, so lower his MAIN_DMG_RATING (down from G.Axe levels)
-    local reduce_damage_by_percent = 0.3
-    mob:addMod(tpz.mod.MAIN_DMG_RATING, mob:getWeaponDmg() * reduce_damage_by_percent * -1.0)
+    local reduce_damage_by_percent = 30
+    mob:addMod(tpz.mod.MAIN_DMG_RATING, mob:getWeaponDmg() * (reduce_damage_by_percent / 100) * -1.0)
 end
 
 function onMobDespawn(mob)

--- a/scripts/globals/spells/trust/shantotto.lua
+++ b/scripts/globals/spells/trust/shantotto.lua
@@ -20,6 +20,11 @@ function onMobSpawn(mob)
 
     mob:addSimpleGambit(ai.t.TARGET, ai.c.NOT_SC_AVAILABLE, 0,
                         ai.r.MA, ai.s.HIGHEST, tpz.magic.spellFamily.NONE, 30)
+
+    local power = mob:getMainLvl() / 5
+    mob:addMod(tpz.mod.MATT, power)
+    mob:addMod(tpz.mod.MACC, power)
+    mob:SetAutoAttackEnabled(false)
 end
 
 function onMobDespawn(mob)

--- a/src/map/utils/trustutils.cpp
+++ b/src/map/utils/trustutils.cpp
@@ -384,14 +384,22 @@ void LoadTrustStatsAndSkills(CTrustEntity* PTrust)
     float damage_mod = 1.0f;
     switch (mJob)
     {
-        // TODO: All jobs
+        // TODO: Check all jobs
 
         // Assuming the job is using its "default" weapon type, otherwise adjust damage with mods.
         // FAST WEAPONS
-        case JOB_MNK: { damage_mod = 0.60f; break; }
-        case JOB_THF: { damage_mod = 0.60f; break; }
+        case JOB_MNK:
+        case JOB_THF:
+        case JOB_NIN:
+        case JOB_PUP:
+            { damage_mod = 0.60f; break; }
         // SLOW WEAPONS
-        case JOB_WAR: { damage_mod = 1.50f; break; }
+        case JOB_WAR:
+        case JOB_DRK:
+        case JOB_SAM:
+        case JOB_DRG:
+        case JOB_RUN:
+            { damage_mod = 1.50f; break; }
         // NORMAL WEAPONS
         default: { damage_mod = 1.0f; break; }
     }

--- a/src/map/utils/trustutils.cpp
+++ b/src/map/utils/trustutils.cpp
@@ -378,7 +378,31 @@ void LoadTrustStatsAndSkills(CTrustEntity* PTrust)
     PTrust->health.hp = PTrust->GetMaxHP();
     PTrust->health.mp = PTrust->GetMaxMP();
 
-    ((CItemWeapon*)PTrust->m_Weapons[SLOT_MAIN])->setDamage(mobutils::GetWeaponDamage(PTrust));
+    // TODO: Set damage and delay based on job/sjob
+    // Base damage is based on mob calculations and is far too high, scale down here and fine tune below.
+    auto baseDamage = mobutils::GetWeaponDamage(PTrust) * 0.5;
+    float damage_mod = 1.0f;
+    switch (mJob)
+    {
+        // TODO: All jobs
+
+        // Assuming the job is using its "default" weapon type, otherwise adjust damage with mods.
+        // FAST WEAPONS
+        case JOB_MNK: { damage_mod = 0.60f; break; }
+        case JOB_THF: { damage_mod = 0.60f; break; }
+        // SLOW WEAPONS
+        case JOB_WAR: { damage_mod = 1.50f; break; }
+        // NORMAL WEAPONS
+        default: { damage_mod = 1.0f; break; }
+    }
+
+    ((CItemWeapon*)PTrust->m_Weapons[SLOT_MAIN])->setDamage((uint16)(baseDamage * damage_mod));
+
+    // Reduce weapon delay of MNK
+    if (PTrust->GetMJob() == JOB_MNK)
+    {
+        ((CItemWeapon*)PTrust->m_Weapons[SLOT_MAIN])->resetDelay();
+    }
 
     uint16 fSTR = mobutils::GetBaseToRank(PTrust->strRank, mLvl);
     uint16 fDEX = mobutils::GetBaseToRank(PTrust->dexRank, mLvl);


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Trusts were using monster-level weapon damage with no regard to their jobs. This is a quick patch to bring their weapon damage down and scale a bit around their jobs' default weapon. There are mods to adjust Excenmille and Naji's weapon damages since they don't use their jobs' default weapons.

NOTE: Currently only targets Trusts that are "available". Will be expanded in future PRs.