### PR TITLE
Allow players to pop Windurst 8-2 mission NMs aggro-less with sneak

### DIFF
--- a/scripts/zones/Outer_Horutoto_Ruins/npcs/_5e5.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/npcs/_5e5.lua
@@ -19,8 +19,8 @@ function onTrigger(player, npc)
         not GetMobByID(ID.mob.JESTER_WHO_D_BE_KING_OFFSET + 0):isSpawned() and
         not GetMobByID(ID.mob.JESTER_WHO_D_BE_KING_OFFSET + 1):isSpawned()
     then
-        SpawnMob(ID.mob.JESTER_WHO_D_BE_KING_OFFSET + 0):updateEnmity(player)
-        SpawnMob(ID.mob.JESTER_WHO_D_BE_KING_OFFSET + 1):updateEnmity(player)
+        SpawnMob(ID.mob.JESTER_WHO_D_BE_KING_OFFSET + 0)
+        SpawnMob(ID.mob.JESTER_WHO_D_BE_KING_OFFSET + 1)
 
     elseif (player:getCurrentMission(WINDURST) == tpz.mission.id.windurst.THE_JESTER_WHO_D_BE_KING and player:getCharVar("MissionStatus") == 5) then
         player:startEvent(71)


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Both cardians were set to auto-target whoever pops them with or without sneak, now they simply spawn if the player has sneak up.  From wiki: "When the Cracked Wall is examined, the following two level 72 Cardians will spawn and they attack immediately unless the character examining the Cracked Wall is under the effect of Sneak."

Thanks to Eren@GoldSaucer for reporting this.