### PR TITLE
Trust Samba Handling 2

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -989,13 +989,15 @@ namespace battleutils
                 Action->addEffectMessage = 384;
             }
         }
-        else
+        else if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_DRAIN_DAZE) ||
+            PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_HASTE_DAZE) ||
+            PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_ASPIR_DAZE))
         {
             // Generic drain for anyone able to do melee damage to a dazed target
             // TODO: ignore dazes from dancers outside party
             int16 delay = PAttacker->GetWeaponDelay(false) / 10;
 
-            if (PAttacker->PMaster == nullptr || (PAttacker->objtype == TYPE_TRUST && PAttacker->PMaster))
+            if (PAttacker->PMaster == nullptr || PAttacker->objtype == TYPE_TRUST)
             {
                 // TODO: All of this is very ugly, but is fairly fragile, be careful refactoring!
                 EFFECT daze = EFFECT_NONE;
@@ -1024,29 +1026,26 @@ namespace battleutils
                         }
                     }
                 }
-                else if (PAttacker->objtype == TYPE_TRUST && PAttacker->PMaster->PParty)
+                else if (PAttacker->objtype == TYPE_TRUST && PAttacker->PMaster)
                 {
-                    for (uint8 i = 0; i < PAttacker->PMaster->PParty->members.size(); i++)
+                    static_cast<CCharEntity*>(PAttacker->PMaster)->ForPartyWithTrusts([&](CBattleEntity* PMember)
                     {
-                        if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_DRAIN_DAZE, PAttacker->PMaster->PParty->members[i]->id))
+                        if (daze == EFFECT_NONE && PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_DRAIN_DAZE, PMember->id))
                         {
                             daze = EFFECT_DRAIN_DAZE;
-                            power = PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_DRAIN_DAZE, PAttacker->PMaster->PParty->members[i]->id)->GetPower();
-                            break;
+                            power = PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_DRAIN_DAZE, PMember->id)->GetPower();
                         }
-                        if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_HASTE_DAZE, PAttacker->PMaster->PParty->members[i]->id))
+                        if (daze == EFFECT_NONE && PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_DRAIN_DAZE, PMember->id))
                         {
-                            daze = EFFECT_HASTE_DAZE;
-                            power = PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_HASTE_DAZE, PAttacker->PMaster->PParty->members[i]->id)->GetPower();
-                            break;
+                            daze = EFFECT_DRAIN_DAZE;
+                            power = PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_DRAIN_DAZE, PMember->id)->GetPower();
                         }
-                        if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_ASPIR_DAZE, PAttacker->PMaster->PParty->members[i]->id))
+                        if (daze == EFFECT_NONE && PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_ASPIR_DAZE, PMember->id))
                         {
-                            daze = EFFECT_ASPIR_DAZE;
-                            power = PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_ASPIR_DAZE, PAttacker->PMaster->PParty->members[i]->id)->GetPower();
-                            break;
+                            daze = EFFECT_DRAIN_DAZE;
+                            power = PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_ASPIR_DAZE, PMember->id)->GetPower();
                         }
-                    }
+                    });
                 }
                 else
                 {
@@ -1135,71 +1134,6 @@ namespace battleutils
                 }
             }
         }
