### PR TITLE
Guild Reset at JP midnight

### DIFF
--- a/src/map/time_server.cpp
+++ b/src/map/time_server.cpp
@@ -32,7 +32,6 @@
 #include "lua/luautils.h"
 #include "entities/charentity.h"
 #include "latent_effect_container.h"
-#include "daily_system.h"
 
 
 int32 time_server(time_point tick,CTaskMgr::CTask* PTask)
@@ -83,7 +82,6 @@ int32 time_server(time_point tick,CTaskMgr::CTask* PTask)
     {
         if (tick > (CVanaTime::getInstance()->lastMidnight + 1h))
         {
-            daily::UpdateDailyTallyPoints();
             CVanaTime::getInstance()->lastMidnight = tick;
         }
     }

--- a/src/map/time_server.cpp
+++ b/src/map/time_server.cpp
@@ -32,6 +32,7 @@
 #include "lua/luautils.h"
 #include "entities/charentity.h"
 #include "latent_effect_container.h"
+#include "daily_system.h"
 
 
 int32 time_server(time_point tick,CTaskMgr::CTask* PTask)
@@ -77,12 +78,12 @@ int32 time_server(time_point tick,CTaskMgr::CTask* PTask)
 
     }
 
-    //Midnight
+    // Midnight
     if (CVanaTime::getInstance()->getSysHour() == 0 && CVanaTime::getInstance()->getSysMinute() == 0)
     {
         if (tick > (CVanaTime::getInstance()->lastMidnight + 1h))
         {
-            guildutils::UpdateGuildPointsPattern();
+            daily::UpdateDailyTallyPoints();
             CVanaTime::getInstance()->lastMidnight = tick;
         }
     }
@@ -91,6 +92,7 @@ int32 time_server(time_point tick,CTaskMgr::CTask* PTask)
     {
         if (tick > (CVanaTime::getInstance()->lastVDailyUpdate + 4800ms))
         {
+            // Vanadiel Time daily updates ("midnight")
 			zoneutils::ForEachZone([](CZone* PZone)
 			{
                 luautils::OnGameDay(PZone);
@@ -100,6 +102,7 @@ int32 time_server(time_point tick,CTaskMgr::CTask* PTask)
 				});
 			});
 
+            guildutils::UpdateGuildPointsPattern();
             guildutils::UpdateGuildsStock();
             zoneutils::SavePlayTime();
 

--- a/src/map/utils/guildutils.cpp
+++ b/src/map/utils/guildutils.cpp
@@ -72,6 +72,10 @@ void Initialize()
     }
     TPZ_DEBUG_BREAK_IF(g_PGuildShopList.size() != 0);
 
+    // Show in log day number used for guild rank items
+    int vanaDay = CVanaTime::getInstance()->getVanaTime() / (60 * 60 * 24);
+    ShowDebug(CL_CYAN"Guild Items initialized for Vanadiel day: %d\n" CL_RESET, vanaDay);
+
     fmtQuery = "SELECT DISTINCT guildid FROM guild_shops ORDER BY guildid ASC LIMIT 256;";
 
 	if (Sql_Query(SqlHandle,fmtQuery) != SQL_ERROR && Sql_NumRows(SqlHandle) != 0)
@@ -171,7 +175,7 @@ void UpdateGuildPointsPattern()
     }
 
     // load the pattern in case it was set by another server (and this server did not set it)
-    Sql_Query(SqlHandle, "SELECT value FROM server_variables WHERE name = '[GUILD]pattern';");
+    ret = Sql_Query(SqlHandle, "SELECT value FROM server_variables WHERE name = '[GUILD]pattern';");
     if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) == 1 && Sql_NextRow(SqlHandle) == SQL_SUCCESS)
     {
         pattern = Sql_GetUIntData(SqlHandle, 0);


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

(this is @ Tokenr on Discord, btw!)

Should solve:
Fixes https://github.com/project-topaz/topaz/issues/750
Fixes https://github.com/project-topaz/topaz/issues/875
and the first item of:
https://github.com/project-topaz/topaz/issues/22

The way the guild rank items are set up, the reset must happen on JP midnight, independant on server timezone.
