### PR TITLE
Trust Stability 2

### DIFF
--- a/src/map/ai/controllers/trust_controller.cpp
+++ b/src/map/ai/controllers/trust_controller.cpp
@@ -67,6 +67,11 @@ void CTrustController::Tick(time_point tick)
         return;
     }
 
+    if (POwner->PMaster->isCharmed)
+    {
+        this->Despawn();
+    }
+
     if (POwner->PAI->IsEngaged())
     {
         DoCombatTick(tick);

--- a/src/map/ai/helpers/gambits_container.cpp
+++ b/src/map/ai/helpers/gambits_container.cpp
@@ -137,32 +137,20 @@ void CGambitsContainer::Tick(time_point tick)
         }
         else if (gambit.predicate.target == G_TARGET::PARTY)
         {
-            // TODO: This is very messy, priority are player chars
-            CCharEntity* master = static_cast<CCharEntity*>(POwner->PMaster);
-            for (uint8 i = 0; i < master->PParty->members.size(); ++i)
+            auto isValidMember = [&](CBattleEntity* PPartyTarget)
             {
-                auto member = master->PParty->members.at(i);
-                if (member->isAlive() &&
-                    POwner->loc.zone == member->loc.zone &&
-                    distance(POwner->loc.p, member->loc.p) <= 15.0f &&
-                    checkTrigger(member, gambit.predicate))
-                {
-                    target = member;
-                    break;
-                }
-            }
-            if (!target)
+                return !target && PPartyTarget->isAlive() &&
+                    POwner->loc.zone == PPartyTarget->loc.zone &&
+                    distance(POwner->loc.p, PPartyTarget->loc.p) <= 15.0f;
+            };
+
+            static_cast<CCharEntity*>(POwner->PMaster)->ForPartyWithTrusts([&](CBattleEntity* PMember)
             {
-                for (uint8 i = 0; i < master->PTrusts.size(); ++i)
+                if (isValidMember(PMember) && checkTrigger(PMember, gambit.predicate))
                 {
-                    auto member = master->PTrusts.at(i);
-                    if (checkTrigger(member, gambit.predicate))
-                    {
-                        target = member;
-                        break;
-                    }
+                    target = PMember;
                 }
-            }
+            });
         }
         else if (gambit.predicate.target == G_TARGET::MASTER)
         {
@@ -170,42 +158,7 @@ void CGambitsContainer::Tick(time_point tick)
         }
         else if (gambit.predicate.target == G_TARGET::TANK)
         {
-            /*
-            // TODO: This is awful
-            CBattleEntity* tank = nullptr;
-            CCharEntity* master = static_cast<CCharEntity*>(POwner->PMaster);
-            for (uint8 i = 0; i < master->PParty->members.size(); ++i)
-            {
-                auto member = master->PParty->members.at(i);
-                auto job = member->GetMJob();
-                if (member->isAlive() &&
-                    POwner->loc.zone == member->loc.zone &&
-                    distance(POwner->loc.p, member->loc.p) <= 15.0f &&
-                    (job == JOB_PLD || job == JOB_RUN || JOB_WAR || JOB_NIN))
-                {
-                    tank = member;
-                    break;
-                }
-            }
-            if (!tank)
-            {
-                for (uint8 i = 0; i < master->PTrusts.size(); ++i)
-                {
-                    auto member = master->PTrusts.at(i);
-                    auto job = member->GetMJob();
-                    if (job == JOB_PLD || job == JOB_RUN || JOB_WAR || JOB_NIN)
-                    {
-                        tank = member;
-                        break;
-                    }
-                }
-            }
-            if (checkTrigger(tank, gambit.predicate))
-            {
-                target = tank;
-                break;
-            }
-            */
+            // TODO
         }
 
         if (target)

