### PR TITLE
Flyers for Regine: final fixes, I swear

### DIFF
--- a/scripts/quests/flyers_for_regine.lua
+++ b/scripts/quests/flyers_for_regine.lua
@@ -20,23 +20,30 @@ quests.flyers_for_regine = quests.flyers_for_regine or {}
 
 local npcData =
 {
-    [ 0] = {zone = tpz.zone.PORT_SAN_DORIA,     region = 1, x =   76.331, z = -128.655, offset = 0, npc = 'Answald'},
-    [ 1] = {zone = tpz.zone.PORT_SAN_DORIA,     region = 2, x =  -13.768, z =  -95.857, offset = 1, npc = 'Prietta'},
-    [ 2] = {zone = tpz.zone.PORT_SAN_DORIA,     region = 3, x =    0.750, z =  -81.438, offset = 2, npc = 'Miene'},
-    [ 3] = {zone = tpz.zone.PORT_SAN_DORIA,     region = 4, x =  -21.999, z = -106.877, offset = 3, npc = 'Portaure'},
-    [ 4] = {zone = tpz.zone.PORT_SAN_DORIA,     region = 5, x =  -37.821, z =   40.949, offset = 4, npc = 'Auvare'},
-
-    [ 5] = {zone = tpz.zone.NORTHERN_SAN_DORIA, region = 2, x =  146.420, z =  127.601, offset = 0, npc = 'Coullene'},
-    [ 6] = {zone = tpz.zone.NORTHERN_SAN_DORIA, region = 3, x = -159.082, z =  253.794, offset = 1, npc = 'Guilberdrier'},
-    [ 7] = {zone = tpz.zone.NORTHERN_SAN_DORIA, region = 4, x = -156.242, z =   49.184, offset = 2, npc = 'Boncort'},
-    [ 8] = {zone = tpz.zone.NORTHERN_SAN_DORIA, region = 5, x = -127.355, z =  130.461, offset = 3, npc = 'Capiria'},
-    [ 9] = {zone = tpz.zone.NORTHERN_SAN_DORIA, region = 6, x = -157.524, z =  263.818, offset = 4, npc = 'Villion'},
-
-    [10] = {zone = tpz.zone.SOUTHERN_SAN_DORIA, region = 2, x =   33.033, z =  -30.119, offset = 0, npc = 'Blendare'},
-    [11] = {zone = tpz.zone.SOUTHERN_SAN_DORIA, region = 3, x =   69.895, z =   41.073, offset = 1, npc = 'Rosel'},
-    [12] = {zone = tpz.zone.SOUTHERN_SAN_DORIA, region = 4, x =  105.147, z =  -16.735, offset = 3, npc = 'Maugie'},
-    [13] = {zone = tpz.zone.SOUTHERN_SAN_DORIA, region = 5, x =   80.378, z =  -24.644, offset = 5, npc = 'Adaunel'},
-    [14] = {zone = tpz.zone.SOUTHERN_SAN_DORIA, region = 6, x = -136.322, z =   21.958, offset = 7, npc = 'Leuveret'},
+    [tpz.zone.PORT_SAN_DORIA] =
+    {
+        [ 0] = {region = 1, x =   76.331, z = -128.655, offset = 0, npc = 'Answald'},
+        [ 1] = {region = 2, x =  -13.768, z =  -95.857, offset = 1, npc = 'Prietta'},
+        [ 2] = {region = 3, x =    0.750, z =  -81.438, offset = 2, npc = 'Miene'},
+        [ 3] = {region = 4, x =  -21.999, z = -106.877, offset = 3, npc = 'Portaure'},
+        [ 4] = {region = 5, x =  -37.821, z =   40.949, offset = 4, npc = 'Auvare'},
+    },
+    [tpz.zone.NORTHERN_SAN_DORIA] =
+    {
+        [ 5] = {region = 2, x =  146.420, z =  127.601, offset = 0, npc = 'Coullene'},
+        [ 6] = {region = 3, x = -159.082, z =  253.794, offset = 1, npc = 'Guilberdrier'},
+        [ 7] = {region = 4, x = -156.242, z =   49.184, offset = 2, npc = 'Boncort'},
+        [ 8] = {region = 5, x = -127.355, z =  130.461, offset = 3, npc = 'Capiria'},
+        [ 9] = {region = 6, x = -157.524, z =  263.818, offset = 4, npc = 'Villion'},
+    },
+    [tpz.zone.SOUTHERN_SAN_DORIA] =
+    {
+        [10] = {region = 2, x =   33.033, z =  -30.119, offset = 0, npc = 'Blendare'},
+        [11] = {region = 3, x =   69.895, z =   41.073, offset = 1, npc = 'Rosel'},
+        [12] = {region = 4, x =  105.147, z =  -16.735, offset = 3, npc = 'Maugie'},
+        [13] = {region = 5, x =   80.378, z =  -24.644, offset = 5, npc = 'Adaunel'},
+        [14] = {region = 6, x = -136.322, z =   21.958, offset = 7, npc = 'Leuveret'},
+    },
 }
 
 -------------------------------------------------
@@ -44,10 +51,10 @@ local npcData =
 -------------------------------------------------
 
 quests.flyers_for_regine.initZone = function(zone)
-    local zoneId = zone:getID()
+    local data = npcData[zone:getID()]
 
-    for k, v in pairs(npcData) do
-        if v.zone == zoneId then
+    if data then
+        for k, v in pairs(data) do
             zone:registerRegion(v.region, v.x, 10, v.z, 0, 0, 0)
         end
     end
@@ -56,26 +63,30 @@ end
 quests.flyers_for_regine.onRegionEnter = function(player, region)
     local zoneId = player:getZoneID()
     local regionId = region:GetRegionID()
+    local data = npcData[zone:getID()]
 
-    for k, v in pairs(npcData) do
-        if v.zone == zoneId and v.region == regionId then
-            local ID = zones[zoneId]
-            player:messageSpecial(ID.text.FFR_LOOKS_CURIOUSLY_BASE + v.offset)
-            break
+    if data then
+        for k, v in pairs(data) do
+            if v.region == regionId then
+                local ID = zones[zoneId]
+                player:messageSpecial(ID.text.FFR_LOOKS_CURIOUSLY_BASE + v.offset)
+                break
+            end
         end
     end
 end
 
 quests.flyers_for_regine.onTrade = function(player, npc, trade, ffrId)
     if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        local ID = zones[player:getZoneID()]
+        local zoneId = player:getZoneID()
+        local ID = zones[zoneId]
         local mask = player:getCharVar('[ffr]deliveryMask')
         local alreadyDelivered = bit.band(mask, 2^ffrId) ~= 0
 
         if alreadyDelivered then
             player:messageSpecial(ID.text.FLYER_ALREADY)
         else
-            local data = npcData[ffrId]
+            local data = npcData[zoneId][ffrId]
 
             player:messageSpecial(ID.text.FLYER_ACCEPTED)
             player:showText(npc, ID.text['FFR_' .. string.upper(data.npc)])

--- a/scripts/quests/flyers_for_regine.lua
+++ b/scripts/quests/flyers_for_regine.lua
@@ -63,13 +63,19 @@ end
 quests.flyers_for_regine.onRegionEnter = function(player, region)
     local zoneId = player:getZoneID()
     local regionId = region:GetRegionID()
-    local data = npcData[zone:getID()]
+    local data = npcData[zoneId]
 
     if data then
         for k, v in pairs(data) do
             if v.region == regionId then
-                local ID = zones[zoneId]
-                player:messageSpecial(ID.text.FFR_LOOKS_CURIOUSLY_BASE + v.offset)
+                local mask = player:getCharVar('[ffr]deliveryMask')
+                local alreadyDelivered = bit.band(mask, 2^k) ~= 0
+
+                if not alreadyDelivered then
+                    local ID = zones[zoneId]
+                    player:messageSpecial(ID.text.FFR_LOOKS_CURIOUSLY_BASE + v.offset)
+                end
+
                 break
             end
         end

--- a/scripts/quests/flyers_for_regine.lua
+++ b/scripts/quests/flyers_for_regine.lua
@@ -61,22 +61,24 @@ quests.flyers_for_regine.initZone = function(zone)
 end
 
 quests.flyers_for_regine.onRegionEnter = function(player, region)
-    local zoneId = player:getZoneID()
-    local regionId = region:GetRegionID()
-    local data = npcData[zoneId]
+    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED then
+        local zoneId = player:getZoneID()
+        local regionId = region:GetRegionID()
+        local data = npcData[zoneId]
 
-    if data then
-        for k, v in pairs(data) do
-            if v.region == regionId then
-                local mask = player:getCharVar('[ffr]deliveryMask')
-                local alreadyDelivered = bit.band(mask, 2^k) ~= 0
+        if data then
+            for k, v in pairs(data) do
+                if v.region == regionId then
+                    local mask = player:getCharVar('[ffr]deliveryMask')
+                    local alreadyDelivered = bit.band(mask, 2^k) ~= 0
 
-                if not alreadyDelivered then
-                    local ID = zones[zoneId]
-                    player:messageSpecial(ID.text.FFR_LOOKS_CURIOUSLY_BASE + v.offset)
+                    if not alreadyDelivered then
+                        local ID = zones[zoneId]
+                        player:messageSpecial(ID.text.FFR_LOOKS_CURIOUSLY_BASE + v.offset)
+                    end
+
+                    break
                 end
-
-                break
             end
         end
     end

--- a/scripts/zones/Northern_San_dOria/IDs.lua
+++ b/scripts/zones/Northern_San_dOria/IDs.lua
@@ -58,7 +58,6 @@ zones[tpz.zone.NORTHERN_SAN_DORIA] =
         AIVEDOIR_DIALOG          = 11503, -- That's funny. I could have sworn she asked me to meet her here...
         CAPIRIA_DIALOG           = 11504, -- He's late! I do hope he hasn't forgotten.
         BERTENONT_DIALOG         = 11505, -- Stars are more beautiful up close. Don't you agree?
-        FLYER_REFUSED            = 11517, -- Your flyer is refused.
         GILIPESE_DIALOG          = 11526, -- Nothing to report!
         DOGGOMEHR_SHOP_DIALOG    = 11539, -- Welcome to the Blacksmiths' Guild shop.
         CAUZERISTE_SHOP_DIALOG   = 11607, -- Welcome! San d'Oria Carpenters' Guild shop, at your service.

