### PR TITLE
Fix Ore Toss to only remove up to one shadow

### DIFF
--- a/scripts/globals/mobskills/ore_toss.lua
+++ b/scripts/globals/mobskills/ore_toss.lua
@@ -22,7 +22,7 @@ function onMobWeaponSkill(target, mob, skill)
     local accmod = 1
     local dmgmod = math.random(3, 6)
     local info = MobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, TP_DMG_VARIES, 1, 2, 3)
-    local dmg = MobFinalAdjustments(info.dmg, mob, skill, target, tpz.attackType.RANGED, tpz.damageType.BLUNT, MOBPARAM_3_SHADOW)
+    local dmg = MobFinalAdjustments(info.dmg, mob, skill, target, tpz.attackType.RANGED, tpz.damageType.BLUNT, MOBPARAM_1_SHADOW)
     target:takeDamage(dmg, mob, tpz.attackType.RANGED, tpz.damageType.BLUNT)
     return dmg
 end


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Ore toss should only remove one shadow as per: https://youtu.be/OB6vwNs3new?t=90

Thanks to Nireya@GoldSaucer for reporting this and providing the video ^.^