--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -94,7 +94,7 @@ void CTargetFind::findWithinArea(CBattleEntity* PTarget, AOERADIUS radiusType, f
     m_PTarget = PTarget;
     isPlayer = checkIsPlayer(m_PBattleEntity);
 
-    if (isPlayer || m_PTarget->objtype == TYPE_TRUST)
+    if (isPlayer)
     {
         // handle this as a player
         if (m_PMasterTarget->objtype == TYPE_PC)
@@ -114,22 +114,12 @@ void CTargetFind::findWithinArea(CBattleEntity* PTarget, AOERADIUS radiusType, f
                     // add party members
                     addAllInParty(m_PMasterTarget, withPet);
                 }
-
-                // add my trust too, if its allowed
-                for (auto* trust : ((CCharEntity*)m_PMasterTarget)->PTrusts)
-                {
-                    if (validEntity((CBattleEntity*)trust))
-                    {
-                        m_targets.push_back((CBattleEntity*)trust);
-                    }
-                }
             }
             else 
             {
                 // just add myself
                 addEntity(m_PMasterTarget, withPet);
             }
-
         }
         else 
         {
@@ -137,7 +127,6 @@ void CTargetFind::findWithinArea(CBattleEntity* PTarget, AOERADIUS radiusType, f
             // special case to add all mobs in range
             addAllInMobList(m_PMasterTarget, false);
         }
-
     }
     else 
     {
@@ -257,21 +246,20 @@ void CTargetFind::addAllInAlliance(CBattleEntity* PTarget, bool withPet)
 
 void CTargetFind::addAllInParty(CBattleEntity* PTarget, bool withPet)
 {
-    PTarget->ForParty([this, withPet](CBattleEntity* PMember)
+    if (PTarget->objtype == TYPE_PC)
     {
-        // Add Trust
-        if (PMember->objtype == TYPE_PC)
+        static_cast<CCharEntity*>(PTarget)->ForPartyWithTrusts([this, withPet](CBattleEntity* PMember)
         {
-            auto* PChar = (CCharEntity*)PMember;
-            for (auto trust : PChar->PTrusts)
-            {
-                CBattleEntity* PTrust = static_cast<CBattleEntity*>(trust);
-                m_targets.push_back(PTrust);
-            }
-        }
-        
-        addEntity(PMember, withPet);
-    });
+            addEntity(PMember, withPet);
+        });
+    }
+    else
+    {
+        PTarget->ForParty([this, withPet](CBattleEntity* PMember)
+        {
+            addEntity(PMember, withPet);
+        });
+    }
 }
 
 void CTargetFind::addAllInEnmityList()

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -123,14 +123,7 @@ bool CMagicState::Update(time_point tick)
             PTarget->PAI->EventHandler.triggerListener("MAGIC_TAKE", PTarget, m_PEntity, m_PSpell.get(), &action);
         }
 
-        if (PTarget && PTarget->objtype == TYPE_TRUST)
-        {
-            PTarget->loc.zone->PushPacket(PTarget, CHAR_INRANGE_SELF, new CActionPacket(action));
-        }
-        else
-        {
-            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
-        }
+        m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
             
         Complete();
     }

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -494,25 +494,18 @@ void CCharEntity::RemoveTrust(CTrustEntity* PTrust)
         PTrusts.erase(trustIt);
     }
 
-    if (PParty != nullptr)
-    {
-        if (PTrusts.empty() && PParty->members.size() == 1)
-        {
-            PParty->DisbandParty();
-        }
-        else
-        {
-            PParty->ReloadParty();
-        }
-    }
+    ReloadPartyInc();
 }
 
 void CCharEntity::ClearTrusts()
 {
-    for (auto trust : PTrusts)
+    for (auto PTrust : PTrusts)
     {
-        RemoveTrust(trust);
+        PTrust->PAI->Despawn();
     }
+    PTrusts.clear();
+
+    ReloadPartyInc();
 }
 
 void CCharEntity::Tick(time_point tick)
