### PR TITLE
Fix climbpix spawn conditions and THF AF2 script.

### DIFF
--- a/scripts/zones/Sauromugue_Champaign/IDs.lua
+++ b/scripts/zones/Sauromugue_Champaign/IDs.lua
@@ -53,6 +53,7 @@ zones[tpz.zone.SAUROMUGUE_CHAMPAIGN] =
     npc =
     {
         CASKET_BASE = 17269190,
+        QM2         = 17269228,
     },
 }
 

--- a/scripts/zones/Sauromugue_Champaign/Zone.lua
+++ b/scripts/zones/Sauromugue_Champaign/Zone.lua
@@ -18,6 +18,7 @@ end
 function onInitialize(zone)
     UpdateNMSpawnPoint(ID.mob.ROC)
     GetMobByID(ID.mob.ROC):setRespawnTime(math.random(900, 10800))
+    GetNPCByID(ID.npc.QM2 + math.random(0, 5)):setLocalVar("[QM]Select", 1) -- Determine which QM is active today for THF AF2
 end
 
 function onZoneIn( player, prevZone)
@@ -41,6 +42,13 @@ function onConquestUpdate(zone, updatetype)
 end
 
 function onRegionEnter(player, region)
+end
+
+function onGameDay(zone)
+    for i = ID.npc.QM2, ID.npc.QM2+5 do
+        GetNPCByID(i):resetLocalVars()
+    end
+    GetNPCByID(ID.npc.QM2 + math.random(0, 5)):setLocalVar("[QM]Select", 1) -- Determine which QM is active today for THF AF2
 end
 
 function onEventUpdate(player, csid, option)

--- a/scripts/zones/Sauromugue_Champaign/npcs/qm2.lua
+++ b/scripts/zones/Sauromugue_Champaign/npcs/qm2.lua
@@ -19,9 +19,7 @@ local function isNaked(player)
 end
 
 function onTrade(player, npc, trade)
-    local grapplingCS = player:getCharVar("thickAsThievesGrapplingCS")
-
-    if grapplingCS >= 2 and grapplingCS <= 7 and npcUtil.tradeHas(trade, 17474) then
+    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES) == QUEST_ACCEPTED and not player:hasKeyItem(tpz.ki.FIRST_SIGNED_FORGED_ENVELOPE) and npcUtil.tradeHas(trade, 17474) then
         if isNaked(player) then
             player:startEvent(2) -- complete grappling part of the quest
         else
@@ -31,27 +29,25 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-    local thickAsThieves = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES)
-    local grapplingCS = player:getCharVar("thickAsThievesGrapplingCS")
-
-    if thickAsThieves == QUEST_ACCEPTED then
-        if grapplingCS == 2 then
-            local gob = GetMobByID(ID.mob.CLIMBPIX_HIGHRISE)
-
-            if not gob:isSpawned() then
-                player:messageSpecial(ID.text.THF_AF_MOB)
-                gob:setSpawn(193, 32, 211)
-                SpawnMob(ID.mob.CLIMBPIX_HIGHRISE):updateClaim(player)
+    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES) == QUEST_ACCEPTED then
+        if not player:hasKeyItem(tpz.ki.FIRST_SIGNED_FORGED_ENVELOPE) then
+            if npc:getLocalVar("[QM]Select") == 1 then
+                local climbpix = GetMobByID(ID.mob.CLIMBPIX_HIGHRISE)
+                
+                if not climbpix:isSpawned() then
+                    player:messageSpecial(ID.text.THF_AF_MOB)
+                    climbpix:setSpawn(193, 32, 211)
+                    SpawnMob(ID.mob.CLIMBPIX_HIGHRISE):updateClaim(player)
+                end
+            else
+                player:messageSpecial(ID.text.THF_AF_WALL_OFFSET) -- It is impossible to climb this wall with your bare hands.
             end
-        elseif grapplingCS >= 0 or grapplingCS <= 7 then
-            player:messageSpecial(ID.text.THF_AF_WALL_OFFSET) -- It is impossible to climb this wall with your bare hands.
-        elseif grapplingCS == 8 then
+        else
             player:messageSpecial(ID.text.THF_AF_WALL_OFFSET + 1) -- There is no longer any need to climb the tower.
         end
     else
         player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY)
     end
-
 end
 
 function onEventUpdate(player, csid, option)
