### PR TITLE
Check for sharpshot frame on automaton ranged attack.

### DIFF
--- a/src/map/ai/controllers/automaton_controller.cpp
+++ b/src/map/ai/controllers/automaton_controller.cpp
@@ -1333,11 +1333,10 @@ bool CAutomatonController::TryTPMove()
 
 bool CAutomatonController::TryRangedAttack() // TODO: Find the animation for its ranged attack
 {
-    if (PAutomaton->getFrame() == FRAME_SHARPSHOT) {
+    if (PAutomaton->getFrame() == FRAME_SHARPSHOT) 
         if (m_rangedCooldown > 0s && m_Tick > m_LastRangedTime + (m_rangedCooldown - std::chrono::seconds(PAutomaton->getMod(Mod::SNAP_SHOT))))
             return MobSkill(PTarget->targid, m_RangedAbility);
-        return false;
-    }
+
     return false;
 }
 

--- a/src/map/ai/controllers/automaton_controller.cpp
+++ b/src/map/ai/controllers/automaton_controller.cpp
@@ -1333,8 +1333,11 @@ bool CAutomatonController::TryTPMove()
 
 bool CAutomatonController::TryRangedAttack() // TODO: Find the animation for its ranged attack
 {
-    if (m_rangedCooldown > 0s && m_Tick > m_LastRangedTime + (m_rangedCooldown - std::chrono::seconds(PAutomaton->getMod(Mod::SNAP_SHOT))))
-        return MobSkill(PTarget->targid, m_RangedAbility);
+    if (PAutomaton->getFrame() == FRAME_SHARPSHOT) {
+        if (m_rangedCooldown > 0s && m_Tick > m_LastRangedTime + (m_rangedCooldown - std::chrono::seconds(PAutomaton->getMod(Mod::SNAP_SHOT))))
+            return MobSkill(PTarget->targid, m_RangedAbility);
+        return false;
+    }
     return false;
 }
 


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

I noticed that on Tantalus the harlequin frame was doing ranged attacks even when it shouldn't at pretty much every tick that it wasn't doing something earlier in the process. Added in a frame check to the TryRangedAttack function.