@@ -1686,10 +1679,11 @@ void CCharEntity::Die()
 
 void CCharEntity::Die(duration _duration)
 {
+    this->ClearTrusts();
+
     m_deathSyncTime = server_clock::now() + death_update_frequency;
     PAI->ClearStateStack();
     PAI->Internal_Die(_duration);
-    this->ClearTrusts();
 
     // reraise modifiers
     if (this->getMod(Mod::RERAISE_I) > 0)

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -219,6 +219,8 @@ public:
         if (PParty) {
             for (auto PMember : PParty->members) {
                 func(PMember, std::forward<Args>(args)...);
+            }
+            for (auto PMember : PParty->members) {
                 for (auto PTrust : static_cast<CCharEntity*>(PMember)->PTrusts) {
                     func(PTrust, std::forward<Args>(args)...);
                 }
@@ -226,6 +228,9 @@ public:
         }
         else {
             func(this, std::forward<Args>(args)...);
+            for (auto PTrust : this->PTrusts) {
+                func(PTrust, std::forward<Args>(args)...);
+            }
         }
     }
 

--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -70,7 +70,7 @@ void CTrustEntity::PostTick()
 void CTrustEntity::FadeOut()
 {
     CBaseEntity::FadeOut();
-    loc.zone->PushPacket(this, CHAR_INRANGE, new CEntityUpdatePacket(this, ENTITY_DESPAWN, UPDATE_NONE));
+    loc.zone->PushPacket(this, (loc.zone->m_BattlefieldHandler) ? CHAR_INZONE : CHAR_INRANGE, new CEntityUpdatePacket(this, ENTITY_DESPAWN, UPDATE_NONE));
 }
 
 void CTrustEntity::Die()
@@ -141,14 +141,9 @@ void CTrustEntity::OnAbility(CAbilityState& state, action_t& action)
 
 bool CTrustEntity::ValidTarget(CBattleEntity* PInitiator, uint16 targetFlags)
 {
-    if (PInitiator->objtype == TYPE_PC && PInitiator->PParty != PMaster->PParty)
+    if (targetFlags & TARGET_PLAYER_PARTY && PInitiator->allegiance == allegiance && PMaster)
     {
-        return false;
-    }
-
-    if (targetFlags & TARGET_PLAYER_PARTY && PInitiator->allegiance == allegiance)
-    {
-        return true;
+        return PInitiator->PParty == PMaster->PParty;
     }
 
     return CMobEntity::ValidTarget(PInitiator, targetFlags);

--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -141,6 +141,11 @@ void CTrustEntity::OnAbility(CAbilityState& state, action_t& action)
 
 bool CTrustEntity::ValidTarget(CBattleEntity* PInitiator, uint16 targetFlags)
 {
+    if (PInitiator->objtype == TYPE_TRUST && PMaster == PInitiator->PMaster)
+    {
+        return true;
+    }
+
     if (targetFlags & TARGET_PLAYER_PARTY && PInitiator->allegiance == allegiance && PMaster)
     {
         return PInitiator->PParty == PMaster->PParty;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -10449,11 +10449,11 @@ inline int32 CLuaBaseEntity::updateEnmityFromCure(lua_State *L)
     CLuaBaseEntity* PEntity = Lunar<CLuaBaseEntity>::check(L, 1);
     auto amount = (int32)lua_tointeger(L, 2);
 
-    auto PCurer = [&]() -> CCharEntity*
+    auto PCurer = [&]() -> CBattleEntity*
     {
-        if (m_PBaseEntity->objtype == TYPE_PC)
+        if (m_PBaseEntity->objtype == TYPE_PC || m_PBaseEntity->objtype == TYPE_TRUST)
         {
-            return static_cast<CCharEntity*>(m_PBaseEntity);
+            return static_cast<CBattleEntity*>(m_PBaseEntity);
         }
         else if (m_PBaseEntity->objtype == TYPE_PET && static_cast<CPetEntity*>(m_PBaseEntity)->getPetType() != PETTYPE_AUTOMATON)
         {

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -12427,7 +12427,7 @@ inline int32 CLuaBaseEntity::trustPartyMessage(lua_State* L)
 
     auto PTrust = static_cast<CTrustEntity*>(m_PBaseEntity);
 
-    auto message_id = lua_tointeger(L, 1);
+    auto message_id = static_cast<int32>(lua_tointeger(L, 1));
 
     auto PMaster = static_cast<CCharEntity*>(PTrust->PMaster);
     if (PMaster)

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -844,24 +844,24 @@ namespace battleutils
         Action->addEffectMessage = 0;
         Action->addEffectParam = 0;
 
-        EFFECT daze = EFFECT_NONE;
-        uint16 power = 0;
+        EFFECT previous_daze = EFFECT_NONE;
+        uint16 previous_daze_power = 0;
         if (PAttacker->StatusEffectContainer->HasStatusEffect(EFFECT_DRAIN_SAMBA))
         {
-            daze = EFFECT_DRAIN_DAZE;
-            power = PAttacker->StatusEffectContainer->GetStatusEffect(EFFECT_DRAIN_SAMBA)->GetPower();
+            previous_daze = EFFECT_DRAIN_DAZE;
+            previous_daze_power = PAttacker->StatusEffectContainer->GetStatusEffect(EFFECT_DRAIN_SAMBA)->GetPower();
         }
         else if (PAttacker->StatusEffectContainer->HasStatusEffect(EFFECT_ASPIR_SAMBA))
         {
-            daze = EFFECT_ASPIR_DAZE;
-            power = PAttacker->StatusEffectContainer->GetStatusEffect(EFFECT_ASPIR_SAMBA)->GetPower();
+            previous_daze = EFFECT_ASPIR_DAZE;
+            previous_daze_power = PAttacker->StatusEffectContainer->GetStatusEffect(EFFECT_ASPIR_SAMBA)->GetPower();
         }
         else if (PAttacker->StatusEffectContainer->HasStatusEffect(EFFECT_HASTE_SAMBA))
         {
-            daze = EFFECT_HASTE_DAZE;
-            power = PAttacker->StatusEffectContainer->GetStatusEffect(EFFECT_HASTE_SAMBA)->GetPower();
+            previous_daze = EFFECT_HASTE_DAZE;
+            previous_daze_power = PAttacker->StatusEffectContainer->GetStatusEffect(EFFECT_HASTE_SAMBA)->GetPower();
         }
-        if (daze != EFFECT_NONE)
+        if (previous_daze != EFFECT_NONE)
         {
             if (PAttacker->PParty != nullptr)
             {
@@ -878,10 +878,10 @@ namespace battleutils
                 PDefender->StatusEffectContainer->DelStatusEffect(EFFECT_HASTE_DAZE, PAttacker->id);
                 PDefender->StatusEffectContainer->DelStatusEffect(EFFECT_ASPIR_DAZE, PAttacker->id);
             }
-            if ((PDefender->m_EcoSystem != SYSTEM_UNDEAD) || (daze == EFFECT_HASTE_DAZE))
+            if ((PDefender->m_EcoSystem != SYSTEM_UNDEAD) || (previous_daze == EFFECT_HASTE_DAZE))
             {
-                PDefender->StatusEffectContainer->AddStatusEffect(new CStatusEffect(daze,
-                    0, power,
+                PDefender->StatusEffectContainer->AddStatusEffect(new CStatusEffect(previous_daze,
+                    0, previous_daze_power,
                     0, 10, PAttacker->id), true);
             }
         }
@@ -994,45 +994,77 @@ namespace battleutils
             // Generic drain for anyone able to do melee damage to a dazed target
             // TODO: ignore dazes from dancers outside party
             int16 delay = PAttacker->GetWeaponDelay(false) / 10;
-            if (PAttacker->PMaster == nullptr || PAttacker->objtype == TYPE_TRUST)
+
+            if (PAttacker->PMaster == nullptr || (PAttacker->objtype == TYPE_TRUST && PAttacker->PMaster))
             {
+                // TODO: All of this is very ugly, but is fairly fragile, be careful refactoring!
                 EFFECT daze = EFFECT_NONE;
                 uint16 power = 0;
-
-                auto setDazeAndPower = [&](CBattleEntity* PCurrentAttacker)
+                if (PAttacker->objtype == TYPE_PC && PAttacker->PParty != nullptr)
                 {
-                    if (power) { return; }
-                    if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_DRAIN_DAZE, PCurrentAttacker->id))
+                    for (uint8 i = 0; i < PAttacker->PParty->members.size(); i++)
                     {
-                        daze = EFFECT_DRAIN_DAZE;
-                        power = PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_DRAIN_DAZE, PCurrentAttacker->id)->GetPower();
+                        if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_DRAIN_DAZE, PAttacker->PParty->members[i]->id))
+                        {
+                            daze = EFFECT_DRAIN_DAZE;
+                            power = PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_DRAIN_DAZE, PAttacker->PParty->members[i]->id)->GetPower();
+                            break;
+                        }
+                        if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_HASTE_DAZE, PAttacker->PParty->members[i]->id))
+                        {
+                            daze = EFFECT_HASTE_DAZE;
+                            power = PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_HASTE_DAZE, PAttacker->PParty->members[i]->id)->GetPower();
+                            break;
+                        }
+                        if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_ASPIR_DAZE, PAttacker->PParty->members[i]->id))
+                        {
+                            daze = EFFECT_ASPIR_DAZE;
+                            power = PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_ASPIR_DAZE, PAttacker->PParty->members[i]->id)->GetPower();
+                            break;
+                        }
                     }