--- a/scripts/zones/Northern_San_dOria/npcs/Ailbeche.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Ailbeche.lua
@@ -10,13 +10,9 @@ require("scripts/globals/settings")
 require("scripts/globals/quests")
 require("scripts/globals/status")
 require("scripts/globals/titles")
-require("scripts/globals/shop")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
     if (player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FATHER_AND_SON) == QUEST_COMPLETED and player:getCharVar("returnedAilbecheRod") ~= 1) then
         if (trade:hasItemQty(17391,1) == true and trade:getItemCount() == 1) then
             player:startEvent(61); -- Finish Quest "Father and Son" (part2) (trading fishing rod)
@@ -30,28 +26,20 @@ function onTrade(player,npc,trade)
             player:startEvent(47); -- During Quest "A Boy's Dream" (trading odontotyrannus)
         end
     end
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)
-    fatherAndSon = player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FATHER_AND_SON);
-    sharpeningTheSword = player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.SHARPENING_THE_SWORD);
-    aBoysDream = player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.A_BOY_S_DREAM);
+    local fatherAndSon = player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FATHER_AND_SON);
+    local sharpeningTheSword = player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.SHARPENING_THE_SWORD);
+    local aBoysDream = player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.A_BOY_S_DREAM);
 
     -- Checking levels and jobs for af quest
-    mLvl = player:getMainLvl();
-    mJob = player:getMainJob();
+    local mLvl = player:getMainLvl();
+    local mJob = player:getMainJob();
     -- Check if they have key item "Ordelle whetStone"
-    OrdelleWhetstone = player:hasKeyItem(tpz.ki.ORDELLE_WHETSTONE);
-    sharpeningTheSwordCS = player:getCharVar("sharpeningTheSwordCS");
-    aBoysDreamCS = player:getCharVar("aBoysDreamCS");
+    local OrdelleWhetstone = player:hasKeyItem(tpz.ki.ORDELLE_WHETSTONE);
+    local sharpeningTheSwordCS = player:getCharVar("sharpeningTheSwordCS");
+    local aBoysDreamCS = player:getCharVar("aBoysDreamCS");
 
     -- "Father and Son" Event Dialogs
     if (fatherAndSon == QUEST_AVAILABLE) then

--- a/scripts/zones/Northern_San_dOria/npcs/Anilla.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Anilla.lua
@@ -4,18 +4,10 @@
 -- Involved in Quest: Lure of the Wildcat (San d'Oria)
 -- !pos 8 0.1 61 231
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/quests");
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(532,1) and trade:getItemCount() == 1) then -- Trade Magicmart_flyer
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Antonian.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Antonian.lua
@@ -6,17 +6,11 @@
 -----------------------------------
 local ID = require("scripts/zones/Northern_San_dOria/IDs")
 require("scripts/globals/events/harvest_festivals")
-require("scripts/globals/npc_util")
-require("scripts/globals/conquest")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    else
-        onHalloweenTrade(player, trade, npc)
-    end
+    onHalloweenTrade(player, trade, npc)
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Arachagnon.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Arachagnon.lua
@@ -4,14 +4,10 @@
 -- Standard Merchant NPC
 -----------------------------------
 local ID = require("scripts/zones/Northern_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Arlenne.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Arlenne.lua
@@ -4,14 +4,10 @@
 -- Standard Merchant NPC
 -----------------------------------
 local ID = require("scripts/zones/Northern_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Attarena.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Attarena.lua
@@ -5,17 +5,11 @@
 -----------------------------------
 local ID = require("scripts/zones/Northern_San_dOria/IDs")
 require("scripts/globals/events/harvest_festivals")
-require("scripts/globals/npc_util")
-require("scripts/globals/conquest")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    else
-        onHalloweenTrade(player,trade,npc);
-    end
+    onHalloweenTrade(player,trade,npc);
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Aurege.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Aurege.lua
@@ -13,9 +13,6 @@ require("scripts/globals/titles")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player, npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Bertenont.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Bertenont.lua
@@ -4,18 +4,11 @@
 -- Involved in Quest: Lure of the Wildcat (San d'Oria)
 -- !pos -165 0.1 226 231
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/quests");
+local ID = require("scripts/zones/Northern_San_dOria/IDs")
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(532,1) and trade:getItemCount() == 1) then -- Trade Magicmart_flyer
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Calovour.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Calovour.lua
@@ -3,22 +3,8 @@
 --  NPC: Calovour
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Castilchat.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Castilchat.lua
@@ -4,22 +4,17 @@
 -- Starts Quest: Trial Size Trial by Ice
 -- !pos -186 0 107 231
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/teleports");
-require("scripts/globals/status");
-require("scripts/globals/quests");
+local ID = require("scripts/zones/Northern_San_dOria/IDs")
+require("scripts/globals/teleports")
+require("scripts/globals/quests")
+require("scripts/globals/status")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    -- "Flyers for Regine" conditional script
     local count = trade:getItemCount();
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and trade:hasItemQty(532,1) and count == 1) then
-        player:messageSpecial(ID.text.FLYER_REFUSED);
-    elseif (trade:hasItemQty(1545,1) and player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.TRIAL_SIZE_TRIAL_BY_ICE) == QUEST_ACCEPTED and player:getMainJob() == tpz.job.SMN and count == 1) then -- Trade mini fork of ice
+    if (trade:hasItemQty(1545,1) and player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.TRIAL_SIZE_TRIAL_BY_ICE) == QUEST_ACCEPTED and player:getMainJob() == tpz.job.SMN and count == 1) then -- Trade mini fork of ice
         player:startEvent(734,0,1545,4,20);
     end
-
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Charlaimagnat.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Charlaimagnat.lua
@@ -3,23 +3,12 @@
 --  NPC: Charlaimagnat
 -- Standard Info NPC
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/quests");
-require("scripts/globals/keyitems");
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
+local ID = require("scripts/zones/Northern_San_dOria/IDs")
+require("scripts/globals/keyitems")
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Commojourt.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Commojourt.lua
@@ -3,26 +3,12 @@
 --  NPC: Commojourt
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)
-    rand = math.random(1,2);
+    local rand = math.random(1,2);
 
     if (rand == 1) then
         player:startEvent(653);

--- a/scripts/zones/Northern_San_dOria/npcs/Danngogg.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Danngogg.lua
@@ -3,22 +3,8 @@
 --  NPC: Danngogg
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Dapraugeant.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Dapraugeant.lua
@@ -3,22 +3,8 @@
 --  NPC: Dapraugeant
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Daveille.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Daveille.lua
@@ -3,22 +3,8 @@
 --  NPC: Daveille
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Esqualea.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Esqualea.lua
@@ -3,22 +3,8 @@
 --  NPC: Esqualea
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Eugballion.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Eugballion.lua
@@ -4,15 +4,10 @@
 -- Only sells when San d'Oria controlls Qufim Region
 -----------------------------------
 local ID = require("scripts/zones/Northern_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/conquest")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Explorer_Moogle.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Explorer_Moogle.lua
@@ -2,18 +2,12 @@
 -- Area: Northern San d'Oria
 --  NPC: Explorer Moogle
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs")
 require("scripts/globals/teleports")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 -----------------------------------
 
 local eventId = 862
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Fantarviont.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Fantarviont.lua
@@ -3,22 +3,8 @@
 --  NPC: Fantarviont
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Gaudylox.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Gaudylox.lua
@@ -4,23 +4,10 @@
 -- Standard merchant, though he acts like a guild merchant
 -- !pos -147.593 11.999 222.550 231
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
-require("scripts/globals/shop");
+local ID = require("scripts/zones/Northern_San_dOria/IDs")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Giaunne.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Giaunne.lua
@@ -4,18 +4,10 @@
 -- Involved in Quest: Lure of the Wildcat (San d'Oria)
 -- !pos -13 0 36 231
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/quests");
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(532,1) and trade:getItemCount() == 1) then -- Trade Magicmart_flyer
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Gilipese.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Gilipese.lua
@@ -4,14 +4,9 @@
 -- !pos -155.088 0.000 120.300 231
 -----------------------------------
 local ID = require("scripts/zones/Northern_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player, npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Guilerme.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Guilerme.lua
@@ -4,30 +4,18 @@
 --  Involved in Quest: Rosel the Armorer
 -- !pos -4.500 0.000 99.000 231
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/titles");
-require("scripts/globals/keyitems");
-require("scripts/globals/quests");
+local ID = require("scripts/zones/Northern_San_dOria/IDs")
+require("scripts/globals/keyitems")
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)
 
     -- "Rosel the Armorer" quest status var
-    RoselTheArmorer = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.ROSEL_THE_ARMORER);
+    local RoselTheArmorer = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.ROSEL_THE_ARMORER);
 
     -- "Rosel the Armorer" - turn in reciept to prince
     if (RoselTheArmorer == QUEST_ACCEPTED and player:hasKeyItem(tpz.ki.RECEIPT_FOR_THE_PRINCE)) then

--- a/scripts/zones/Northern_San_dOria/npcs/Heruze-Moruze.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Heruze-Moruze.lua
@@ -4,25 +4,16 @@
 -- Involved in Mission: 2-3 Windurst
 -- !pos -56 -3 36 231
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/keyitems");
-require("scripts/globals/missions");
+require("scripts/globals/missions")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(532,1) and trade:getItemCount() == 1) then -- Trade Magicmart_flyer
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
 end;
 
 function onTrigger(player,npc)
 
-    pNation = player:getNation();
-    currentMission = player:getCurrentMission(pNation);
+    local pNation = player:getNation();
+    local currentMission = player:getCurrentMission(pNation);
 
     if (pNation == tpz.nation.WINDURST) then
         if (currentMission == tpz.mission.id.windurst.THE_THREE_KINGDOMS and player:getCharVar("MissionStatus") == 1) then

--- a/scripts/zones/Northern_San_dOria/npcs/Justi.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Justi.lua
@@ -4,14 +4,10 @@
 -- Conquest depending furniture seller
 -----------------------------------
 local ID = require("scripts/zones/Northern_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)
@@ -24,8 +20,8 @@ function onTrigger(player,npc)
         1657,   92, 3,    -- Bundling Twine
         93,    518, 3,    -- Water Cask
         57,  15881, 3,    -- Cupboard
-        24, 129168, 3,    --Oak Table
-        46,   8376, 3,    --Armor Box
+        24, 129168, 3,    -- Oak Table
+        46,   8376, 3,    -- Armor Box
     }
 
     player:showText(npc, ID.text.JUSTI_SHOP_DIALOG)

