### PR TITLE
Fix for null item crash introduced in PR #857

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -2186,16 +2186,11 @@ namespace charutils
         }
         if (equipSlotID == SLOT_MAIN || equipSlotID == SLOT_RANGED || equipSlotID == SLOT_SUB)
         {
-            if ((PItem != nullptr) && PItem->isType(ITEM_EQUIPMENT))
+            if (!PItem || !PItem->isType(ITEM_EQUIPMENT) ||
+                ( ((CItemWeapon*)PItem)->getSkillType() != SKILL_STRING_INSTRUMENT &&
+                  ((CItemWeapon*)PItem)->getSkillType() != SKILL_WIND_INSTRUMENT ))
             {
-                // If the weapon ISN'T an wind based instrument or an string based instrument
-                if (((CItemWeapon*)PItem)->getSkillType() != SKILL_STRING_INSTRUMENT && ((CItemWeapon*)PItem)->getSkillType() != SKILL_WIND_INSTRUMENT)
-                {
-                    PChar->health.tp = 0;
-                }
-            }
-            else
-            {
+                // If the weapon ISN'T a wind based instrument or a string based instrument
                 PChar->health.tp = 0;
             }
 

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -2186,8 +2186,15 @@ namespace charutils
         }
         if (equipSlotID == SLOT_MAIN || equipSlotID == SLOT_RANGED || equipSlotID == SLOT_SUB)
         {
-            // If the weapon ISN'T an wind based instrument or an string based instrument
-            if (((CItemWeapon*)PItem)->getSkillType() != SKILL_STRING_INSTRUMENT && ((CItemWeapon*)PItem)->getSkillType() != SKILL_WIND_INSTRUMENT)
+            if ((PItem != nullptr) && PItem->isType(ITEM_EQUIPMENT))
+            {
+                // If the weapon ISN'T an wind based instrument or an string based instrument
+                if (((CItemWeapon*)PItem)->getSkillType() != SKILL_STRING_INSTRUMENT && ((CItemWeapon*)PItem)->getSkillType() != SKILL_WIND_INSTRUMENT)
+                {
+                    PChar->health.tp = 0;
+                }
+            }
+            else
             {
                 PChar->health.tp = 0;
             }


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Regression of PR #857:
We cannot unequip a weapon (main / sub and range slots) without crashing the server
