### PR TITLE
Add extend mission log migration

### DIFF
--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -19,6 +19,7 @@ from migrations import broken_linkshells
 from migrations import spell_family_column
 from migrations import mission_blob_extra
 from migrations import cop_mission_ids
+from migrations import extend_mission_log
 # Append new migrations to this list and import above
 migrations = [
     unnamed_flags,
@@ -28,6 +29,7 @@ migrations = [
     crystal_storage,
     broken_linkshells,
     spell_family_column,
+    extend_mission_log,
     mission_blob_extra,
     cop_mission_ids,
 ]
@@ -382,10 +384,14 @@ def run_all_migrations(silent=False):
                 return
             else:
                 backup_db()
+        os.remove('migration_errors.log')
         for migration in migrations_needed:
             print('Running migrations for ' + migration.migration_name() + '...')
             migration.migrate(cur, db)
         print(Fore.GREEN + 'Finished migrations!')
+        if os.path.exists('migration_errors.log'):
+            print(Fore.RED + 'There were errors with some migrations, this likely means one or more characters \n'
+                'have corrupt data in some field. See migration_errors.log for more details.')
         time.sleep(0.5)
     else:
         print(Fore.GREEN + 'All migrations done!')

--- a/tools/migrations/cop_mission_ids.py
+++ b/tools/migrations/cop_mission_ids.py
@@ -55,13 +55,14 @@ def check_preconditions(cur):
 
 def needs_to_run(cur):
     # Ensure old mission IDs are still being used
-    cur.execute("SELECT missions FROM chars WHERE missions IS NOT NULL LIMIT 1;")
-
-    row = cur.fetchone()
-    if row and len(row[0]) != 1050:
+    cur.execute("SELECT COUNT(*) FROM chars WHERE LENGTH(missions) < 1050;")
+    row = cur.fetchone()[0]
+    if row and row > 0:
         return True
-    if row and len(row[0]) == 1050:
-        row = bytearray(bytes(row[0]))
+    cur.execute("SELECT missions FROM chars WHERE missions IS NOT NULL AND LENGTH(missions) = 1050 LIMIT 1;")
+    row = cur.fetchone()
+    if row:
+        row = bytearray(row[0])
         currentMissionID = int.from_bytes(row[420:422], byteorder='little')
         if currentMissionID < 101:
             return True
@@ -69,29 +70,29 @@ def needs_to_run(cur):
 
 
 def migrate(cur, db):
-    minID = 0
-    maxID = 0
-
-    cur.execute("SELECT MIN(charid), MAX(charid) FROM chars;")
-
+    efile = open('migration_errors.log', 'a')
+    cur.execute("SELECT charid FROM chars WHERE LENGTH(missions) = 1050;")
     rows = cur.fetchall()
-
-    for ids in rows:
-
-        minID = ids[0]
-        maxID = ids[1]
-
-        for charid in range(minID, maxID + 1):
-            cur.execute("SELECT missions FROM chars WHERE charid = {} AND missions IS NOT NULL".format(charid))
-            row = cur.fetchone()
-            if row:
-                row = bytearray(bytes(row[0]))
+    for charid in rows:
+        charid = charid[0]
+        cur.execute("SELECT missions FROM chars WHERE charid = {}".format(charid))
+        row = cur.fetchone()
+        if row:
+            try:
+                row = bytearray(row[0])
                 currentMissionID = int.from_bytes(row[420:422], byteorder='little')
+                if currentMissionID not in mission_map:
+                    if currentMissionID > 100:
+                        continue
+                    efile.write('[cop_mission_ids] Invalid CoP mission for charid: ' + str(charid) + ', Mission ID: ' + str(currentMissionID) + '.')
+                    continue
                 newMissionID = mission_map[currentMissionID]
                 row[420:422] = newMissionID.to_bytes(2, 'little')
-            try:
-                cur.execute("UPDATE chars SET missions = %s WHERE charid = %s", (row, charid))
-                db.commit()
-            except mysql.connector.Error as err:
-                print("Something went wrong: {}".format(err))                
+                try:
+                    cur.execute("UPDATE chars SET missions = %s WHERE charid = %s", (row, charid))
+                    db.commit()
+                except mysql.connector.Error as err:
+                    print("Something went wrong: {}".format(err))
+            except:
+                efile.write('[cop_mission_ids] Error reading missions in chars table for charid: ' + str(charid) + '\n')
     db.commit()

--- a/tools/migrations/extend_mission_log.py
+++ b/tools/migrations/extend_mission_log.py
@@ -1,0 +1,36 @@
+import array
+import mysql.connector
+
+def migration_name():
+    return "Pad mission log"
+
+def check_preconditions(cur):
+    return
+
+def needs_to_run(cur):
+    # Ensure mission blob hasn't already been expanded
+    cur.execute("SELECT COUNT(*) FROM chars WHERE LENGTH(missions) < 990;")
+    row = cur.fetchone()[0]
+    if not row or row == 0:
+        return False
+    return True
+
+def migrate(cur, db):
+    efile = open('migration_errors.log', 'a')
+    cur.execute("SELECT charid FROM chars WHERE LENGTH(missions) < 990;")
+    ids = cur.fetchall()
+    for charid in ids:
+        try:
+            charid = charid[0]
+            cur.execute("SELECT missions FROM chars WHERE charid = {}".format(charid))
+            missions = bytearray(cur.fetchone()[0])
+            while len(missions) < 990:
+                missions.append(0)
+            try:
+                cur.execute("UPDATE chars SET missions = %s WHERE charid = %s", (missions, charid))
+                db.commit()
+            except mysql.connector.Error as err:
+                print("Something went wrong: {}".format(err))
+        except:
+            efile.write('[extend_mission_log] Error reading missions in chars table for charid: ' + str(charid) + '\n')
+    db.commit()

--- a/tools/migrations/mission_blob_extra.py
+++ b/tools/migrations/mission_blob_extra.py
@@ -9,40 +9,33 @@ def check_preconditions(cur):
 
 def needs_to_run(cur):
     # Ensure mission blob hasn't already been expanded
-    cur.execute("SELECT missions FROM chars WHERE missions IS NOT NULL LIMIT 1;")
-
-    row = cur.fetchone()
-    if not row or len(row[0]) == 1050:
+    cur.execute("SELECT COUNT(*) FROM chars WHERE LENGTH(missions) < 1050;")
+    row = cur.fetchone()[0]
+    if not row or row == 0:
         return False
-
     return True
 
 def migrate(cur, db):
-    minID = 0
-    maxID = 0
-
-    cur.execute("SELECT MIN(charid), MAX(charid) FROM chars;")
-
+    efile = open('migration_errors.log', 'a')
+    cur.execute("SELECT charid FROM chars WHERE LENGTH(missions) < 1050;")
     rows = cur.fetchall()
-
-    for ids in rows:
-
-        minID = ids[0]
-        maxID = ids[1]
-
-        for charid in range(minID, maxID + 1):
-            cur.execute("SELECT missions FROM chars WHERE charid = {} AND missions IS NOT NULL".format(charid))
-            row = cur.fetchone()
-            if row:
-                row = bytearray(bytes(row[0]))
+    for charid in rows:
+        charid = charid[0]
+        cur.execute("SELECT missions FROM chars WHERE charid = {}".format(charid))
+        row = cur.fetchone()
+        if row:
+            try:
+                row = bytearray(row[0])
                 logEx = bytearray(b'\x00\x00\x00\x00')
                 pos = 2
                 for _ in range(1,16):
                     row[pos:pos] = logEx
                     pos += 70
-            try:
-                cur.execute("UPDATE chars SET missions = %s WHERE charid = %s", (row, charid))
-                db.commit()
-            except mysql.connector.Error as err:
-                print("Something went wrong: {}".format(err))                
+                try:
+                    cur.execute("UPDATE chars SET missions = %s WHERE charid = %s", (row, charid))
+                    db.commit()
+                except mysql.connector.Error as err:
+                    print("Something went wrong: {}".format(err))
+            except:
+                efile.write('[mission_blob_extra] Error reading missions in chars table for charid: ' + str(charid) + '\n')
     db.commit()


### PR DESCRIPTION
This is for old DSP databases for characters that haven't done missions
in a while and thus have a shorter mission log because of newer logs
being added for SoA, mini expansions, etc. This new migration will bring
all characters to the new format before continuing to add the mission
log extra data and converting CoP mission IDs. Also added error checking
for other migrations in case of corrupt data, and improved mission log
extra and CoP missions migrations to be more smart/efficient.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

