### PR TITLE
Lowers the damage from Goblins' Bomb Toss

### DIFF
--- a/scripts/globals/mobskills/bomb_toss.lua
+++ b/scripts/globals/mobskills/bomb_toss.lua
@@ -13,7 +13,7 @@ end
 
 function onMobWeaponSkill(target, mob, skill)
     local dmgmod = 1
-    local info = MobMagicalMove(mob, target, skill, mob:getWeaponDmg()*3, tpz.magic.ele.FIRE, dmgmod, TP_MAB_BONUS, 1)
+    local info = MobMagicalMove(mob, target, skill, mob:getWeaponDmg()*2.75, tpz.magic.ele.FIRE, dmgmod, TP_MAB_BONUS, 1)
     local dmg = MobFinalAdjustments(info.dmg, mob, skill, target, tpz.attackType.MAGICAL, tpz.damageType.FIRE, MOBPARAM_IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, tpz.attackType.MAGICAL, tpz.damageType.FIRE)
     return dmg

--- a/scripts/globals/mobskills/bomb_toss_suicide.lua
+++ b/scripts/globals/mobskills/bomb_toss_suicide.lua
@@ -21,7 +21,7 @@ function onMobWeaponSkill(target, mob, skill)
     local BOMB_TOSS_HPP = skill:getMobHPP() / 100
 
     local job = mob:getMainJob()
-    local power = math.random(12, 18)
+    local power = math.random(6, 8)
 
     local info = MobMagicalMove(mob, target, skill, mob:getWeaponDmg()*power*BOMB_TOSS_HPP, tpz.magic.ele.FIRE, dmgmod, TP_MAB_BONUS, 1)
     local dmg = MobFinalAdjustments(info.dmg, mob, skill, target, tpz.attackType.MAGICAL, tpz.damageType.FIRE, MOBPARAM_IGNORE_SHADOWS)


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

We all know that the suicide Bomb Toss from goblins is too high on Topaz.  On private servers running stock topaz bomb toss scripts, you'll see that no one can actually form an exp party to specifically hunt IT goblins, unlike retail.  This is because suicide bomb toss is doing 2-3x more damage than it should.  The formula developed to emulate SE's bomb toss was made arbitrarily because we don't actually have a method to determine how mob parameters exactly affect the damage.  I propose we slash the bomb toss power in half, and the only evidence I can offer to support this is this video from 2009 where a party is exping on a goblin, and it blows up at 25% for 25ish damage to each member:
https://youtu.be/9-4PGvPxuu8?t=420

On Topaz I believe that same bomb would have caused 60ish damage per party member.  
**Cast your vote to end the tyranny of bomb toss on private servers!**