--- a/scripts/zones/Northern_San_dOria/npcs/Kasaroro.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Kasaroro.lua
@@ -5,27 +5,20 @@
 -- Involved in Mission: 2-3 Windurst
 -- !pos -72 -3 34 231
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/keyitems");
-require("scripts/globals/missions");
+local ID = require("scripts/zones/Northern_San_dOria/IDs")
+require("scripts/globals/keyitems")
+require("scripts/globals/missions")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(532,1) and trade:getItemCount() == 1) then -- Trade Magicmart_flyer
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
 end;
 
 function onTrigger(player,npc)
 
-    pNation = player:getNation();
+    local pNation = player:getNation();
     if (pNation == tpz.nation.WINDURST) then
-        currentMission = player:getCurrentMission(pNation);
-        MissionStatus = player:getCharVar("MissionStatus");
+        local currentMission = player:getCurrentMission(pNation);
+        local MissionStatus = player:getCharVar("MissionStatus");
 
         if (currentMission == tpz.mission.id.windurst.THE_THREE_KINGDOMS) then
             if (MissionStatus == 2) then

--- a/scripts/zones/Northern_San_dOria/npcs/Letterare.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Letterare.lua
@@ -3,22 +3,8 @@
 --  NPC: Letterare
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Machella.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Machella.lua
@@ -3,22 +3,8 @@
 --  NPC: Machella
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Madaline.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Madaline.lua
@@ -3,22 +3,8 @@
 --  NPC: Madaline
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Maloquedil.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Maloquedil.lua
@@ -4,21 +4,14 @@
 -- Involved in Quest : Warding Vampires, Riding on the Clouds, Lure of the Wildcat (San d'Oria)
 -- !pos 35 0.1 60 231
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/titles");
-require("scripts/globals/quests");
+local ID = require("scripts/zones/Northern_San_dOria/IDs")
+require("scripts/globals/keyitems")
+require("scripts/globals/settings")
+require("scripts/globals/quests")
+require("scripts/globals/titles")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(532,1) and trade:getItemCount() == 1) then -- Trade Magicmart Flyer
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
     if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.WARDING_VAMPIRES) ~= QUEST_AVAILABLE) then
         if (trade:hasItemQty(1018,2) and trade:getItemCount() == 2) then -- Trade Shaman Garlic
             player:startEvent(23);
@@ -33,7 +26,6 @@ function onTrade(player,npc,trade)
             player:messageSpecial(ID.text.KEYITEM_OBTAINED,tpz.ki.SCOWLING_STONE);
         end
     end
-
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Matildie.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Matildie.lua
@@ -3,26 +3,15 @@
 --  NPC: Matildie
 -- Adventurer's Assistant
 -------------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
+local ID = require("scripts/zones/Northern_San_dOria/IDs")
+require("scripts/globals/settings")
+-------------------------------------
 
 function onTrade(player,npc,trade)
     if (trade:getItemCount() == 1 and trade:hasItemQty(536,1) == true) then
         player:startEvent(631);
         player:addGil(GIL_RATE*50);
         player:tradeComplete();
-    end
-
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
     end
 end;
 

--- a/scripts/zones/Northern_San_dOria/npcs/Maurinne.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Maurinne.lua
@@ -4,14 +4,9 @@
 -- !pos -127.185 0.000 179.193 231
 -----------------------------------
 local ID = require("scripts/zones/Northern_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player, npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Mevaloud.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Mevaloud.lua
@@ -3,22 +3,8 @@
 --  NPC: Mevaloud
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Miageau.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Miageau.lua
@@ -6,31 +6,22 @@
 --
 -- Starts and Finishes: Waters of Cheval
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/titles");
-require("scripts/globals/quests");
+local ID = require("scripts/zones/Northern_San_dOria/IDs")
+require("scripts/globals/quests")
+require("scripts/globals/titles")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(532,1) == true and trade:getItemCount() == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
     if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.WATER_OF_THE_CHEVAL) == QUEST_ACCEPTED) then
         if (trade:getItemCount() == 1 and trade:hasItemQty(603, 1)) then
             player:startEvent(515);
         end;
     end;
-
 end;
 
 function onTrigger(player,npc)
 
-    watersOfTheCheval = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.WATER_OF_THE_CHEVAL);
+    local watersOfTheCheval = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.WATER_OF_THE_CHEVAL);
     if (watersOfTheCheval == QUEST_ACCEPTED) then
         if (player:hasItem(602) == true) then
             player:startEvent(512);

--- a/scripts/zones/Northern_San_dOria/npcs/Millechuca.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Millechuca.lua
@@ -5,14 +5,10 @@
 -- Only sells when San d'Oria controls Vollbow.
 -----------------------------------
 local ID = require("scripts/zones/Northern_San_dOria/IDs")
-require("scripts/globals/conquest")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Morunaude.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Morunaude.lua
@@ -3,22 +3,8 @@
 --  NPC: Morunaude
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Narsaude.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Narsaude.lua
@@ -3,22 +3,8 @@
 --  NPC: Narsaude
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Nouveil.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Nouveil.lua
@@ -4,25 +4,16 @@
 -- Type: General
 -- !pos 123 0 106 231
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
+local ID = require("scripts/zones/Northern_San_dOria/IDs")
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(532,1) == true and trade:getItemCount() == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
     if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.WATER_OF_THE_CHEVAL) == QUEST_ACCEPTED) then
         if (trade:getGil() >= 10) then
             player:startEvent(571);
         end;
     end;
-
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Pala_Korin.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Pala_Korin.lua
@@ -3,22 +3,8 @@
 --  NPC: Pala_Korin
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Palguevion.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Palguevion.lua
@@ -4,15 +4,10 @@
 -- Only sells when San d'Oria controlls Valdeaunia Region
 -----------------------------------
 local ID = require("scripts/zones/Northern_San_dOria/IDs")
-require("scripts/globals/conquest")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Pepigort.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Pepigort.lua
@@ -4,14 +4,9 @@
 -- !pos -126.739 11.999 262.757 231
 -----------------------------------
 local ID = require("scripts/zones/Northern_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player, npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Phairupegiont.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Phairupegiont.lua
@@ -4,18 +4,10 @@
 -- Involved in Quest: Lure of the Wildcat (San d'Oria)
 -- !pos -46 0.1 76 231
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/quests");
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(532,1) and trade:getItemCount() == 1) then -- Trade Magicmart_flyer
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Pikiki.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Pikiki.lua
@@ -3,22 +3,8 @@
 --  NPC: Pikiki
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Pirvidiauce.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Pirvidiauce.lua
@@ -4,14 +4,10 @@
 -- Conquest depending medicine seller
 -----------------------------------
 local ID = require("scripts/zones/Northern_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Rodaillece.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Rodaillece.lua
@@ -4,14 +4,9 @@
 -- !pos -246.943 7.000 46.836 231
 -----------------------------------
 local ID = require("scripts/zones/Northern_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player, npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Taulenne.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Taulenne.lua
@@ -3,18 +3,10 @@
 --  NPC: Taulenne
 -- Armor Storage NPC
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/armorstorage");
-require("scripts/globals/quests");
+require("scripts/globals/armorstorage")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(532,1) and trade:getItemCount() == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
     tpz.armorStorage.onTrade(player, trade, 772);
 end;
 

--- a/scripts/zones/Northern_San_dOria/npcs/Taurette.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Taurette.lua
@@ -4,20 +4,12 @@
 -- Involved in Quests: Riding on the Clouds
 -- !pos -159 0 91 231
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/quests");
+local ID = require("scripts/zones/Northern_San_dOria/IDs")
+require("scripts/globals/keyitems")
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(532,1) and trade:getItemCount() == 1) then -- Trade Magicmart Flyer
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
     if (player:getQuestStatus(JEUNO,tpz.quest.id.jeuno.RIDING_ON_THE_CLOUDS) == QUEST_ACCEPTED and player:getCharVar("ridingOnTheClouds_1") == 3) then
         if (trade:hasItemQty(1127,1) and trade:getItemCount() == 1) then -- Trade Kindred seal
             player:setCharVar("ridingOnTheClouds_1",0);
@@ -26,7 +18,6 @@ function onTrade(player,npc,trade)
             player:messageSpecial(ID.text.KEYITEM_OBTAINED,tpz.ki.SCOWLING_STONE);
         end
     end
-
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Tavourine.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Tavourine.lua
@@ -4,14 +4,10 @@
 -- Standard Merchant NPC
 -----------------------------------
 local ID = require("scripts/zones/Northern_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Telmoda.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Telmoda.lua
@@ -3,26 +3,12 @@
 --  NPC: Telmoda
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)
-    Telmoda_Madaline = player:getCharVar("Telmoda_Madaline_Event");
+    local Telmoda_Madaline = player:getCharVar("Telmoda_Madaline_Event");
 
     if (Telmoda_Madaline ~= 1) then
         player:setCharVar(player,"Telmoda_Madaline_Event",1);

--- a/scripts/zones/Northern_San_dOria/npcs/Vavegallet.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Vavegallet.lua
@@ -3,22 +3,8 @@
 --  NPC: Vavegallet
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Vichuel.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Vichuel.lua
@@ -5,17 +5,11 @@
 -----------------------------------
 local ID = require("scripts/zones/Northern_San_dOria/IDs")
 require("scripts/globals/events/harvest_festivals")
-require("scripts/globals/npc_util")
-require("scripts/globals/conquest")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    else
-        onHalloweenTrade(player, trade, npc)
-    end
+    onHalloweenTrade(player, trade, npc)
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Port_San_dOria/IDs.lua
+++ b/scripts/zones/Port_San_dOria/IDs.lua
@@ -21,7 +21,6 @@ zones[tpz.zone.PORT_SAN_DORIA] =
         CONQUEST_BASE                  = 7066, -- Tallying conquest results...
         FISHING_MESSAGE_OFFSET         = 7225, -- You can't fish here.
         PICKPOCKET_AVANDALE            = 7379, -- What? A pickpocket? Well, I did see a strange woman run to Northern San d'Oria. But I didn't see her steal anything.
-        FLYER_REFUSED                  = 7557, -- This person isn't interested.
         FLYER_ALREADY                  = 7558, -- This person already has a flyer.
         FLYER_ACCEPTED                 = 7559, -- Your flyer is accepted!
         PICKPOCKET_COMITTIE            = 7597, -- A pickpocket? No one like that around here.

--- a/scripts/zones/Port_San_dOria/npcs/Altiret.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Altiret.lua
@@ -6,17 +6,13 @@
 -----------------------------------
 local ID = require("scripts/zones/Port_San_dOria/IDs")
 require("scripts/globals/npc_util")
-require("scripts/globals/titles")
 require("scripts/globals/quests")
+require("scripts/globals/titles")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    -- FLYERS FOR REGINE
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-
     -- THE PICKPOCKET
-    elseif player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.THE_PICKPOCKET) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 579) then
+    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.THE_PICKPOCKET) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 579) then
         player:startEvent(550)
 
     -- DEFAULT DIALOG