@@ -59,7 +55,6 @@ end
 
 function onEventFinish(player, csid, option)
     if csid == 2 then
-        player:setCharVar("thickAsThievesGrapplingCS", 8)
         player:delKeyItem(tpz.ki.FIRST_FORGED_ENVELOPE)
         npcUtil.giveKeyItem(player, tpz.ki.FIRST_SIGNED_FORGED_ENVELOPE)
         player:confirmTrade()

--- a/scripts/zones/Sauromugue_Champaign/npcs/qm2.lua
+++ b/scripts/zones/Sauromugue_Champaign/npcs/qm2.lua
@@ -31,17 +31,10 @@ end
 function onTrigger(player, npc)
     if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES) == QUEST_ACCEPTED then
         if not player:hasKeyItem(tpz.ki.FIRST_SIGNED_FORGED_ENVELOPE) then
-            if npc:getLocalVar("[QM]Select") == 1 then
-                local climbpix = GetMobByID(ID.mob.CLIMBPIX_HIGHRISE)
-                
-                if not climbpix:isSpawned() then
-                    player:messageSpecial(ID.text.THF_AF_MOB)
-                    climbpix:setSpawn(193, 32, 211)
-                    SpawnMob(ID.mob.CLIMBPIX_HIGHRISE):updateClaim(player)
-                end
-            else
-                player:messageSpecial(ID.text.THF_AF_WALL_OFFSET) -- It is impossible to climb this wall with your bare hands.
+            if npc:getLocalVar("[QM]Select") == 1 and npcUtil.popFromQM(player, npc, ID.mob.CLIMBPIX_HIGHRISE, {radius = 1, hide = 0}) then
+                player:messageSpecial(ID.text.THF_AF_MOB)
             end
+            player:messageSpecial(ID.text.THF_AF_WALL_OFFSET) -- It is impossible to climb this wall with your bare hands.
         else
             player:messageSpecial(ID.text.THF_AF_WALL_OFFSET + 1) -- There is no longer any need to climb the tower.
         end

--- a/scripts/zones/Sauromugue_Champaign/npcs/qm3.lua
+++ b/scripts/zones/Sauromugue_Champaign/npcs/qm3.lua
@@ -10,28 +10,27 @@ require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    local grapplingCS = player:getCharVar("thickAsThievesGrapplingCS")
-
-    if grapplingCS >= 2 and grapplingCS <= 7 and npcUtil.tradeHas(trade, 17474) then
+    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 17474) then
         player:messageSpecial(ID.text.THF_AF_WALL_OFFSET + 3, 0, 17474) -- You cannot get a decent grip on the wall using the [Grapnel].
     end
 end
 
 function onTrigger(player, npc)
-    local thickAsThieves = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES)
-    local grapplingCS = player:getCharVar("thickAsThievesGrapplingCS")
-
-    if thickAsThieves == QUEST_ACCEPTED then
-        if grapplingCS == 3 then
-            local gob = GetMobByID(ID.mob.CLIMBPIX_HIGHRISE)
-
-            if not gob:isSpawned() then
-                player:messageSpecial(ID.text.THF_AF_MOB)
-                gob:setSpawn(414, 16, -131)
-                SpawnMob(ID.mob.CLIMBPIX_HIGHRISE):updateClaim(player)
+    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES) == QUEST_ACCEPTED then
+        if not player:hasKeyItem(tpz.ki.FIRST_SIGNED_FORGED_ENVELOPE) then
+            if npc:getLocalVar("[QM]Select") == 1 then
+                local climbpix = GetMobByID(ID.mob.CLIMBPIX_HIGHRISE)
+                
+                if not climbpix:isSpawned() then
+                    player:messageSpecial(ID.text.THF_AF_MOB)
+                    climbpix:setSpawn(414, 16, -131)
+                    SpawnMob(ID.mob.CLIMBPIX_HIGHRISE):updateClaim(player)
+                end
+            else
+                player:messageSpecial(ID.text.THF_AF_WALL_OFFSET) -- It is impossible to climb this wall with your bare hands.
             end
-        elseif grapplingCS >= 0 or grapplingCS <= 7 then
-            player:messageSpecial(ID.text.THF_AF_WALL_OFFSET)
+        else
+            player:messageSpecial(ID.text.THF_AF_WALL_OFFSET + 1) -- There is no longer any need to climb the tower.
         end
     else
         player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY)

