### PR TITLE
Fix server crash when trying to obtain Trion and Apururu trusts

### DIFF
--- a/scripts/zones/Chateau_dOraguille/npcs/_6h0.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/_6h0.lua
@@ -25,7 +25,7 @@ local function TrustMemory(player)
         memories = memories + 4
     end
     -- 8 - UNDER_OATH
-    if player:hasCompletedMission(SANDORIA, tpz.mission.id.sandoria.UNDER_OATH) then
+    if player:hasCompletedQuest(SANDORIA, tpz.quest.id.sandoria.UNDER_OATH) then
         memories = memories + 8
     end
     -- 16 - FIT_FOR_A_PRINCE

--- a/scripts/zones/Windurst_Woods/npcs/Apururu.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Apururu.lua
@@ -15,7 +15,7 @@ require("scripts/globals/titles")
 local TrustMemory = function(player)
     local memories = 0
     -- 2 - Saw him at the start of the game
-    if player:getNation() == WINDURST then
+    if player:getNation() == tpz.nation.WINDURST then
         memories = memories + 2
     end
     -- 4 - WONDER_WANDS
@@ -23,7 +23,7 @@ local TrustMemory = function(player)
         memories = memories + 4
     end
     -- 8 - THE_TIGRESS_STIRS
-    if player:hasCompletedQuest(WINDURST, tpz.quest.id.windurst.THE_TIGRESS_STIRS) then
+    if player:hasCompletedQuest(CRYSTAL_WAR, tpz.quest.id.crystalWar.THE_TIGRESS_STIRS) then
         memories = memories + 8
     end
     -- 16 - I_CAN_HEAR_A_RAINBOW

--- a/scripts/zones/Windurst_Woods/npcs/Nanaa_Mihgo.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Nanaa_Mihgo.lua
@@ -19,7 +19,7 @@ require("scripts/globals/titles")
 local TrustMemory = function(player)
     local memories = 0
     -- 2 - Saw her at the start of the game
-    if player:getNation() == WINDURST then
+    if player:getNation() == tpz.nation.WINDURST then
         memories = memories + 2
     end
     -- 4 - ROCK_RACKETEER


### PR DESCRIPTION
Crashes were the result of mismatched ID table look-ups, not the nation checks (but the nation checks would always fail since the globals are tables, not integers).

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