--- a/scripts/zones/Port_San_dOria/npcs/Anton.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Anton.lua
@@ -3,23 +3,10 @@
 --  NPC: Anton
 -- !pos -19 -8 27 232
 -----------------------------------
-local ID = require("scripts/zones/Port_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/quests");
+require("scripts/globals/keyitems")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Port_San_dOria/npcs/Apstaule.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Apstaule.lua
@@ -3,23 +3,14 @@
 --  NPC: Apstaule
 -- Not used cutscenes: 541
 -----------------------------------
-local ID = require("scripts/zones/Port_San_dOria/IDs");
 require("scripts/globals/quests");
-require("scripts/globals/shop");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
     local count = trade:getItemCount();
-    local MagicFlyer    = trade:hasItemQty(532,1);
     local AuctionParcel = trade:hasItemQty(594,1);
 
-    if (MagicFlyer == true and count == 1) then
-        local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-        if (FlyerForRegine == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    elseif (AuctionParcel == true and count == 1) then
+    if (AuctionParcel == true and count == 1) then
         local TheBrugaireConsortium = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.THE_BRUGAIRE_CONSORTIUM);
         if (TheBrugaireConsortium == 1) then
             player:tradeComplete();

--- a/scripts/zones/Port_San_dOria/npcs/Arminibit.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Arminibit.lua
@@ -3,21 +3,10 @@
 --  NPC: Arminibit
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Port_San_dOria/IDs");
-require("scripts/globals/quests");
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Port_San_dOria/npcs/Artinien.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Artinien.lua
@@ -3,14 +3,9 @@
 --  NPC: Artinien
 -----------------------------------
 local ID = require("scripts/zones/Port_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player, npc)

--- a/scripts/zones/Port_San_dOria/npcs/Avandale.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Avandale.lua
@@ -4,14 +4,9 @@
 -- !pos -105.524 -9 -125.274 232
 -----------------------------------
 local ID = require("scripts/zones/Port_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player, npc)

--- a/scripts/zones/Port_San_dOria/npcs/Bellue.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Bellue.lua
@@ -3,21 +3,8 @@
 --  NPC: Bellue
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Port_San_dOria/IDs");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Port_San_dOria/npcs/Bonarpant.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Bonarpant.lua
@@ -3,21 +3,8 @@
 --  NPC: Bonarpant
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Port_San_dOria/IDs");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Port_San_dOria/npcs/Bonmaurieut.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Bonmaurieut.lua
@@ -4,15 +4,10 @@
 -- Elshimo Uplands Regional Merchant
 -----------------------------------
 local ID = require("scripts/zones/Port_San_dOria/IDs")
-require("scripts/globals/conquest")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Port_San_dOria/npcs/Bricorsant.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Bricorsant.lua
@@ -3,21 +3,8 @@
 --  NPC: Bricorsant
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Port_San_dOria/IDs");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Port_San_dOria/npcs/Brifalien.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Brifalien.lua
@@ -11,10 +11,7 @@ require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-
-    elseif player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.RIDING_ON_THE_CLOUDS) == QUEST_ACCEPTED and player:getCharVar("ridingOnTheClouds_1") == 7 and npcUtil.tradeHas(trade, 1127) then
+    if player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.RIDING_ON_THE_CLOUDS) == QUEST_ACCEPTED and player:getCharVar("ridingOnTheClouds_1") == 7 and npcUtil.tradeHas(trade, 1127) then
         player:setCharVar("ridingOnTheClouds_1", 0)
         npcUtil.giveKeyItem(player, tpz.ki.SCOWLING_STONE)
         player:confirmTrade()