-                    if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_HASTE_DAZE, PCurrentAttacker->id))
-                    {
-                        daze = EFFECT_HASTE_DAZE;
-                        power = PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_HASTE_DAZE, PCurrentAttacker->id)->GetPower();
-                    }
-                    if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_ASPIR_DAZE, PCurrentAttacker->id))
-                    {
-                        daze = EFFECT_ASPIR_DAZE;
-                        power = PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_ASPIR_DAZE, PCurrentAttacker->id)->GetPower();
-                    }
-                };
-
-                // Note: If not in a party, ForParty forwards to just the caller
-                if (PAttacker->objtype == TYPE_TRUST)
+                }
+                else if (PAttacker->objtype == TYPE_TRUST && PAttacker->PMaster->PParty)
                 {
-                    static_cast<CTrustEntity*>(PAttacker)->PMaster->ForParty([&](CBattleEntity* PMember)
+                    for (uint8 i = 0; i < PAttacker->PMaster->PParty->members.size(); i++)
                     {
-                         setDazeAndPower(PMember);
-                    });
+                        if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_DRAIN_DAZE, PAttacker->PMaster->PParty->members[i]->id))
+                        {
+                            daze = EFFECT_DRAIN_DAZE;
+                            power = PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_DRAIN_DAZE, PAttacker->PMaster->PParty->members[i]->id)->GetPower();
+                            break;
+                        }
+                        if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_HASTE_DAZE, PAttacker->PMaster->PParty->members[i]->id))
+                        {
+                            daze = EFFECT_HASTE_DAZE;
+                            power = PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_HASTE_DAZE, PAttacker->PMaster->PParty->members[i]->id)->GetPower();
+                            break;
+                        }
+                        if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_ASPIR_DAZE, PAttacker->PMaster->PParty->members[i]->id))
+                        {
+                            daze = EFFECT_ASPIR_DAZE;
+                            power = PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_ASPIR_DAZE, PAttacker->PMaster->PParty->members[i]->id)->GetPower();
+                            break;
+                        }
+                    }
                 }
                 else
                 {
-                    PAttacker->ForParty([&](CBattleEntity* PMember)
+                    if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_DRAIN_DAZE, PAttacker->id))
                     {
-                        setDazeAndPower(PMember);
-                    });
+                        daze = EFFECT_DRAIN_DAZE;
+                        power = PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_DRAIN_DAZE, PAttacker->id)->GetPower();
+                    }
+                    if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_HASTE_DAZE, PAttacker->id))
+                    {
+                        daze = EFFECT_HASTE_DAZE;
+                        power = PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_HASTE_DAZE, PAttacker->id)->GetPower();
+                    }
+                    if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_ASPIR_DAZE, PAttacker->id))
+                    {
+                        daze = EFFECT_ASPIR_DAZE;
+                        power = PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_ASPIR_DAZE, PAttacker->id)->GetPower();
+                    }
                 }
 
                 if (daze == EFFECT_DRAIN_DAZE)
