### PR TITLE
Alchemist torque

### DIFF
--- a/scripts/globals/casket_loot.lua
+++ b/scripts/globals/casket_loot.lua
@@ -2946,7 +2946,7 @@ tpz.casket_loot.casketItems =
     },
     [tpz.zone.VELUGANNON_PALACE] =
     {
-        regionalItems = {13467}, -- Dragon Ring
+        regionalItems = {13467,10954}, -- Dragon Ring | Alchemist's Torque
         temps =
         {
         ----------------------------------


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Missing Alchemist's Torque.
It's a treasure casket drop of Ve'lugannon Palace
https://www.bg-wiki.com/bg/Alchemst._Torque