--- a/scripts/zones/Port_San_dOria/npcs/Callort.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Callort.lua
@@ -3,21 +3,8 @@
 --  NPC: Callort
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Port_San_dOria/IDs");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Port_San_dOria/npcs/Cherlodeau.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Cherlodeau.lua
@@ -4,18 +4,10 @@
 -- Involved in Quest: Lure of the Wildcat (San d'Oria)
 -- !pos -20 -4 -69 232
 -----------------------------------
-local ID = require("scripts/zones/Port_San_dOria/IDs");
-require("scripts/globals/quests");
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(532,1) and trade:getItemCount() == 1) then -- Trade Magicmart_flyer
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Port_San_dOria/npcs/Comittie.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Comittie.lua
@@ -4,14 +4,9 @@
 -- !pos -6.570 -9.8 -147.952 232
 -----------------------------------
 local ID = require("scripts/zones/Port_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player, npc)

--- a/scripts/zones/Port_San_dOria/npcs/Coribalgeant.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Coribalgeant.lua
@@ -3,14 +3,9 @@
 --  NPC: Coribalgeant
 -----------------------------------
 local ID = require("scripts/zones/Port_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player, npc)

--- a/scripts/zones/Port_San_dOria/npcs/Coullave.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Coullave.lua
@@ -4,14 +4,10 @@
 -- Standard Merchant NPC
 -----------------------------------
 local ID = require("scripts/zones/Port_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Port_San_dOria/npcs/Crilde.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Crilde.lua
@@ -3,14 +3,9 @@
 --  NPC: Crilde
 -----------------------------------
 local ID = require("scripts/zones/Port_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player, npc)

--- a/scripts/zones/Port_San_dOria/npcs/Croumangue.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Croumangue.lua
@@ -4,14 +4,10 @@
 -- Standard Merchant NPC
 -----------------------------------
 local ID = require("scripts/zones/Port_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Port_San_dOria/npcs/Deguerendars.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Deguerendars.lua
@@ -4,16 +4,11 @@
 -- Tavnazian Archipelago Regional Merchant
 -----------------------------------
 local ID = require("scripts/zones/Port_San_dOria/IDs")
-require("scripts/globals/conquest")
 require("scripts/globals/missions")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Port_San_dOria/npcs/Diraulate.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Diraulate.lua
@@ -3,21 +3,8 @@
 --  NPC: Diraulate
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Port_San_dOria/IDs");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Port_San_dOria/npcs/Eaugouint.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Eaugouint.lua
@@ -4,14 +4,9 @@
 -- !pos 28.555 -4.000 -74.860 232
 -----------------------------------
 local ID = require("scripts/zones/Port_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player, npc)

--- a/scripts/zones/Port_San_dOria/npcs/Fiva.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Fiva.lua
@@ -4,15 +4,10 @@
 -- Kolshushu Regional Merchant
 -----------------------------------
 local ID = require("scripts/zones/Port_San_dOria/IDs")
-require("scripts/globals/conquest")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Port_San_dOria/npcs/Fontoumant.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Fontoumant.lua
@@ -5,11 +5,11 @@
 -- Involved in Quests: Riding on the Clouds
 -- !pos -10 -10 -122 232
 -----------------------------------
-local ID = require("scripts/zones/Port_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/titles");
-require("scripts/globals/quests");
+local ID = require("scripts/zones/Port_San_dOria/IDs")
+require("scripts/globals/keyitems")
+require("scripts/globals/settings")
+require("scripts/globals/quests")
+require("scripts/globals/titles")
 -----------------------------------
 
 function onTrade(player,npc,trade)
@@ -27,12 +27,6 @@ function onTrade(player,npc,trade)
                 player:startEvent(610);
                 player:setCharVar("TheBrugaireConsortium-Parcels",31)
             end
-        end
-    end
-
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(532,1) and count == 1) then -- Trade Magicmart Flyer
-            player:messageSpecial(ID.text.FLYER_REFUSED);
         end
     end
 

--- a/scripts/zones/Port_San_dOria/npcs/Gournaie.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Gournaie.lua
@@ -3,21 +3,8 @@
 --  NPC: Gournaie
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Port_San_dOria/IDs");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Port_San_dOria/npcs/Gulemont.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Gulemont.lua
@@ -6,26 +6,19 @@
 --
 -- Starts and Finishes Quest: The Dismayed Customer
 -----------------------------------
-local ID = require("scripts/zones/Port_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/quests");
-require("scripts/globals/titles");
+local ID = require("scripts/zones/Port_San_dOria/IDs")
+require("scripts/globals/keyitems")
+require("scripts/globals/settings")
+require("scripts/globals/quests")
+require("scripts/globals/titles")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(532,1) == true and trade:getItemCount() == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end;
-    end;
-
 end;
 
 function onTrigger(player,npc)
 
-    theDismayedCustomer = player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.THE_DISMAYED_CUSTOMER);
+    local theDismayedCustomer = player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.THE_DISMAYED_CUSTOMER);
     if (theDismayedCustomer == QUEST_ACCEPTED) then
         if (player:hasKeyItem(tpz.ki.GULEMONTS_DOCUMENT) == true) then
             player:startEvent(607);

--- a/scripts/zones/Port_San_dOria/npcs/Jaireto.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Jaireto.lua
@@ -3,21 +3,8 @@
 --  NPC: Jaireto
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Port_San_dOria/IDs");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Port_San_dOria/npcs/Laucimercen.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Laucimercen.lua
@@ -3,14 +3,9 @@
 --  NPC: Laucimercen
 -----------------------------------
 local ID = require("scripts/zones/Port_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player, npc)

--- a/scripts/zones/Port_San_dOria/npcs/Leonora.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Leonora.lua
@@ -4,22 +4,8 @@
 -- Involved in Quest:
 -- !pos -24 -8 15 232
 -----------------------------------
-local ID = require("scripts/zones/Port_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Port_San_dOria/npcs/Liloune.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Liloune.lua
@@ -3,21 +3,8 @@
 --  NPC: Liloune
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Port_San_dOria/IDs");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Port_San_dOria/npcs/Marquie.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Marquie.lua
@@ -4,14 +4,9 @@
 -- Standard Info NPC
 -----------------------------------
 local ID = require("scripts/zones/Port_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player, npc)

--- a/scripts/zones/Port_San_dOria/npcs/Maunadolace.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Maunadolace.lua
@@ -5,14 +5,9 @@
 -- !pos -22.800 -9.3 -148.645 232
 -----------------------------------
 local ID = require("scripts/zones/Port_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player, npc)

--- a/scripts/zones/Port_San_dOria/npcs/Meinemelle.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Meinemelle.lua
@@ -4,14 +4,9 @@
 -- !pos -8.289 -9.3 -146.093 232
 -----------------------------------
 local ID = require("scripts/zones/Port_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player, npc)

--- a/scripts/zones/Port_San_dOria/npcs/Meta.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Meta.lua
@@ -3,21 +3,8 @@
 --  NPC: Meta
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Port_San_dOria/IDs");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Port_San_dOria/npcs/Meuxtajean.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Meuxtajean.lua
@@ -3,14 +3,9 @@
 --  NPC: Meuxtajean
 -----------------------------------
 local ID = require("scripts/zones/Port_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player, npc)

--- a/scripts/zones/Port_San_dOria/npcs/Milva.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Milva.lua
@@ -4,15 +4,10 @@
 -- Sarutabaruta Regional Merchant
 -----------------------------------
 local ID = require("scripts/zones/Port_San_dOria/IDs")
-require("scripts/globals/conquest")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Port_San_dOria/npcs/Nimia.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Nimia.lua
@@ -4,15 +4,10 @@
 -- Elshimo Lowlands Regional Merchant
 -----------------------------------
 local ID = require("scripts/zones/Port_San_dOria/IDs")
-require("scripts/globals/conquest")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Port_San_dOria/npcs/Nogelle.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Nogelle.lua
@@ -3,23 +3,13 @@
 --  NPC: Nogelle
 -- Starts Lufet's Lake Salt
 -----------------------------------
-local ID = require("scripts/zones/Port_San_dOria/IDs");
-require("scripts/globals/quests");
-require("scripts/globals/titles");
+local ID = require("scripts/zones/Port_San_dOria/IDs")
+require("scripts/globals/settings")
+require("scripts/globals/quests")
+require("scripts/globals/titles")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
     if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.LUFET_S_LAKE_SALT) == QUEST_ACCEPTED) then
         local count = trade:getItemCount();
         LufetSalt = trade:hasItemQty(1019,3);

--- a/scripts/zones/Port_San_dOria/npcs/Noquerelle.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Noquerelle.lua
@@ -4,14 +4,9 @@
 -- Standard Info NPC
 -----------------------------------
 local ID = require("scripts/zones/Port_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player, npc)

--- a/scripts/zones/Port_San_dOria/npcs/Parcarin.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Parcarin.lua
@@ -9,9 +9,6 @@ require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player, npc)

--- a/scripts/zones/Port_San_dOria/npcs/Patolle.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Patolle.lua
@@ -4,16 +4,10 @@
 -- Kuzotz Regional Merchant
 -----------------------------------
 local ID = require("scripts/zones/Port_San_dOria/IDs")
-require("scripts/globals/conquest")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
-
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Port_San_dOria/npcs/Perdiouvilet.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Perdiouvilet.lua
@@ -4,18 +4,10 @@
 -- Involved in Quest: Lure of the Wildcat (San d'Oria)
 -- !pos -59 -5 -29 232
 -----------------------------------
-local ID = require("scripts/zones/Port_San_dOria/IDs");
-require("scripts/globals/quests");
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(532,1) and trade:getItemCount() == 1) then -- Trade Magicmart_flyer
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Port_San_dOria/npcs/Phersula.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Phersula.lua
@@ -3,21 +3,8 @@
 --  NPC: Phersula
 -- Standard Info NPC
 -----------------------------------
-local ID = require("scripts/zones/Port_San_dOria/IDs");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Port_San_dOria/npcs/Pomilla.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Pomilla.lua
@@ -4,18 +4,10 @@
 -- Involved in Quest: Lure of the Wildcat (San d'Oria)
 -- !pos -38 -4 -55 232
 -----------------------------------
-local ID = require("scripts/zones/Port_San_dOria/IDs");
-require("scripts/globals/quests");
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(532,1) and trade:getItemCount() == 1) then -- Trade Magicmart_flyer
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Port_San_dOria/npcs/Raqtibahl.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Raqtibahl.lua
@@ -3,21 +3,15 @@
 --  NPC: Raqtibahl
 -- (Corsair's Frac) !pos -59 -4 -39 232
 -----------------------------------
-local ID = require("scripts/zones/Port_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/quests");
+local ID = require("scripts/zones/Port_San_dOria/IDs")
+require("scripts/globals/keyitems")
 -----------------------------------
 
 function onTrade(player,npc,trade)
     local letterRed = player:getCharVar("LeleroonsLetterRed");
 
-    -- magicmart flyer
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and trade:getItemCount() == 1 and trade:hasItemQty(532,1)) then
-        player:messageSpecial(ID.text.FLYER_REFUSED);
-
     -- gold chain, velvet cloth, red grass cloth, sailcloth
-    elseif (letterRed == 2 and trade:getItemCount() == 4 and trade:hasItemQty(761,1) and trade:hasItemQty(828,1) and trade:hasItemQty(1829,1) and trade:hasItemQty(1997,1)) then
+    if (letterRed == 2 and trade:getItemCount() == 4 and trade:hasItemQty(761,1) and trade:hasItemQty(828,1) and trade:hasItemQty(1829,1) and trade:hasItemQty(1997,1)) then
         player:startEvent(755); -- accepts materials, now bring me imperial gold piece
 
     -- imperial gold piece

--- a/scripts/zones/Port_San_dOria/npcs/Regine.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Regine.lua
@@ -28,12 +28,9 @@ end;
 
 function onTrigger(player,npc)
     local ffr = player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE)
-    local ffrStat = player:getCharVar("FFR")
 
     -- FLYERS FOR REGINE
-    if ffr == QUEST_AVAILABLE and ffrStat == 0 then -- pre-quest cutscene
-        player:startEvent(601)
-    elseif ffr == QUEST_AVAILABLE and ffrStat == 1 then -- ready to accept quest
+    if ffr == QUEST_AVAILABLE then -- ready to accept quest
         player:startEvent(510, 2)
     elseif ffr == QUEST_ACCEPTED and not player:hasItem(532) then -- on quest but out of flyers
         player:startEvent(510, 3)
@@ -51,12 +48,9 @@ end;
 
 function onEventFinish(player,csid,option)
     -- FLYERS FOR REGINE
-    if csid == 601 then
-        player:setCharVar("FFR", 1)
-    elseif csid == 510 and option == 2 then
+    if csid == 510 and option == 2 then
         if npcUtil.giveItem(player, {{532,12}, {532,3}}) then
             player:addQuest(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE)
-            player:setCharVar("FFR", 0)
         end
     elseif csid == 603 then
         npcUtil.completeQuest(

--- a/scripts/zones/Port_San_dOria/npcs/Regine.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Regine.lua
@@ -19,8 +19,6 @@ function onTrade(player,npc,trade)
         if (npcUtil.giveItem(player, 532)) then
             player:confirmTrade();
         end
-    elseif (flyersForRegine == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532)) then
-        player:messageSpecial(ID.text.FLYER_REFUSED);
 
     -- THE BRUGAIRE CONSORTIUM
     elseif (theBrugaireConsortium == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 593)) then

--- a/scripts/zones/Port_San_dOria/npcs/Rielle.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Rielle.lua
@@ -3,14 +3,9 @@
 --  NPC: Rielle
 -----------------------------------
 local ID = require("scripts/zones/Port_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player, npc)

--- a/scripts/zones/Port_San_dOria/npcs/Rugiette.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Rugiette.lua
@@ -38,9 +38,5 @@ function onEventFinish(player,csid,option)
 
     if (csid == 746) then
         player:setMaskBit(player:getCharVar("WildcatSandy"),"WildcatSandy",14,true);
-    elseif (csid == 601) then
-        if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_AVAILABLE and player:getCharVar("FFR") == 0) then
-            player:setCharVar("FFR",1);
-        end
     end
 end;

--- a/scripts/zones/Port_San_dOria/npcs/Rugiette.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Rugiette.lua
@@ -4,19 +4,12 @@
 -- Involved in Quests: Riding on the Clouds, Lure of the Wildcat (San d'Oria)
 -- !pos 71 -9 -73 232
 -----------------------------------
-local ID = require("scripts/zones/Port_San_dOria/IDs");
-require("scripts/globals/keyitems");
-require("scripts/globals/quests");
+local ID = require("scripts/zones/Port_San_dOria/IDs")
+require("scripts/globals/keyitems")
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(532,1) and trade:getItemCount() == 1) then -- Trade Magicmart Flyer
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
     if (player:getQuestStatus(JEUNO,tpz.quest.id.jeuno.RIDING_ON_THE_CLOUDS) == QUEST_ACCEPTED and player:getCharVar("ridingOnTheClouds_1") == 8) then
         if (trade:hasItemQty(1127,1) and trade:getItemCount() == 1) then -- Trade Kindred seal
             player:setCharVar("ridingOnTheClouds_1",0);
@@ -25,7 +18,6 @@ function onTrade(player,npc,trade)
             player:messageSpecial(ID.text.KEYITEM_OBTAINED,tpz.ki.SCOWLING_STONE);
         end
     end
-
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Port_San_dOria/npcs/Sheridan.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Sheridan.lua
@@ -11,10 +11,7 @@ require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-
-    elseif player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.RIDING_ON_THE_CLOUDS) == QUEST_ACCEPTED and player:getCharVar("ridingOnTheClouds_1") == 5 and npcUtil.tradeHas(trade, 1127) then
+    if player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.RIDING_ON_THE_CLOUDS) == QUEST_ACCEPTED and player:getCharVar("ridingOnTheClouds_1") == 5 and npcUtil.tradeHas(trade, 1127) then
         player:setCharVar("ridingOnTheClouds_1", 0)
         npcUtil.giveKeyItem(player, tpz.ki.SCOWLING_STONE)
         player:confirmTrade()

--- a/scripts/zones/Port_San_dOria/npcs/Solgierte.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Solgierte.lua
@@ -3,14 +3,9 @@
 --  NPC: Solgierte
 -----------------------------------
 local ID = require("scripts/zones/Port_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player, npc)

--- a/scripts/zones/Port_San_dOria/npcs/Teilsa.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Teilsa.lua
@@ -5,9 +5,8 @@
 -- Only recieving Adv.Coupon and simple talk event are scrited
 -- This NPC participates in Quests and Missions
 -------------------------------------
-local ID = require("scripts/zones/Port_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
+local ID = require("scripts/zones/Port_San_dOria/IDs")
+require("scripts/globals/settings")
 -------------------------------------
 
 function onTrade(player,npc,trade)
@@ -15,16 +14,6 @@ function onTrade(player,npc,trade)
         player:startEvent(612);
         player:addGil(GIL_RATE*50);
         player:tradeComplete();
-    end
-    -- "Flyers for Regine" conditional script
-    local count = trade:getItemCount();
-    local MagicFlyer = trade:hasItemQty(532,1);
-
-    if (MagicFlyer == true and count == 1) then
-        local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-        if (FlyerForRegine == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
     end
 end;
 

--- a/scripts/zones/Port_San_dOria/npcs/Vendavoq.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Vendavoq.lua
@@ -4,15 +4,10 @@
 --  Movalpolos Regional Merchant
 -----------------------------------
 local ID = require("scripts/zones/Port_San_dOria/IDs")
-require("scripts/globals/conquest")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/IDs.lua
+++ b/scripts/zones/Southern_San_dOria/IDs.lua
@@ -53,7 +53,6 @@ zones[tpz.zone.SOUTHERN_SAN_DORIA] =
         SHILAH_SHOP_DIALOG             = 8114, -- Welcome, weary traveler. Make yourself at home!
         VALERIANO_SHOP_DIALOG          = 8132, -- Oh, a fellow outsider! We are Troupe Valeriano. I am Valeriano, at your service!
         FERDOULEMIONT_SHOP_DIALOG      = 8148, -- Hello!
-        FLYER_REFUSED                  = 8180, -- Your flyer is refused.
         CLETAE_DIALOG                  = 8200, -- Why, hello. All our skins are guild-approved.
         KUEH_IGUNAHMORI_DIALOG         = 8201, -- Good day! We have lots in stock today.
         PAUNELIE_DIALOG                = 8309, -- I'm sorry, can I help you?

--- a/scripts/zones/Southern_San_dOria/npcs/Ailevia.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Ailevia.lua
@@ -6,25 +6,14 @@
 -- This NPC participates in Quests and Missions
 -- !pos -8 1 1 230
 -------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
+local ID = require("scripts/zones/Southern_San_dOria/IDs")
+require("scripts/globals/settings")
 -----------------------------------
 
 function onTrade(player,npc,trade)
     -- Adventurer coupon
     if (trade:getItemCount() == 1 and trade:hasItemQty(536,1) == true) then
         player:startEvent(655);
-    end
-    -- "Flyers for Regine" conditional script
-    local count = trade:getItemCount();
-    local MagicFlyer = trade:hasItemQty(532,1);
-
-    if (MagicFlyer == true and count == 1) then
-        local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-        if (FlyerForRegine == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
     end
 end;
 

--- a/scripts/zones/Southern_San_dOria/npcs/Alaune.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Alaune.lua
@@ -4,26 +4,10 @@
 -- Type: Tutorial NPC
 -- !pos -90 1 -56 230
 -----------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs")
-require("scripts/globals/status")
-require("scripts/globals/keyitems")
-require("scripts/globals/settings")
-require("scripts/globals/npc_util")
 require("scripts/quests/tutorial")
 -----------------------------------
 
-
 function onTrade(player, npc, trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE)
-
-    if FlyerForRegine == 1 then
-        local count = trade:getItemCount()
-        local MagicFlyer = trade:hasItemQty(532, 1)
-        if MagicFlyer and (count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED)
-        end
-    end
 end
 
 function onTrigger(player, npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Alivatand.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Alivatand.lua
@@ -4,10 +4,10 @@
 -- Type: Guildworker's Union Representative
 -- !pos -179.458 -1 15.857 230
 -----------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/keyitems");
-require("scripts/globals/crafting");
-require("scripts/globals/quests");
+local ID = require("scripts/zones/Southern_San_dOria/IDs")
+require("scripts/globals/crafting")
+require("scripts/globals/keyitems")
+-----------------------------------
 
 local keyitems = {
     [0] = {
@@ -76,17 +76,7 @@ local items = {
 };
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    else
-        unionRepresentativeTrade(player, npc, trade, 691, 5);
-    end
+    unionRepresentativeTrade(player, npc, trade, 691, 5);
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Amutiyaal.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Amutiyaal.lua
@@ -4,12 +4,13 @@
 --  Warp NPC (Aht Urhgan)
 -- !pos 116 0.1 84 230
 -------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/keyitems");
-require("scripts/globals/teleports");
-require("scripts/globals/missions");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
+local ID = require("scripts/zones/Southern_San_dOria/IDs")
+require("scripts/globals/teleports")
+require("scripts/globals/keyitems")
+require("scripts/globals/missions")
+require("scripts/globals/settings")
+require("scripts/globals/quests")
+-------------------------------------
 
 --[[
 Bitmask Designations:
@@ -43,18 +44,10 @@ Chateau d'Oraguille (East to West)
 --]]
 
 function onTrade(player,npc,trade)
-
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(532,1) and trade:getItemCount() == 1) then -- Trade Magicmart_flyer
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
     if (trade:getGil() == 300 and trade:getItemCount() == 1 and player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_COMPLETED and player:getCurrentMission(TOAU) > tpz.mission.id.toau.IMMORTAL_SENTRIES) then
         -- Needs a check for at least traded an invitation card to Naja Salaheem
         player:startEvent(881);
     end
-
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Andecia.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Andecia.lua
@@ -4,38 +4,25 @@
 -- Starts and Finishes Quest: Grave Concerns
 -- !pos 167 0 45 230
 -----------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
-require("scripts/globals/titles");
+local ID = require("scripts/zones/Southern_San_dOria/IDs")
+require("scripts/globals/settings")
+require("scripts/globals/quests")
+require("scripts/globals/titles")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
     if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.GRAVE_CONCERNS) == QUEST_ACCEPTED) then
         if (trade:hasItemQty(547, 1) and trade:getItemCount() == 1 and player:getCharVar("OfferingWaterOK") == 1) then
             player:startEvent(624);
         end
     end
-
-        -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
 end;
 
 function onTrigger(player,npc)
 
-    Tomb = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.GRAVE_CONCERNS);
-    WellWater = player:hasItem(567); -- Well Water
-    Waterskin = player:hasItem(547); -- Tomb Waterskin
+    local Tomb = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.GRAVE_CONCERNS);
+    local WellWater = player:hasItem(567); -- Well Water
+    local Waterskin = player:hasItem(547); -- Tomb Waterskin
 
     if (Tomb == QUEST_AVAILABLE) then
         player:startEvent(541);

--- a/scripts/zones/Southern_San_dOria/npcs/Anxaberoute.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Anxaberoute.lua
@@ -4,22 +4,8 @@
 -- Type: Standard Info NPC
 -- !pos 108.892 0.000 -49.038 230
 -----------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Apairemant.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Apairemant.lua
@@ -6,16 +6,11 @@
 -----------------------------------
 local ID = require("scripts/zones/Southern_San_dOria/IDs")
 require("scripts/globals/events/harvest_festivals")
-require("scripts/globals/conquest")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
+require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    else
-        onHalloweenTrade(player, trade, npc)
-    end
+    onHalloweenTrade(player, trade, npc)
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Arpetion.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Arpetion.lua
@@ -4,22 +4,8 @@
 --  General Info NPC
 -- !pos -11 1 -30 230
 -------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Arvilauge.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Arvilauge.lua
@@ -4,22 +4,8 @@
 -- Optional Involvement in Quest: A Squire's Test II
 -- !pos -11 1 -94 230
 -------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Ashene.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Ashene.lua
@@ -5,14 +5,10 @@
 -- !pos 70 0 61 230
 -----------------------------------
 local ID = require("scripts/zones/Southern_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Atelloune.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Atelloune.lua
@@ -4,22 +4,11 @@
 -- Starts and Finishes Quest: Atelloune's Lament
 -- !pos 122 0 82 230
 -------------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/quests");
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
+local ID = require("scripts/zones/Southern_San_dOria/IDs")
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
     -----lady bug
     if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.ATELLOUNE_S_LAMENT) == QUEST_ACCEPTED) then
         if (trade:hasItemQty(2506,1) and trade:getItemCount() == 1) then
@@ -31,8 +20,8 @@ end;
 
 function onTrigger(player,npc)
 
-    atellounesLament = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.ATELLOUNE_S_LAMENT)
-    sanFame = player:getFameLevel(SANDORIA);
+    local atellounesLament = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.ATELLOUNE_S_LAMENT)
+    local sanFame = player:getFameLevel(SANDORIA);
 
     if (atellounesLament == QUEST_AVAILABLE and sanFame >= 2) then
         player:startEvent(890);

--- a/scripts/zones/Southern_San_dOria/npcs/Aubejart.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Aubejart.lua
@@ -4,22 +4,8 @@
 --  General Info NPC
 -- !pos 3 -2 46 230
 -------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Authere.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Authere.lua
@@ -4,18 +4,10 @@
 -- Involved in Quest: Lure of the Wildcat (San d'Oria)
 -- !pos 33 1 -31 230
 -------------------------------------
-require("scripts/globals/quests");
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(532,1) and trade:getItemCount() == 1) then -- Trade Magicmart_flyer
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Aveline.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Aveline.lua
@@ -5,14 +5,10 @@
 -- !pos -139 -6 46 230
 -----------------------------------
 local ID = require("scripts/zones/Southern_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Benaige.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Benaige.lua
@@ -5,14 +5,10 @@
 -- !pos -142 -6 47 230
 -----------------------------------
 local ID = require("scripts/zones/Southern_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Cahaurme.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Cahaurme.lua
@@ -4,23 +4,11 @@
 -- Involved in Quest: A Knight's Test, Lost Chick
 -- !pos 55.749 -8.601 -29.354 230
 -------------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/quests");
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
+local ID = require("scripts/zones/Southern_San_dOria/IDs")
+require("scripts/globals/keyitems")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Camereine.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Camereine.lua
@@ -4,8 +4,6 @@
 -- Type: Chocobo Renter
 -- !pos -12.3 1.4 -98 230
 -----------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs")
-require("scripts/globals/npc_util")
 require("scripts/globals/chocobo")
 -----------------------------------
 
@@ -13,9 +11,6 @@ local eventSucceed = 599
 local eventFail    = 602
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Carautia.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Carautia.lua
@@ -5,14 +5,10 @@
 -- !pos 70 0 39 230
 -----------------------------------
 local ID = require("scripts/zones/Southern_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Celyddon.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Celyddon.lua
@@ -4,27 +4,15 @@
 --  General Info NPC
 -- !pos -129 -6 90 230
 -------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)
 
-    ASquiresTest = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.A_SQUIRE_S_TEST)
+    local ASquiresTest = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.A_SQUIRE_S_TEST)
 
     if ASquiresTest == (QUEST_AVAILABLE) then
         player:startEvent(618); -- im looking for the examiner

--- a/scripts/zones/Southern_San_dOria/npcs/Ceraule.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Ceraule.lua
@@ -4,22 +4,8 @@
 --  General Info NPC
 -- !pos -86 2 -35 230
 -------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Chanpau.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Chanpau.lua
@@ -4,23 +4,10 @@
 -- Optional Involvement in Quest: A Squire's Test II
 -- !pos -152 -2 55 230
 -------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
 end;
 
 function onTrigger(player,npc)
@@ -28,10 +15,10 @@ function onTrigger(player,npc)
     if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.A_SQUIRE_S_TEST_II) == QUEST_ACCEPTED) then
         player:startEvent(629);
     elseif (player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.THE_BRUGAIRE_CONSORTIUM) == QUEST_COMPLETED) then