--- a/scripts/zones/Sauromugue_Champaign/npcs/qm3.lua
+++ b/scripts/zones/Sauromugue_Champaign/npcs/qm3.lua
@@ -18,17 +18,10 @@ end
 function onTrigger(player, npc)
     if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES) == QUEST_ACCEPTED then
         if not player:hasKeyItem(tpz.ki.FIRST_SIGNED_FORGED_ENVELOPE) then
-            if npc:getLocalVar("[QM]Select") == 1 then
-                local climbpix = GetMobByID(ID.mob.CLIMBPIX_HIGHRISE)
-                
-                if not climbpix:isSpawned() then
-                    player:messageSpecial(ID.text.THF_AF_MOB)
-                    climbpix:setSpawn(414, 16, -131)
-                    SpawnMob(ID.mob.CLIMBPIX_HIGHRISE):updateClaim(player)
-                end
-            else
-                player:messageSpecial(ID.text.THF_AF_WALL_OFFSET) -- It is impossible to climb this wall with your bare hands.
+            if npc:getLocalVar("[QM]Select") == 1 and npcUtil.popFromQM(player, npc, ID.mob.CLIMBPIX_HIGHRISE, {radius = 1, hide = 0}) then
+                player:messageSpecial(ID.text.THF_AF_MOB)
             end
+            player:messageSpecial(ID.text.THF_AF_WALL_OFFSET) -- It is impossible to climb this wall with your bare hands.
         else
             player:messageSpecial(ID.text.THF_AF_WALL_OFFSET + 1) -- There is no longer any need to climb the tower.
         end

--- a/scripts/zones/Sauromugue_Champaign/npcs/qm4.lua
+++ b/scripts/zones/Sauromugue_Champaign/npcs/qm4.lua
@@ -10,28 +10,27 @@ require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    local grapplingCS = player:getCharVar("thickAsThievesGrapplingCS")
-
-    if grapplingCS >= 2 and grapplingCS <= 7 and npcUtil.tradeHas(trade, 17474) then
+    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 17474) then
         player:messageSpecial(ID.text.THF_AF_WALL_OFFSET + 3, 0, 17474) -- You cannot get a decent grip on the wall using the [Grapnel].
     end
 end
 
 function onTrigger(player, npc)
-    local thickAsThieves = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES)
-    local grapplingCS = player:getCharVar("thickAsThievesGrapplingCS")
-
-    if thickAsThieves == QUEST_ACCEPTED then
-        if grapplingCS == 4 then
-            local gob = GetMobByID(ID.mob.CLIMBPIX_HIGHRISE)
-
-            if not gob:isSpawned() then
-                player:messageSpecial(ID.text.THF_AF_MOB)
-                gob:setSpawn(122, 0, -230)
-                SpawnMob(ID.mob.CLIMBPIX_HIGHRISE):updateClaim(player)
+    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES) == QUEST_ACCEPTED then
+        if not player:hasKeyItem(tpz.ki.FIRST_SIGNED_FORGED_ENVELOPE) then
+            if npc:getLocalVar("[QM]Select") == 1 then
+                local climbpix = GetMobByID(ID.mob.CLIMBPIX_HIGHRISE)
+                
+                if not climbpix:isSpawned() then
+                    player:messageSpecial(ID.text.THF_AF_MOB)
+                    climbpix:setSpawn(122, 0, -230)
+                    SpawnMob(ID.mob.CLIMBPIX_HIGHRISE):updateClaim(player)
+                end
+            else
+                player:messageSpecial(ID.text.THF_AF_WALL_OFFSET) -- It is impossible to climb this wall with your bare hands.
             end
-        elseif grapplingCS >= 0 or grapplingCS <= 7 then
-            player:messageSpecial(ID.text.THF_AF_WALL_OFFSET)
+        else
+            player:messageSpecial(ID.text.THF_AF_WALL_OFFSET + 1) -- There is no longer any need to climb the tower.
         end
     else
         player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY)

--- a/scripts/zones/Sauromugue_Champaign/npcs/qm4.lua
+++ b/scripts/zones/Sauromugue_Champaign/npcs/qm4.lua
@@ -18,17 +18,10 @@ end
 function onTrigger(player, npc)
     if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES) == QUEST_ACCEPTED then
         if not player:hasKeyItem(tpz.ki.FIRST_SIGNED_FORGED_ENVELOPE) then