@@ -1508,7 +1540,12 @@ namespace battleutils
         return x;
     }
 
-    bool TryInterruptSpell(CBattleEntity* PAttacker, CBattleEntity* PDefender, CSpell* PSpell) {
+    bool TryInterruptSpell(CBattleEntity* PAttacker, CBattleEntity* PDefender, CSpell* PSpell)
+    {
+        if (PDefender->objtype == TYPE_TRUST)
+        {
+            return false;
+        }
 
         // cannot interrupt when manafont is active
         if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_MANAFONT))
@@ -1519,7 +1556,6 @@ namespace battleutils
         // Songs cannot be interrupted by physical attacks.
         if ((SKILLTYPE)PSpell->getSkillType() == SKILL_SINGING)
         {
-            // ShowDebug("Is song, interrupt prevented.\n");
             return false;
         }
 
@@ -3431,12 +3467,15 @@ namespace battleutils
     *                                                                       *
     ************************************************************************/
 
-    void GenerateCureEnmity(CCharEntity* PSource, CBattleEntity* PTarget, int32 amount)
+    void GenerateCureEnmity(CBattleEntity* PSource, CBattleEntity* PTarget, int32 amount)
     {
         TPZ_DEBUG_BREAK_IF(PSource == nullptr);
         TPZ_DEBUG_BREAK_IF(PTarget == nullptr);
 
-        for (SpawnIDList_t::const_iterator it = PSource->SpawnMOBList.begin(); it != PSource->SpawnMOBList.end(); ++it)
+        auto PMasterSource = PSource->PMaster ? PSource->PMaster : PSource;
+        auto PMasterSourceChar = static_cast<CCharEntity*>(PMasterSource);
+
+        for (SpawnIDList_t::const_iterator it = PMasterSourceChar->SpawnMOBList.begin(); it != PMasterSourceChar->SpawnMOBList.end(); ++it)
         {
             CMobEntity* PCurrentMob = static_cast<CMobEntity*>(it->second);
 

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -3970,6 +3970,9 @@ namespace battleutils
             {
                 petutils::DespawnPet(PVictim);
             }
+
+            static_cast<CCharEntity*>(PVictim)->ClearTrusts();
+
             PVictim->PAI->SetController(std::make_unique<CPlayerCharmController>(static_cast<CCharEntity*>(PVictim)));
 
             battleutils::RelinquishClaim(static_cast<CCharEntity*>(PVictim));

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -168,7 +168,7 @@ namespace battleutils
     bool                isValidSelfTargetWeaponskill(int wsid);
     bool                CanUseWeaponskill(CCharEntity* PChar, CWeaponSkill* PSkill);
     int16               CalculateBaseTP(int delay);
-    void                GenerateCureEnmity(CCharEntity* PSource, CBattleEntity* PTarget, int32 amount);
+    void                GenerateCureEnmity(CBattleEntity* PSource, CBattleEntity* PTarget, int32 amount);
     void                GenerateInRangeEnmity(CBattleEntity* PSource, int16 CE, int16 VE);
 
     CItemWeapon*        GetEntityWeapon(CBattleEntity* PEntity, SLOTTYPE Slot);

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -139,7 +139,7 @@ void CZoneEntities::InsertPET(CBaseEntity* PPet)
             }
             targid++;
         }