-        Fired = player:getCharVar("Fired")
+        local Fired = player:getCharVar("Fired")
         if Fired == 1 then
             player:startEvent(567) -- i got fired in a day
-            else
+        else
             player:startEvent(505) -- theres work ill go check it out
         end
     else

--- a/scripts/zones/Southern_San_dOria/npcs/Clainomille.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Clainomille.lua
@@ -3,18 +3,9 @@
 --   NPC: Clainomille
 -- Type: Standard NPC
 -- !pos -72.771 0.999 -6.112 230
--- Auto-Script: Requires Verification (Verified by Brawndo)
------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs")
-require("scripts/globals/quests");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED then
-        if trade:hasItemQty(532,1) and trade:getItemCount() == 1 then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Cletae.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Cletae.lua
@@ -5,20 +5,12 @@
 -- !pos -189.142 -8.800 14.449 230
 -----------------------------------
 local ID = require("scripts/zones/Southern_San_dOria/IDs")
-require("scripts/globals/shop")
 require("scripts/globals/crafting")
-require("scripts/globals/settings")
 require("scripts/globals/status")
+require("scripts/globals/shop")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    if (FlyerForRegine == 1) then
-        count = trade:getItemCount()
-        MagicFlyer = trade:hasItemQty(532,1)
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED)
-        end
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Coderiant.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Coderiant.lua
@@ -4,22 +4,8 @@
 --  General Info NPC
 -- !pos -111 -2 33 230
 -------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Collione.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Collione.lua