-            if npc:getLocalVar("[QM]Select") == 1 then
-                local climbpix = GetMobByID(ID.mob.CLIMBPIX_HIGHRISE)
-                
-                if not climbpix:isSpawned() then
-                    player:messageSpecial(ID.text.THF_AF_MOB)
-                    climbpix:setSpawn(122, 0, -230)
-                    SpawnMob(ID.mob.CLIMBPIX_HIGHRISE):updateClaim(player)
-                end
-            else
-                player:messageSpecial(ID.text.THF_AF_WALL_OFFSET) -- It is impossible to climb this wall with your bare hands.
+            if npc:getLocalVar("[QM]Select") == 1 and npcUtil.popFromQM(player, npc, ID.mob.CLIMBPIX_HIGHRISE, {radius = 1, hide = 0}) then
+                player:messageSpecial(ID.text.THF_AF_MOB)
             end
+            player:messageSpecial(ID.text.THF_AF_WALL_OFFSET) -- It is impossible to climb this wall with your bare hands.
         else
             player:messageSpecial(ID.text.THF_AF_WALL_OFFSET + 1) -- There is no longer any need to climb the tower.
         end

--- a/scripts/zones/Sauromugue_Champaign/npcs/qm5.lua
+++ b/scripts/zones/Sauromugue_Champaign/npcs/qm5.lua
@@ -18,17 +18,10 @@ end
 function onTrigger(player, npc)
     if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES) == QUEST_ACCEPTED then
         if not player:hasKeyItem(tpz.ki.FIRST_SIGNED_FORGED_ENVELOPE) then
-            if npc:getLocalVar("[QM]Select") == 1 then
-                local climbpix = GetMobByID(ID.mob.CLIMBPIX_HIGHRISE)
-                
-                if not climbpix:isSpawned() then
-                    player:messageSpecial(ID.text.THF_AF_MOB)
-                    climbpix:setSpawn(-114, 16, 51)
-                    SpawnMob(ID.mob.CLIMBPIX_HIGHRISE):updateClaim(player)
-                end
-            else
-                player:messageSpecial(ID.text.THF_AF_WALL_OFFSET) -- It is impossible to climb this wall with your bare hands.
+            if npc:getLocalVar("[QM]Select") == 1 and npcUtil.popFromQM(player, npc, ID.mob.CLIMBPIX_HIGHRISE, {radius = 1, hide = 0}) then
+                player:messageSpecial(ID.text.THF_AF_MOB)
             end
+            player:messageSpecial(ID.text.THF_AF_WALL_OFFSET) -- It is impossible to climb this wall with your bare hands.
         else
             player:messageSpecial(ID.text.THF_AF_WALL_OFFSET + 1) -- There is no longer any need to climb the tower.
         end

--- a/scripts/zones/Sauromugue_Champaign/npcs/qm5.lua
+++ b/scripts/zones/Sauromugue_Champaign/npcs/qm5.lua
@@ -10,28 +10,27 @@ require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    local grapplingCS = player:getCharVar("thickAsThievesGrapplingCS")
-
-    if grapplingCS >= 2 and grapplingCS <= 7 and npcUtil.tradeHas(trade, 17474) then
+    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 17474) then
         player:messageSpecial(ID.text.THF_AF_WALL_OFFSET + 3, 0, 17474) -- You cannot get a decent grip on the wall using the [Grapnel].
     end
 end
 
 function onTrigger(player, npc)
-    local thickAsThieves = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES)
-    local grapplingCS = player:getCharVar("thickAsThievesGrapplingCS")
-
-    if thickAsThieves == QUEST_ACCEPTED then
-        if grapplingCS == 5 then
-            local gob = GetMobByID(ID.mob.CLIMBPIX_HIGHRISE)
-
-            if not gob:isSpawned() then
-                player:messageSpecial(ID.text.THF_AF_MOB)
-                gob:setSpawn(-114, 16, 51)
-                SpawnMob(ID.mob.CLIMBPIX_HIGHRISE):updateClaim(player)
+    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES) == QUEST_ACCEPTED then
+        if not player:hasKeyItem(tpz.ki.FIRST_SIGNED_FORGED_ENVELOPE) then
+            if npc:getLocalVar("[QM]Select") == 1 then
+                local climbpix = GetMobByID(ID.mob.CLIMBPIX_HIGHRISE)
+                
+                if not climbpix:isSpawned() then
+                    player:messageSpecial(ID.text.THF_AF_MOB)
+                    climbpix:setSpawn(-114, 16, 51)
+                    SpawnMob(ID.mob.CLIMBPIX_HIGHRISE):updateClaim(player)
+                end
+            else
+                player:messageSpecial(ID.text.THF_AF_WALL_OFFSET) -- It is impossible to climb this wall with your bare hands.
             end