-        if (targid >= 0x800)
+        if (targid >= 0x780)
         {
             ShowError(CL_RED"CZone::InsertPET : targid is high (03hX)\n" CL_RESET, targid);
             return;
@@ -168,7 +168,7 @@ void CZoneEntities::InsertTRUST(CBaseEntity* PTrust)
 {
     if (PTrust != nullptr)
     {
-        uint16 targid = 0x800;
+        uint16 targid = 0x780;
 
         for (EntityList_t::const_iterator it = m_trustList.begin(); it != m_trustList.end(); ++it)
         {
@@ -178,7 +178,7 @@ void CZoneEntities::InsertTRUST(CBaseEntity* PTrust)
             }
             targid++;
         }
-        if (targid >= 0x900)
+        if (targid >= 0x800)
         {
             ShowError(CL_RED"CZone::InsertTRUST : targid is high (03hX)\n" CL_RESET, targid);
             return;
@@ -702,7 +702,7 @@ CBaseEntity* CZoneEntities::GetEntity(uint16 targid, uint8 filter)
             }
         }
     }
-    else if (targid < 0x800)
+    else if (targid < 0x780)
     {
         if (filter & TYPE_PET)
         {
@@ -713,7 +713,7 @@ CBaseEntity* CZoneEntities::GetEntity(uint16 targid, uint8 filter)
             }
         }
     }