@@ -4,22 +4,8 @@
 --  General Info NPC
 -- !pos 10 2 -66 230
 -------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Corua.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Corua.lua
@@ -6,17 +6,11 @@
 -----------------------------------
 local ID = require("scripts/zones/Southern_San_dOria/IDs")
 require("scripts/globals/events/harvest_festivals")
-require("scripts/globals/conquest")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    else
-        onHalloweenTrade(player, trade, npc)
-    end
+    onHalloweenTrade(player, trade, npc)
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Daggao.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Daggao.lua
@@ -4,18 +4,10 @@
 -- Involved in Quest: Peace for the Spirit, Lure of the Wildcat (San d'Oria)
 -- !pos 89 0 119 230
 -----------------------------------
-require("scripts/globals/quests");
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(532,1) and trade:getItemCount() == 1) then -- Trade Magicmart_flyer
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Dahjal.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Dahjal.lua
@@ -4,18 +4,8 @@
 -- first in conquest Npc
 -- !zone 230
 -----------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
------------------------------------
 
 function onTrade(player,npc,trade)
-    if (FlyerForRegine == 1) then
-        count = trade:getItemCount();
-        MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Deraquien.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Deraquien.lua
@@ -4,18 +4,10 @@
 -- Involved in Quest: Lure of the Wildcat (San d'Oria)
 -- !pos -98 -2 31 230
 -------------------------------------
-require("scripts/globals/quests");
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(532,1) and trade:getItemCount() == 1) then -- Trade Magicmart_flyer
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Emoussine.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Emoussine.lua
@@ -4,8 +4,6 @@
 -- Type: Chocobo Renter
 -- !pos -12.3 1.4 -98 230
 -----------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs")
-require("scripts/globals/npc_util")
 require("scripts/globals/chocobo")
 -----------------------------------
 
@@ -13,9 +11,6 @@ local eventSucceed = 600
 local eventFail    = 603
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Ephauge.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Ephauge.lua
@@ -4,22 +4,8 @@
 --  General Info NPC
 -- !pos -2 -2 45 230
 -------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Esmallegue.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Esmallegue.lua
@@ -4,22 +4,8 @@
 --  General Info NPC
 -- !pos 0 2 -83 230
 -------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Estiliphire.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Estiliphire.lua
@@ -3,22 +3,9 @@
 --   NPC: Estiliphire
 -- Type: Event Sideshow NPC
 -- !pos -41.550 1.999 -2.845 230
---
------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Exoroche.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Exoroche.lua
@@ -5,22 +5,11 @@
 -- !pos 72 -1 60 230
 
 -----------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
+require("scripts/globals/keyitems")
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Femitte.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Femitte.lua
@@ -4,19 +4,12 @@
 -- Involved in Quest: Lure of the Wildcat (San d'Oria), Distant Loyalties
 -- !pos -17 2 10 230
 -------------------------------------
-require("scripts/globals/quests");
-require("scripts/globals/keyitems");
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
+local ID = require("scripts/zones/Southern_San_dOria/IDs")
+require("scripts/globals/keyitems")
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(532,1) and trade:getItemCount() == 1) then -- Trade Magicmart_flyer
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Ferdoulemiont.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Ferdoulemiont.lua
@@ -4,14 +4,10 @@
 -- Standard Merchant NPC
 -----------------------------------
 local ID = require("scripts/zones/Southern_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Foletta.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Foletta.lua
@@ -3,21 +3,8 @@
 --  NPC: Foletta
 --  General Info NPC
 -------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Gizel.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Gizel.lua
@@ -4,22 +4,8 @@
 -- Type: Event Scene Replayer NPC
 -- !pos -34.412 0.000 33.362 230
 -----------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Glenne.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Glenne.lua
@@ -4,11 +4,10 @@
 -- Starts and Finishes Quest: A Sentry's Peril
 -- !pos -122 -2 15 230
 -------------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/titles");
-require("scripts/globals/shop");
-require("scripts/globals/quests");
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
+local ID = require("scripts/zones/Southern_San_dOria/IDs")
+require("scripts/globals/quests")
+require("scripts/globals/titles")
+-------------------------------------
 
 require("scripts/globals/pathfind");
 
@@ -39,13 +38,7 @@ function onPath(npc)
 end;
 
 function onTrade(player,npc,trade)
-
-    local count = trade:getItemCount();
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and
-        trade:hasItemQty(532,1) and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-
-    elseif (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.A_SENTRY_S_PERIL) == QUEST_ACCEPTED and
+    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.A_SENTRY_S_PERIL) == QUEST_ACCEPTED and
         trade:hasItemQty(601,1) and count == 1) then
             player:startEvent(513);
             npc:wait();
@@ -76,8 +69,6 @@ function onTrigger(player,npc)
 end;
 
 function onEventUpdate(player,csid,option)
-    -- printf("CSID2: %u",csid);
-    -- printf("RESULT2: %u",option);
 end;
 
 function onEventFinish(player,csid,option,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Guilboire.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Guilboire.lua
@@ -3,21 +3,8 @@
 --  NPC: Guilboire
 --  General Info NPC
 -------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Hae_Jakhya.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Hae_Jakhya.lua
@@ -3,28 +3,17 @@
 --  NPC: Hae Jakhya
 --  General Info NPC
 -------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
+local ID = require("scripts/zones/Southern_San_dOria/IDs")
 require("scripts/globals/keyitems")
-require("scripts/globals/settings");
-require("scripts/globals/quests");
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)
 
-    chasingStatus = player:getQuestStatus(WINDURST,tpz.quest.id.windurst.CHASING_TALES);
+    local chasingStatus = player:getQuestStatus(WINDURST,tpz.quest.id.windurst.CHASING_TALES);
 
     if (player:getCharVar("CHASING_TALES_TRACK_BOOK") == 1 and player:hasKeyItem(tpz.ki.A_SONG_OF_LOVE) == false) then
         player:startEvent(611); -- Neeed CS here

--- a/scripts/zones/Southern_San_dOria/npcs/Hanaa_Punaa.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Hanaa_Punaa.lua
@@ -4,12 +4,9 @@
 -- Starts and Finishes: A Squire's Test, A Squire's Test II, A Knight's Test
 -- !zone 230
 -------------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/titles");
-require("scripts/globals/keyitems");
-require("scripts/globals/shop");
-require("scripts/globals/quests");
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
+local ID = require("scripts/zones/Southern_San_dOria/IDs")
+require("scripts/globals/quests")
+require("scripts/globals/titles")
 -----------------------------------
 
 function onTrade(player,npc,trade)
@@ -34,25 +31,15 @@ function onTrade(player,npc,trade)
             player:startEvent(561);
         end
     end
-
-    -- "Flyers for Regine"
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
 end;
 
 function onTrigger(player,npc)
 
     -- Checking Fame Level & Quest
-    sanFame = player:getFameLevel(SANDORIA);
-    theSteamStress = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.THE_SEAMSTRESS);
-    lizardSkins = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.LIZARD_SKINS);
-    blackTigerSkins = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.BLACK_TIGER_SKINS);
+    local sanFame = player:getFameLevel(SANDORIA);
+    local theSteamStress = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.THE_SEAMSTRESS);
+    local lizardSkins = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.LIZARD_SKINS);
+    local blackTigerSkins = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.BLACK_TIGER_SKINS);
 
     -- "The Seamstress" Quest Status
     if (theSteamStress == QUEST_AVAILABLE and player:getCharVar("theSeamStress") == 1) then