-        elseif grapplingCS >= 0 or grapplingCS <= 7 then
-            player:messageSpecial(ID.text.THF_AF_WALL_OFFSET)
+        else
+            player:messageSpecial(ID.text.THF_AF_WALL_OFFSET + 1) -- There is no longer any need to climb the tower.
         end
     else
         player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY)

--- a/scripts/zones/Sauromugue_Champaign/npcs/qm6.lua
+++ b/scripts/zones/Sauromugue_Champaign/npcs/qm6.lua
@@ -18,17 +18,10 @@ end
 function onTrigger(player, npc)
     if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES) == QUEST_ACCEPTED then
         if not player:hasKeyItem(tpz.ki.FIRST_SIGNED_FORGED_ENVELOPE) then
-            if npc:getLocalVar("[QM]Select") == 1 then
-                local climbpix = GetMobByID(ID.mob.CLIMBPIX_HIGHRISE)
-                
-                if not climbpix:isSpawned() then
-                    player:messageSpecial(ID.text.THF_AF_MOB)
-                    climbpix:setSpawn(371, 24, 8)
-                    SpawnMob(ID.mob.CLIMBPIX_HIGHRISE):updateClaim(player)
-                end
-            else
-                player:messageSpecial(ID.text.THF_AF_WALL_OFFSET) -- It is impossible to climb this wall with your bare hands.
+            if npc:getLocalVar("[QM]Select") == 1 and npcUtil.popFromQM(player, npc, ID.mob.CLIMBPIX_HIGHRISE, {radius = 1, hide = 0}) then
+                player:messageSpecial(ID.text.THF_AF_MOB)
             end
+            player:messageSpecial(ID.text.THF_AF_WALL_OFFSET) -- It is impossible to climb this wall with your bare hands.
         else
             player:messageSpecial(ID.text.THF_AF_WALL_OFFSET + 1) -- There is no longer any need to climb the tower.
         end

--- a/scripts/zones/Sauromugue_Champaign/npcs/qm6.lua
+++ b/scripts/zones/Sauromugue_Champaign/npcs/qm6.lua
@@ -10,28 +10,27 @@ require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    local grapplingCS = player:getCharVar("thickAsThievesGrapplingCS")
-
-    if grapplingCS >= 2 and grapplingCS <= 7 and npcUtil.tradeHas(trade, 17474) then
+    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 17474) then
         player:messageSpecial(ID.text.THF_AF_WALL_OFFSET + 3, 0, 17474) -- You cannot get a decent grip on the wall using the [Grapnel].
     end
 end
 
 function onTrigger(player, npc)
-    local thickAsThieves = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES)
-    local grapplingCS = player:getCharVar("thickAsThievesGrapplingCS")
-
-    if thickAsThieves == QUEST_ACCEPTED then
-        if grapplingCS == 6 then
-            local gob = GetMobByID(ID.mob.CLIMBPIX_HIGHRISE)
-
-            if not gob:isSpawned() then
-                player:messageSpecial(ID.text.THF_AF_MOB)
-                gob:setSpawn(371, 24, 8)
-                SpawnMob(ID.mob.CLIMBPIX_HIGHRISE):updateClaim(player)
+    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES) == QUEST_ACCEPTED then
+        if not player:hasKeyItem(tpz.ki.FIRST_SIGNED_FORGED_ENVELOPE) then
+            if npc:getLocalVar("[QM]Select") == 1 then
+                local climbpix = GetMobByID(ID.mob.CLIMBPIX_HIGHRISE)
+                
+                if not climbpix:isSpawned() then
+                    player:messageSpecial(ID.text.THF_AF_MOB)
+                    climbpix:setSpawn(371, 24, 8)
+                    SpawnMob(ID.mob.CLIMBPIX_HIGHRISE):updateClaim(player)
+                end
+            else
+                player:messageSpecial(ID.text.THF_AF_WALL_OFFSET) -- It is impossible to climb this wall with your bare hands.
             end
