### PR TITLE
Add onEventUpdate to some HP luas.  Cost in menu now reflects Rhapsody in White KI.  

### DIFF
--- a/scripts/globals/homepoint.lua
+++ b/scripts/globals/homepoint.lua
@@ -194,6 +194,11 @@ tpz.homepoint.onTrigger = function(player, csid, index)
         params = bit.bor(params, 0x10000) -- OR in New HP Bit Flag
     end
 
+    if player:hasKeyItem(tpz.keyItem.RHAPSODY_IN_WHITE) then
+        -- "Rhapsody in White" key item reduces teleport fee by 80%
+        params = bit.bor(params, 0x20000)
+    end
+
     player:setLocalVar("originIndex", index)
     local G1,G2,G3,G4 = unpack(player:getTeleport(travelType))
     player:startEvent(csid, 1, G1, G2, G3, G4, player:getGil(), 4095, params)

--- a/scripts/zones/Mount_Zhayolm/npcs/HomePoint#1.lua
+++ b/scripts/zones/Mount_Zhayolm/npcs/HomePoint#1.lua
@@ -13,6 +13,10 @@ function onTrigger(player, npc)
     tpz.homepoint.onTrigger(player, hpEvent, hpIndex)
 end
 
+function onEventUpdate(player, csid, option)
+    tpz.homepoint.onEventUpdate(player, csid, option)
+end
+
 function onEventFinish(player, csid, option)
     tpz.homepoint.onEventFinish(player, csid, option, hpEvent)
 end

--- a/scripts/zones/Newton_Movalpolos/npcs/HomePoint#1.lua
+++ b/scripts/zones/Newton_Movalpolos/npcs/HomePoint#1.lua
@@ -13,6 +13,10 @@ function onTrigger(player, npc)
     tpz.homepoint.onTrigger(player, hpEvent, hpIndex)
 end
 
+function onEventUpdate(player, csid, option)
+    tpz.homepoint.onEventUpdate(player, csid, option)
+end
+
 function onEventFinish(player, csid, option)
     tpz.homepoint.onEventFinish(player, csid, option, hpEvent)
 end

--- a/scripts/zones/Palborough_Mines/npcs/HomePoint#1.lua
+++ b/scripts/zones/Palborough_Mines/npcs/HomePoint#1.lua
@@ -13,6 +13,10 @@ function onTrigger(player, npc)
     tpz.homepoint.onTrigger(player, hpEvent, hpIndex)
 end
 
+function onEventUpdate(player, csid, option)
+    tpz.homepoint.onEventUpdate(player, csid, option)
+end
+
 function onEventFinish(player, csid, option)
     tpz.homepoint.onEventFinish(player, csid, option, hpEvent)
 end

--- a/scripts/zones/Qufim_Island/npcs/HomePoint#1.lua
+++ b/scripts/zones/Qufim_Island/npcs/HomePoint#1.lua
@@ -13,6 +13,10 @@ function onTrigger(player, npc)
     tpz.homepoint.onTrigger(player, hpEvent, hpIndex)
 end
 
+function onEventUpdate(player, csid, option)
+    tpz.homepoint.onEventUpdate(player, csid, option)
+end
+
 function onEventFinish(player, csid, option)
     tpz.homepoint.onEventFinish(player, csid, option, hpEvent)
 end

--- a/scripts/zones/Xarcabard_[S]/npcs/HomePoint#1.lua
+++ b/scripts/zones/Xarcabard_[S]/npcs/HomePoint#1.lua
@@ -13,6 +13,10 @@ function onTrigger(player, npc)
     tpz.homepoint.onTrigger(player, hpEvent, hpIndex)
 end
 
+function onEventUpdate(player, csid, option)
+    tpz.homepoint.onEventUpdate(player, csid, option)
+end
+
 function onEventFinish(player, csid, option)
     tpz.homepoint.onEventFinish(player, csid, option, hpEvent)
 end

--- a/scripts/zones/Yughott_Grotto/npcs/HomePoint#1.lua
+++ b/scripts/zones/Yughott_Grotto/npcs/HomePoint#1.lua
@@ -13,6 +13,10 @@ function onTrigger(player, npc)
     tpz.homepoint.onTrigger(player, hpEvent, hpIndex)
 end
 
+function onEventUpdate(player, csid, option)
+    tpz.homepoint.onEventUpdate(player, csid, option)
+end
+
 function onEventFinish(player, csid, option)
     tpz.homepoint.onEventFinish(player, csid, option, hpEvent)
 end


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

* add missing onEventUpdate to several homepoints
* players with Rhapsody in White KI will now see reduced cost in HP teleport menu [Fixes #602, Relates to #800]