--- a/scripts/zones/Southern_San_dOria/npcs/Lanqueron.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Lanqueron.lua
@@ -5,23 +5,10 @@
 -- Involved in Quest: Lost Chick
 -- !pos 0.335 1.199 -28.404 230
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/shop");
-require("scripts/globals/quests");
 local ID = require("scripts/zones/Southern_San_dOria/IDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Lotte.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Lotte.lua
@@ -3,21 +3,8 @@
 --  NPC: Lotte
 -- General Info NPC
 -------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Lusiane.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Lusiane.lua
@@ -4,14 +4,10 @@
 -- Standard Merchant NPC
 -----------------------------------
 local ID = require("scripts/zones/Southern_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Luthiaque.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Luthiaque.lua
@@ -3,21 +3,8 @@
 --  NPC: Luthiaque
 -- General Info NPC
 -------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Machielle.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Machielle.lua
@@ -3,18 +3,13 @@
 --  NPC: Machielle
 -- Norvallen Regional Merchant
 -----------------------------------
-require("scripts/globals/events/harvest_festivals")
 local ID = require("scripts/zones/Southern_San_dOria/IDs")
-require("scripts/globals/conquest")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
+require("scripts/globals/events/harvest_festivals")
+require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    else
-        onHalloweenTrade(player, trade, npc)
-    end
+    onHalloweenTrade(player, trade, npc)
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Maleme.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Maleme.lua
@@ -4,21 +4,8 @@
 -- Type: Weather Reporter
 -- Involved in Quest: Flyers for Regine
 -----------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Melledanne.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Melledanne.lua
@@ -4,23 +4,8 @@
 -- Type: Melody Minstrel NPC
 -- !pos -33.194 0.000 34.662 230
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/shop");
-require("scripts/globals/quests");
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Meuneille.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Meuneille.lua
@@ -4,8 +4,6 @@
 -- Type: Chocobo Renter
 -- !pos -12.3 1.4 -98 230
 -----------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs")
-require("scripts/globals/npc_util")
 require("scripts/globals/chocobo")
 -----------------------------------
 
@@ -13,9 +11,6 @@ local eventSucceed = 601
 local eventFail    = 604
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Miogique.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Miogique.lua
@@ -4,14 +4,10 @@
 -- Standard Merchant NPC
 -----------------------------------
 local ID = require("scripts/zones/Southern_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Najjar.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Najjar.lua
@@ -3,21 +3,8 @@
 --  NPC: Najjar
 --  General Info NPC
 -------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Ophelia.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Ophelia.lua
@@ -3,21 +3,8 @@
 --  NPC: Ophelia
 --  General Info NPC
 -------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Ostalie.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Ostalie.lua
@@ -4,15 +4,10 @@
 -- Standard Merchant NPC
 -----------------------------------
 local ID = require("scripts/zones/Southern_San_dOria/IDs")
-require("scripts/globals/conquest")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Parvipon.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Parvipon.lua
@@ -4,30 +4,17 @@
 -- Starts and Finishes Quest: The Merchant's Bidding (R)
 -- !pos -169 -1 13 230
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/shop");
-require("scripts/globals/quests");
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
+local ID = require("scripts/zones/Southern_San_dOria/IDs")
+require("scripts/globals/settings")
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
     if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.THE_MERCHANT_S_BIDDING) ~= QUEST_AVAILABLE) then
         if (trade:hasItemQty(856,3) and trade:getItemCount() == 3) then
             player:startEvent(89);
         end
     end
-
-    -- "Flyers for Regine" conditional script    local count = trade:getItemCount();
-MagicFlyer = trade:hasItemQty(532,1);
-
-    if (MagicFlyer == true and count == 1) then
-        local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-        if (FlyerForRegine == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Phamelise.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Phamelise.lua
@@ -5,18 +5,11 @@
 -----------------------------------
 local ID = require("scripts/zones/Southern_San_dOria/IDs")
 require("scripts/globals/events/harvest_festivals")
-require("scripts/globals/conquest")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    else
-        onHalloweenTrade(player, trade, npc)
-    end
+    onHalloweenTrade(player, trade, npc)
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Phillone.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Phillone.lua
@@ -3,21 +3,8 @@
 --  NPC: Phillone
 --  General Info NPC
 -------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Poudoruchant.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Poudoruchant.lua
@@ -3,21 +3,8 @@
 --  NPC: Poudoruchant
 --  General Info NPC
 -------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Pourette.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Pourette.lua
@@ -5,16 +5,11 @@
 -----------------------------------
 local ID = require("scripts/zones/Southern_San_dOria/IDs")
 require("scripts/globals/events/harvest_festivals")
-require("scripts/globals/conquest")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
+require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    else
-        onHalloweenTrade(player, trade, npc)
-    end
+    onHalloweenTrade(player, trade, npc)
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Raimbroy.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Raimbroy.lua
@@ -4,16 +4,12 @@
 -- Starts and Finishes Quest: The Sweetest Things
 -- !zone 230
 -------------------------------------
-require("scripts/globals/settings");
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/titles");
-require("scripts/globals/shop");
-require("scripts/globals/quests");
+require("scripts/globals/settings")
+require("scripts/globals/quests")
+require("scripts/globals/titles")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
     -- "The Sweetest Things" quest status var
     local theSweetestThings = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.THE_SWEETEST_THINGS);
 
@@ -24,15 +20,6 @@ function onTrade(player,npc,trade)
             player:startEvent(522);
         end
     end
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Raminel.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Raminel.lua
@@ -8,6 +8,7 @@ local ID = require("scripts/zones/Southern_San_dOria/IDs");
 require("scripts/globals/keyitems");
 require("scripts/globals/pathfind");
 require("scripts/globals/quests");
+-----------------------------------
 
 local path =
 {
@@ -96,13 +97,6 @@ function onPath(npc)
 end;
 
 function onTrade(player,npc,trade)
-
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(532,1) and trade:getItemCount() == 1) then -- Trade Magicmart Flyer
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
     if (player:getQuestStatus(JEUNO,tpz.quest.id.jeuno.RIDING_ON_THE_CLOUDS) == QUEST_ACCEPTED and player:getCharVar("ridingOnTheClouds_1") == 1) then
         if (trade:hasItemQty(1127,1) and trade:getItemCount() == 1) then -- Trade Kindred seal
             player:setCharVar("ridingOnTheClouds_1",0);
@@ -111,7 +105,6 @@ function onTrade(player,npc,trade)
             player:messageSpecial(ID.text.KEYITEM_OBTAINED,tpz.ki.SCOWLING_STONE);
         end
     end
-
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Rouva.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Rouva.lua
@@ -5,17 +5,9 @@
 -- !pos -17 2 10 230
 -------------------------------------
 require("scripts/globals/quests");
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(532,1) and trade:getItemCount() == 1) then -- Trade Magicmart_flyer
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Rumoie.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Rumoie.lua
@@ -4,22 +4,8 @@
 -- Type: Map Marker NPC
 -- !pos 149.696 -2.000 151.631 230
 -------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Shilah.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Shilah.lua
@@ -4,14 +4,10 @@
 -- Standard Merchant NPC
 -----------------------------------
 local ID = require("scripts/zones/Southern_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Simmie.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Simmie.lua
@@ -3,21 +3,8 @@
 --  NPC: Simmie
 --  General Info NPC
 -------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Sobane.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Sobane.lua
@@ -6,19 +6,14 @@
 -- !pos -190 -3 97 230
 -- csid: 52  732  733  734  735  736  737  738  739  740  741
 -------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs")
 require("scripts/globals/keyitems")
 require("scripts/globals/npc_util")
 require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    -- FLYERS FOR REGINE
-    if npcUtil.tradeHas(trade, 532) and player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-
     -- SIGNED IN BLOOD
-    elseif npcUtil.tradeHas(trade, 1662) and player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.SIGNED_IN_BLOOD) == QUEST_ACCEPTED and player:getCharVar("SIGNED_IN_BLOOD_Prog") < 1 then
+    if npcUtil.tradeHas(trade, 1662) and player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.SIGNED_IN_BLOOD) == QUEST_ACCEPTED and player:getCharVar("SIGNED_IN_BLOOD_Prog") < 1 then
         player:startEvent(734,0,1662)
 
     -- RIDING ON THE CLOUDS

--- a/scripts/zones/Southern_San_dOria/npcs/Thadiene.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Thadiene.lua
@@ -4,14 +4,10 @@
 -- Standard Merchant NPC
 -----------------------------------
 local ID = require("scripts/zones/Southern_San_dOria/IDs")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Ullasa.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Ullasa.lua
@@ -3,21 +3,8 @@
 --  NPC: Ullasa
 --  General Info NPC
 -------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Valderotaux.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Valderotaux.lua
@@ -4,19 +4,10 @@
 --  General Info NPC
 -- !pos 97 0.1 113 230
 -------------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-
-    if (player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(532,1) and trade:getItemCount() == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Valeriano.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Valeriano.lua
@@ -4,15 +4,10 @@
 -- Standard Merchant NPC
 -----------------------------------
 local ID = require("scripts/zones/Southern_San_dOria/IDs")
-require("scripts/globals/conquest")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
 require("scripts/globals/shop")
+-----------------------------------
 
 function onTrade(player,npc,trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
-        player:messageSpecial(ID.text.FLYER_REFUSED)
-    end
 end
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Vaquelage.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Vaquelage.lua
@@ -4,22 +4,10 @@
 -- Type: Item Deliverer NPC
 -- !pos 17.396 1.699 -29.357 230
 -----------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/quests");
+local ID = require("scripts/zones/Southern_San_dOria/IDs")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,tpz.quest.id.sandoria.FLYERS_FOR_REGINE);
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Vemalpeau.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Vemalpeau.lua
@@ -3,21 +3,12 @@
 --  NPC: Vemalpeau
 -- Involved in Quests: Under Oath
 -------------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/quests");
-require("scripts/globals/keyitems");
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
+local ID = require("scripts/zones/Southern_San_dOria/IDs")
+require("scripts/globals/keyitems")
+require("scripts/globals/quests")
+-------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-
-    if (FlyerForRegine == 1) then
-        local count = trade:getItemCount();
-        local MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
 end;
 
 function onTrigger(player,npc)


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

* subtable npcData for faster lookups
* npcs will no longer look over curiously once you've traded them a flyer
* removed pre-quest dialog from Regine, per video and Nyu's retail testing
* removed npc flyer refusal dialog, per Nyu's retail testing
* localed some variables in npc scripts
* npcs will no longer look over curiously when you're not on the quest [Fixes #865]
