### PR TITLE
Fix crash on character names of 15 characters long

### DIFF
--- a/src/login/lobby.cpp
+++ b/src/login/lobby.cpp
@@ -768,7 +768,7 @@ int32 lobby_createchar(login_session_data_t *loginsd, int8 *buf)
     srand(clock());
     char_mini createchar;
 
-    memcpy(createchar.m_name, loginsd->charname, 16);
+    memcpy(createchar.m_name, loginsd->charname, 15);
     memset(&createchar.m_look, 0, sizeof(look_t));
 
     createchar.m_look.race = ref<uint8>(buf, 48);

--- a/src/login/lobby.cpp
+++ b/src/login/lobby.cpp
@@ -191,7 +191,7 @@ int32 lobbydata_parse(int32 fd)
                         ////////////////////////////////////////////////////
                         ref<uint32>(CharList, 4 + 32 + i * 140) = CharID;
 
-                        memcpy(CharList + 12 + 32 + i * 140, strCharName, 15);
+                        memcpy(CharList + 12 + 32 + i * 140, strCharName, 16);
 
                         ref<uint8>(CharList, 46 + 32 + i * 140) = MainJob;
                         ref<uint8>(CharList, 73 + 32 + i * 140) = lvlMainJob;

--- a/src/login/login_session.h
+++ b/src/login/login_session.h
@@ -34,7 +34,7 @@ struct login_session_data_t {
     uint16 client_port;
     uint32 servip;
 
-    char charname[17];
+    char charname[16];
     int32 login_fd;
     int32 login_lobbydata_fd;
     int32 login_lobbyview_fd;


### PR DESCRIPTION
Does what it says on the tin! Fixed evil memcpy with assumptive byte-lengths.

Fixes #825 
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

