### PR TITLE
Deoffset Ability Fix (typo)

### DIFF
--- a/scripts/globals/ability.lua
+++ b/scripts/globals/ability.lua
@@ -75,7 +75,7 @@ tpz.jobAbility =
     REWARD             = 78,
     COVER              = 79,
     SPIRIT_LINK        = 80,
-    ENRAGE             - 81,
+    ENRAGE             = 81,
     CHI_BLAST          = 82,
     CONVERT            = 83,
     ACCOMPLICE         = 84,


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

```
 luautils::onMagicCastingCheck: .\scripts/globals/ability.lua:78: attempt to perform arithmetic on global 'ENRAGE' (a nil value)
```

Was trying to do maths inside an enum