### PR TITLE
Pr dnc fixes

### DIFF
--- a/scripts/globals/abilities/violent_flourish.lua
+++ b/scripts/globals/abilities/violent_flourish.lua
@@ -61,7 +61,7 @@ function onUseAbility(player, target, ability, action)
     end
 
     local base = weaponDamage + fstr
-    local cratio, ccritratio = cMeleeRatio(player, target, params, 0)
+    local cratio, ccritratio = cMeleeRatio(player, target, params, 0, 0)
     local isSneakValid = player:hasStatusEffect(tpz.effect.SNEAK_ATTACK)
     if (isSneakValid and not player:isBehind(target)) then
         isSneakValid = false

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -106,8 +106,8 @@ function calculateRawWSDmg(attacker, target, wsID, tp, action, wsParams, calcPar
         critrate = fTP(tp, wsParams.crit100, wsParams.crit200, wsParams.crit300)
 
         if calcParams.flourishEffect then
-            if calcParams.flourisheffect:getPower() > 1 then
-                critrate = critrate + (10 + calcParams.flourisheffect:getSubPower()/2)/100
+            if calcParams.flourishEffect:getPower() > 1 then
+                critrate = critrate + (10 + calcParams.flourishEffect:getSubPower()/2)/100
             end
         end
 


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Building Flourish was breaking crit WSes due to typo
Violent Flourish was failing out and reporting "it stunned" everytime. 