-    else if (targid < 0x900)
+    else if (targid < 0x800)
     {
         if (filter & TYPE_TRUST)
         {
@@ -924,11 +924,11 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
                                             spawnlist = PCurrentChar->SpawnNPCList;
                                         }
                                     }
-                                    else if (entity->targid < 0x800)
+                                    else if (entity->targid < 0x780)
                                     {
                                         spawnlist = PCurrentChar->SpawnPETList;
                                     }
-                                    else if (entity->targid < 0x900)
+                                    else if (entity->targid < 0x800)
                                     {
                                         spawnlist = PCurrentChar->SpawnTRUSTList;
                                     }


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Last round of stability fixes did a pretty good job and things are looking fairly stable, but they have opened the gates for _other_ bugs to finally start showing themselves.

A lot of these are areas _outside_ of main trust logic areas (which are very well sanity checked). Since PMaster is now cleared out more aggressively, there are likely going to be some more instances of trying to access it after it's gone - which we need to wrap in checks 🤷 

**Bugs fixed:**
- Trusts are now correctly targetted by AOE + Cones, before all trusts would get hit regardless of position 
- Trusts who were the target of an AOE attack were counted and hit twice, not anymore
- If you entered and flee'd a BCNM with trusts out, their "ghosts" would still be in the waiting room. Fixed the packet range that caused this.
- Removed the strange patch in MagicState that kicked off all the trust work, we now model trusts better and don't need it! 
- Interesting goings ons with trust targids (local ids). Will make an issue after this PR to handle them properly properly, but now there is a middle-ground fix that stops crashes when using Windower's Timer plugin and allows Battlemod addon to work with Trusts <3
- Trusts are correctly cleared on death and entry to BCNMs
- You can no longer cast on trusts in another party, or hit your own trusts with SMN skills or offensive spells!
- Trusts now generate enmity when they cure (Curilla & PLD trusts are viable)
- Trust spells are no longer interrupted on melee hit.
- Reverted Samba handling to old layout and added another case to handle trusts. Refactoring it made it explode sometimes...
- Trusts being removed/cleared from your party will no longer destroy the underlying party object.
- ^ This also stops the server exploding if someone DC's or logs out with trusts out
- Despawn Trusts when charmed, if the trust is somehow orphaned, despawn them then too for safety.
- Trust <-> Trust targeting is fixed, and ForParty-style priority is fixed to always go through players first, then trusts.
- Fixed warning-as-error stopping compilation on x86_64

**Notes:**
I've opted to _not_ destroy a player's party when all the trusts are removed because it was causing so many issues. I feel like stability now is worth the cost of people having to dissolve their own party until we can find a good solution (I want to refactor Party lifetimes eventually). 