-        elseif grapplingCS >= 0 or grapplingCS <= 7 then
-            player:messageSpecial(ID.text.THF_AF_WALL_OFFSET)
+        else
+            player:messageSpecial(ID.text.THF_AF_WALL_OFFSET + 1) -- There is no longer any need to climb the tower.
         end
     else
         player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY)

--- a/scripts/zones/Sauromugue_Champaign/npcs/qm7.lua
+++ b/scripts/zones/Sauromugue_Champaign/npcs/qm7.lua
@@ -18,17 +18,10 @@ end
 function onTrigger(player, npc)
     if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES) == QUEST_ACCEPTED then
         if not player:hasKeyItem(tpz.ki.FIRST_SIGNED_FORGED_ENVELOPE) then
-            if npc:getLocalVar("[QM]Select") == 1 then
-                local climbpix = GetMobByID(ID.mob.CLIMBPIX_HIGHRISE)
-                
-                if not climbpix:isSpawned() then
-                    player:messageSpecial(ID.text.THF_AF_MOB)
-                    climbpix:setSpawn(-194, 15, 269)
-                    SpawnMob(ID.mob.CLIMBPIX_HIGHRISE):updateClaim(player)
-                end
-            else
-                player:messageSpecial(ID.text.THF_AF_WALL_OFFSET) -- It is impossible to climb this wall with your bare hands.
+            if npc:getLocalVar("[QM]Select") == 1 and npcUtil.popFromQM(player, npc, ID.mob.CLIMBPIX_HIGHRISE, {radius = 1, hide = 0}) then
+                player:messageSpecial(ID.text.THF_AF_MOB)
             end
+            player:messageSpecial(ID.text.THF_AF_WALL_OFFSET) -- It is impossible to climb this wall with your bare hands.
         else
             player:messageSpecial(ID.text.THF_AF_WALL_OFFSET + 1) -- There is no longer any need to climb the tower.
         end

--- a/scripts/zones/Sauromugue_Champaign/npcs/qm7.lua
+++ b/scripts/zones/Sauromugue_Champaign/npcs/qm7.lua
@@ -10,28 +10,27 @@ require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    local grapplingCS = player:getCharVar("thickAsThievesGrapplingCS")
-
-    if grapplingCS >= 2 and grapplingCS <= 7 and npcUtil.tradeHas(trade, 17474) then
+    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 17474) then
         player:messageSpecial(ID.text.THF_AF_WALL_OFFSET + 3, 0, 17474) -- You cannot get a decent grip on the wall using the [Grapnel].
     end
 end
 
 function onTrigger(player, npc)
-    local thickAsThieves = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES)
-    local grapplingCS = player:getCharVar("thickAsThievesGrapplingCS")
-
-    if thickAsThieves == QUEST_ACCEPTED then
-        if grapplingCS == 7 then
-            local gob = GetMobByID(ID.mob.CLIMBPIX_HIGHRISE)
-
-            if not gob:isSpawned() then
-                player:messageSpecial(ID.text.THF_AF_MOB)
-                gob:setSpawn(-194, 15, 269)
-                SpawnMob(ID.mob.CLIMBPIX_HIGHRISE):updateClaim(player)
+    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES) == QUEST_ACCEPTED then
+        if not player:hasKeyItem(tpz.ki.FIRST_SIGNED_FORGED_ENVELOPE) then
+            if npc:getLocalVar("[QM]Select") == 1 then
+                local climbpix = GetMobByID(ID.mob.CLIMBPIX_HIGHRISE)
+                
+                if not climbpix:isSpawned() then
+                    player:messageSpecial(ID.text.THF_AF_MOB)
+                    climbpix:setSpawn(-194, 15, 269)
+                    SpawnMob(ID.mob.CLIMBPIX_HIGHRISE):updateClaim(player)
+                end
+            else
+                player:messageSpecial(ID.text.THF_AF_WALL_OFFSET) -- It is impossible to climb this wall with your bare hands.
             end
-        elseif grapplingCS >= 0 or grapplingCS <= 7 then
-            player:messageSpecial(ID.text.THF_AF_WALL_OFFSET)
+        else
+            player:messageSpecial(ID.text.THF_AF_WALL_OFFSET + 1) -- There is no longer any need to climb the tower.
         end
     else
         player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY)

