### PR TITLE
Trust Targetting

### DIFF
--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -503,11 +503,6 @@ CBattleEntity* CTargetFind::getValidTarget(uint16 actionTargetID, uint16 validTa
         return m_PBattleEntity->PPet;
     }
 
-    if (PTarget->objtype == TYPE_TRUST)
-    {
-        return PTarget;
-    }
-
     if (PTarget->ValidTarget(m_PBattleEntity, validTargetFlags))
     {
         return PTarget;

--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -141,10 +141,16 @@ void CTrustEntity::OnAbility(CAbilityState& state, action_t& action)
 
 bool CTrustEntity::ValidTarget(CBattleEntity* PInitiator, uint16 targetFlags)
 {
-    if (targetFlags & TARGET_PLAYER && PInitiator->allegiance == allegiance)
+    if (PInitiator->objtype == TYPE_PC && PInitiator->PParty != PMaster->PParty)
     {
         return false;
     }
+
+    if (targetFlags & TARGET_PLAYER_PARTY && PInitiator->allegiance == allegiance)
+    {
+        return true;
+    }
+
     return CMobEntity::ValidTarget(PInitiator, targetFlags);
 }
 


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**Tested so far:**
**Possible:**
- Single target cure your own trust
- AOE heal yourself and it hits trusts
- AOE heal a trust and it hits you and trusts
- Trust can provoke, attack cast spells on mobs and mobs can target them
- Everything works as normal in BCNMs

**Not Possible:**
- Single target cure someone else's trust
- Select your or another trust with Dia etc.
- CTRL-A to attack your own Trust
- CTRL-A to attack someone else's Trust
- /a <t> to attack your own Trust
- /ja "Assault" <t> to have your avatar attack your trust.

**Not valid**
Alliances

All looks good!