### PR TITLE
Bug when retrieving crystals from Ephemeral Moogle

### DIFF
--- a/scripts/globals/ephemeral.lua
+++ b/scripts/globals/ephemeral.lua
@@ -88,7 +88,7 @@ end
 
 tpz.ephemeral.onEventFinish = function(player, option, wasTrade)
     -- Early out if the player cancelled the menu
-    if not wasTrade and bit.band(option, 0xF) == 0 then
+    if not wasTrade and bit.band(option, 0xFFFF) == 0 then
         return
     end
 


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Fixes https://github.com/project-topaz/topaz/issues/903

(Incorrect bit mask when trying to determine if menu from retrieving crystal was canceled)