-
-        // TODO: move all this to scripts for each of these weapons
-
-        // elemental damage equation = (weapDmg / 2) +- (weapDmg / 4)
-
-        // no enspells active, check weapon additional effects
-
-        /*if (Action->animation == 1)
-            PWeapon = (CItemWeapon*)PChar->getStorage(LOC_INVENTORY)->GetItem(PChar->equip[SLOT_SUB]);
-        if(PWeapon != nullptr)
-        {
-            EFFECT dispelled;
-            switch(PWeapon->getID())
-            {
-                //Additional Effect: HP drain Weapons
-                case 16827:
-                case 16528:
-                case 16824:
-                case 17651:
-                case 16556:
-                case 16609:
-                case 16580:
-                case 17646:
-                case 16777:
-                case 16791:
-                case 16846:
-                case 16881:
-                case 17561:
-                case 17562:
-                case 17778:
-                case 17779:
-                case 17576:
-                case 17510:
-                    //30 % chance to drain, will heal 30% of damage done
-                    if (rand()%100 >= 30 || PWeapon==nullptr) return;
-
-                    Action->additionalEffect = SUBEFFECT_HP_DRAIN;
-                    Action->addEffectMessage = 161;
-                    Action->addEffectParam = (float)(Action->param * 0.3f);
-                    PAttacker->addHP(Action->addEffectParam);
-
-                    PChar->updatemask |= UPDATE_HP;
-                    return;
-
-
-                //Additional Effect: Dispel Weapons (10% chance needs verifying)
-                case 16942:
-                case 16944:
-                case 16950:
-                case 16951:
-                case 18330:
-                    if (rand()%100 > 10) return;
-                    dispelled = PDefender->StatusEffectContainer->DispelStatusEffect();
-                    // if(dispelled > 0){
-                    //     Action->submessageID = 42;
-                    //     Action->flag = 2;
-                    //     Action->subeffect = SUBEFFECT_LIGHT;
-                    //     Action->subparam = dispelled;
-                    // }
-                    return;
-                default:
-                    return;
-            }
-        }*/
-        return;
     }
 
     /************************************************************************


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

My original comment still holds true:
```
// TODO: All of this is very ugly, but is fairly fragile, be careful refactoring!
```

`trust_stability_2` cleaned up a lot of things, but the samba handling is still exploding with trusts. 

Crash report from Canaria:
```
Thread 1 "topaz_game" received signal SIGSEGV, Segmentation fault.
battleutils::HandleEnspell (PAttacker=0x55558663a9b0, PDefender=0x5555710c4a10, Action=0x5555865ab420, isFirstSwing=<optimized out>, weapon=0x5555865d2ae0,
    finaldamage=1) at src/map/utils/battleutils.cpp:1027
1027                    else if (PAttacker->objtype == TYPE_TRUST && PAttacker->PMaster->PParty)
1022                                power = PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_ASPIR_DAZE, PAttacker->PParty->members[i]->id)->GetPower();
1023                                break;
1024                            }
1025                        }
1026                    }
1027                    else if (PAttacker->objtype == TYPE_TRUST && PAttacker->PMaster->PParty)
1028                    {
1029                        for (uint8 i = 0; i < PAttacker->PMaster->PParty->members.size(); i++)
1030                        {
1031                            if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_DRAIN_DAZE, PAttacker->PMaster->PParty->members[i]->id))
#0  battleutils::HandleEnspell (PAttacker=0x55558663a9b0, PDefender=0x5555710c4a10, Action=0x5555865ab420, isFirstSwing=<optimized out>, weapon=0x5555865d2ae0, 
    finaldamage=1) at src/map/utils/battleutils.cpp:1027
#1  0x00005555555cade5 in CBattleEntity::OnAttack (this=this@entry=0x55558663a9b0, state=..., action=...) at src/map/entities/battleentity.cpp:1684
#2  0x00005555555d821c in CMobEntity::OnAttack (this=0x55558663a9b0, state=..., action=...) at src/map/entities/mobentity.cpp:1132
#3  0x00005555555af8d7 in CAttackState::Update (this=0x5555865cb060, tick=...) at src/map/ai/states/attack_state.cpp:65
#4  0x0000555555597b0e in CAIContainer::Tick (this=0x555586632380, _tick=..., _tick@entry=...) at src/map/ai/ai_container.cpp:361
#5  0x00005555556bcc74 in CZoneEntities::ZoneServer (this=0x55555de29fd0, tick=..., check_regions=false) at src/map/zone_entities.cpp:1097
#6  0x00005555556b604b in CZone::ZoneServer (this=0x55555d677b40, tick=..., check_regions=<optimized out>) at src/map/zone.cpp:806
#7  0x00005555556b6e23 in zone_server (tick=..., PTask=<optimized out>) at src/map/zone.cpp:83
#8  0x0000555555591c99 in CTaskMgr::DoTimer (this=0x555555abab10, tick=...) at src/common/taskmgr.cpp:78
#9  0x0000555555571620 in main (argc=1, argv=0x7fffffffdf98) at src/common/kernel.cpp:267
   0x55555567db1a <battleutils::HandleEnspell(CBattleEntity*, CBattleEntity*, actionTarget_t*, bool, CItemWeapon*, int)+2170>:  test   %al,(%rax)
   0x55555567db1c <battleutils::HandleEnspell(CBattleEntity*, CBattleEntity*, actionTarget_t*, bool, CItemWeapon*, int)+2172>:  add    %al,(%rax)
   0x55555567db1e <battleutils::HandleEnspell(CBattleEntity*, CBattleEntity*, actionTarget_t*, bool, CItemWeapon*, int)+2174>:  add    %al,(%rax)
=> 0x55555567db20 <battleutils::HandleEnspell(CBattleEntity*, CBattleEntity*, actionTarget_t*, bool, CItemWeapon*, int)+2176>:  mov    0x240(%rax),%rax
   0x55555567db27 <battleutils::HandleEnspell(CBattleEntity*, CBattleEntity*, actionTarget_t*, bool, CItemWeapon*, int)+2183>:  test   %rax,%rax
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
```

I've never been able to reproduce this crash reliably on my machine, so another round of refactoring might help.

**Work:**
- Doesn't automatically fall into the Samba/Daze handling with `else`. This should at least only go into the crash-prone code if there is actually a Daze on a mob.
- PMaster or PParty might be getting wiped out while iterating the party members, so swap out for `ForPartyWithTrusts`, which handles a shrinking party (or one disappearing), maybe.
- Remove some dead comments while I'm here.

**Tested with:**
- Regular battle with only Char
- Regular battle with Char + Trusts
- Regular battle with Char (as DNC w/ Sambas) + Trusts
- All of the above, randomly killing trusts
- All of the above, randomly killing main char
- All of the above, randomly killing main char + warping to homepoint immediately
- All of the above, force-zoning with !zone in the middle of battle

**If this goes in, this will at least mean that you can tell your players (or yourself) not to use DNC Sambas and Trusts at the same time.**

**You can apply this as a patch by downloading:**
https://patch-diff.githubusercontent.com/raw/project-topaz/topaz/pull/929.patch
and running `git apply <patch name>`

If it's STILL unstable after this, I would recommend reverting this section all the way back to before it allowed trusts in (like in release), and then open an ongoing bug that trusts don't benefit from sambas.