--- a/scripts/zones/Windurst_Woods/npcs/Bopa_Greso.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Bopa_Greso.lua
@@ -1,10 +1,8 @@
 -----------------------------------
 -- Area: Windurst Woods
---   NPC: Bopa Greso
+--  NPC: Bopa Greso
 -- Type: Standard NPC
 -- !pos 59.773 -6.249 216.766 241
---
--- Auto-Script: Requires Verification (Verfied by Brawndo)
 -----------------------------------
 require("scripts/globals/quests")
 -----------------------------------
@@ -13,21 +11,10 @@ function onTrade(player,npc,trade)
 end
 
 function onTrigger(player,npc)
-    local thickAsThieves = player:getQuestStatus(WINDURST,tpz.quest.id.windurst.AS_THICK_AS_THIEVES)
-    local thickAsThievesCS = player:getCharVar("thickAsThievesCS")
-
-    if thickAsThieves == QUEST_ACCEPTED then
-        player:startEvent(506)
-        if thickAsThievesCS == 1 then
-            player:setCharVar("thickAsThievesCS", 2)
-        elseif thickAsThievesCS == 3 then
-            player:setCharVar("thickAsThievesCS", 4)
-            local rand1 = math.random(2, 7)
-            player:setCharVar("thickAsThievesGrapplingCS", rand1)
-            player:setCharVar("thickAsThievesGamblingCS", 1)
-        end
+    if player:getQuestStatus(WINDURST,tpz.quest.id.windurst.AS_THICK_AS_THIEVES) == QUEST_ACCEPTED then
+        player:startEvent(506) -- Gambling hint
     else
-        player:startEvent(77) -- standard cs
+        player:startEvent(77)  -- Standard dialogue
     end
 end
 

--- a/scripts/zones/Windurst_Woods/npcs/Cha_Lebagta.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Cha_Lebagta.lua
@@ -3,38 +3,25 @@
 --  NPC: Cha Lebagta
 -- Type: Standard NPC
 -- !pos 58.385 -6.249 216.670 241
---    Involved in Quests: As Thick as Thieves, Mihgo's Amigo
+-- Involved in Quests: As Thick as Thieves, Mihgo's Amigo
+-----------------------------------
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
 end
 
 function onTrigger(player,npc)
-    local MihgosAmigo = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.MIHGO_S_AMIGO)
-    local thickAsThieves = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES)
-    local thickAsThievesCS = player:getCharVar("thickAsThievesCS")
+    local mihgosAmigo = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.MIHGO_S_AMIGO)
 
-    -- As Thick As Thieves (THF AF)
-    if thickAsThieves == QUEST_ACCEPTED then
-        player:startEvent(507, 0, 17474)
-        if thickAsThievesCS == 1 then
-            player:setCharVar("thickAsThievesCS", 3)
-        elseif thickAsThievesCS == 2 then
-            player:setCharVar("thickAsThievesCS", 4)
-            local rand1 = math.random(2, 7)
-            player:setCharVar("thickAsThievesGrapplingCS", rand1)
-            player:setCharVar("thickAsThievesGamblingCS", 1)
-        end
-
-    -- Mihgo's Amigo
-    elseif MihgosAmigo == QUEST_ACCEPTED then
-        player:startEvent(85,0,498) -- hint dialog
-
-    -- standard dialog
-    elseif MihgosAmigo == QUEST_COMPLETED then
-        player:startEvent(91, 0, 498) -- new standard dialog after Mihgo's Amigo
+    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES) == QUEST_ACCEPTED then
+        player:startEvent(507, 0, 17474) -- Grappling hint
+    elseif mihgosAmigo == QUEST_ACCEPTED then
+        player:startEvent(85,0,498) -- Migho's Amigo hint dialog
+    elseif mihgosAmigo == QUEST_COMPLETED then
+        player:startEvent(91, 0, 498) -- New standard dialog after Mihgo's Amigo completion
     else
-        player:startEvent(78) -- normal dialog
+        player:startEvent(78) -- Standard dialog
     end
 end
 

