### PR TITLE
[Blue Mage] Fix assimilation merit

### DIFF
--- a/src/map/packets/menu_merit.cpp
+++ b/src/map/packets/menu_merit.cpp
@@ -36,27 +36,18 @@ CMenuMeritPacket::CMenuMeritPacket(CCharEntity* PChar)
 	ref<uint8>(0x06) = 0x0C;
 
     ref<uint16>(0x08) = PChar->PMeritPoints->GetLimitPoints();
-    ref<uint8>(0x0A) = PChar->PMeritPoints->GetMeritPoints();
 
-	uint8 flag = 0x00;
+    uint16 bits = 0;
+    bits += PChar->PMeritPoints->GetMeritPoints() & 0b0000000001111111; // first seven bits are merit points
+    if (PChar->GetMJob() == JOB_BLU && PChar->GetMLevel() > 74)
+        bits += (PChar->PMeritPoints->GetMeritValue(MERIT_ASSIMILATION, PChar) << 7) & 0b0001111110000000; // next six bits are assimilation points. the last three bits are the three flags below:
+    bits += (PChar->jobs.job[PChar->GetMJob()] >= 75 && charutils::hasKeyItem(PChar, 606)) << 13;          // is 75 and has limit breaker KI
+    bits += ((PChar->jobs.job[PChar->GetMJob()] >= PChar->jobs.genkai &&
+              PChar->jobs.exp[PChar->GetMJob()] == charutils::GetExpNEXTLevel(PChar->jobs.job[PChar->GetMJob()]) - 1) || PChar->MeritMode) << 14; // my exp is capped
+    bits += (bits & (1 << 13) && PChar->MeritMode) << 15; // flag 13 is set and merit mode is on
 
-	if (PChar->jobs.job[PChar->GetMJob()] >= 75 && charutils::hasKeyItem(PChar, 606))			// keyitem Limit Breaker
-	{
-		flag |= 0x20;
-		if (PChar->MeritMode)
-		{
-			flag |= 0x80;
-		}
-	}
+    ref<uint16>(0x0A) = bits;
 
-	//capped EXP
-	if ((PChar->jobs.job[PChar->GetMJob()] >= PChar->jobs.genkai && PChar->jobs.exp[PChar->GetMJob()] == charutils::GetExpNEXTLevel(PChar->jobs.job[PChar->GetMJob()]) - 1)
-		|| PChar->MeritMode)
-	{
-		flag |= 0x40;
-	}
-
-	ref<uint8>(0x0B) = flag;
     ref<uint8>(0x0C) = map_config.max_merit_points + PChar->PMeritPoints->GetMeritValue(MERIT_MAX_MERIT, PChar);
 
     PChar->pushPacket(new CBasicPacket(*this));


### PR DESCRIPTION
Assimilation Blue Mage merit now works. It properly raises the amount of blue points per merit assigned.
From my testing, it doesnt seem to break anything.

Credits to Devi for decompiling the game and to Caelic for the actual code.
Permission to PR this was granted by Caelic.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

