### PR TITLE
Enhance !exec command

### DIFF
--- a/scripts/commands/exec.lua
+++ b/scripts/commands/exec.lua
@@ -25,8 +25,12 @@ function onTrigger(player, str)
     local old_os = os
     os = nil
 
+    -- Define "player" and "target" inside the string for use by the caller
+    local define_player = "local player = GetPlayerByName(\"" .. player:getName() .. "\"); "
+    local define_target = "local target = player:getCursorTarget(); "
+
     -- Ensure the command compiles / is valid..
-    local scriptObj, err = loadstring(str)
+    local scriptObj, err = loadstring(define_player .. define_target .. str)
     if (scriptObj == nil) then
         player:PrintToPlayer("Failed to load the given string.")
         player:PrintToPlayer(err)

--- a/scripts/commands/exec.lua
+++ b/scripts/commands/exec.lua
@@ -41,7 +41,7 @@ function onTrigger(player, str)
     -- Execute the string..
     local status, err = pcall(scriptObj)
     if (status == false) then
-        player:PrintToPlayer(err)
+        player:PrintToPlayer("Error calling: " .. str .. "\n" .. err)
     end
 
     -- Restore the os table..


### PR DESCRIPTION
Defines "player" and "target" in exec command.

Allows: `!exec player:setHP(10)` and `!exec target:setHP(10)` etc.

On error, prints the basic string you tried to execute and the error from lua (which starts with the appended values):
![image](https://user-images.githubusercontent.com/1389729/86538026-07326280-befc-11ea-86f4-98a350534461.png)

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