--- a/scripts/zones/Windurst_Woods/npcs/Nanaa_Mihgo.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Nanaa_Mihgo.lua
@@ -36,9 +36,6 @@ function onTrigger(player,npc)
     local rockRacketeer = player:getQuestStatus(WINDURST,tpz.quest.id.windurst.ROCK_RACKETEER)
     local rockRacketeerCS = player:getCharVar("rockracketeer_sold")
     local thickAsThieves = player:getQuestStatus(WINDURST,tpz.quest.id.windurst.AS_THICK_AS_THIEVES)
-    local thickAsThievesCS = player:getCharVar("thickAsThievesCS")
-    local thickAsThievesGrapplingCS = player:getCharVar("thickAsThievesGrapplingCS")
-    local thickAsThievesGamblingCS = player:getCharVar("thickAsThievesGamblingCS")
     local hittingTheMarquisate = player:getQuestStatus(WINDURST,tpz.quest.id.windurst.HITTING_THE_MARQUISATE)
     local hittingTheMarquisateYatnielCS = player:getCharVar("hittingTheMarquisateYatnielCS")
     local hittingTheMarquisateHagainCS = player:getCharVar("hittingTheMarquisateHagainCS")
@@ -79,11 +76,13 @@ function onTrigger(player,npc)
     -- THICK AS THIEVES
     elseif job == tpz.job.THF and lvl >= AF2_QUEST_LEVEL and thickAsThieves == QUEST_AVAILABLE and tenshodoShowdown == QUEST_COMPLETED then
         player:startEvent(504) -- start quest
-    elseif thickAsThievesCS >= 1 and thickAsThievesCS <= 4 and thickAsThievesGamblingCS <= 7 and thickAsThievesGrapplingCS <= 7 then
-        player:startEvent(505, 0, tpz.ki.GANG_WHEREABOUTS_NOTE) -- before completing grappling and gambling sidequests
-    elseif thickAsThievesGamblingCS == 8 and thickAsThievesGrapplingCS == 8 then
-        player:startEvent(508) -- complete quest
-
+    elseif thickAsThieves == QUEST_ACCEPTED then
+        if player:hasKeyItem(tpz.ki.FIRST_SIGNED_FORGED_ENVELOPE) and player:hasKeyItem(tpz.ki.SECOND_SIGNED_FORGED_ENVELOPE) then
+            player:startEvent(508) -- complete quest
+        else
+            player:startEvent(505, 0, tpz.ki.GANG_WHEREABOUTS_NOTE) -- before completing grappling and gambling sidequests
+        end
+        
     -- HITTING THE MARQUISATE
     elseif job == tpz.job.THF and lvl >= AF3_QUEST_LEVEL and thickAsThieves == QUEST_COMPLETED and hittingTheMarquisate == QUEST_AVAILABLE then
         player:startEvent(512) -- start quest
@@ -154,9 +153,9 @@ function onEventFinish(player,csid,option)
     -- THICK AS THIEVES
     elseif (csid == 504 and option == 1) then  -- start quest "as thick as thieves"
         player:addQuest(WINDURST,tpz.quest.id.windurst.AS_THICK_AS_THIEVES)
-        player:setCharVar("thickAsThievesCS",1)
+        player:setCharVar("thickAsThievesGamblingCS",1)
         npcUtil.giveKeyItem(player, {tpz.ki.GANG_WHEREABOUTS_NOTE, tpz.ki.FIRST_FORGED_ENVELOPE, tpz.ki.SECOND_FORGED_ENVELOPE})
-    elseif (csid == 508 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES, {item=12514, var={"thickAsThievesCS", "thickAsThievesGrapplingCS", "thickAsThievesGamblingCS"}})) then
+    elseif (csid == 508 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES, {item=12514, var="thickAsThievesGamblingCS"})) then
         player:delKeyItem(tpz.ki.GANG_WHEREABOUTS_NOTE)
         player:delKeyItem(tpz.ki.FIRST_SIGNED_FORGED_ENVELOPE)
         player:delKeyItem(tpz.ki.SECOND_SIGNED_FORGED_ENVELOPE)


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [] that I've _tested my code_ since the last commit in the PR, and will test after any later commits
This is untested, needs review and testing (which I'll do eventually).

This fixes climbpix's spawn to be accurate with retail.  No longer does it decide and lock in the ??? position for each player after talking to the mithras at the start of the quest, it varies with day.  Also, talking with Nanaa's friends is supposed to be optional, but the topaz script before made it required, which caused grief for players!