### PR TITLE
PR: core: Fix init value for SMN Spirits.

### DIFF
--- a/src/map/entities/petentity.cpp
+++ b/src/map/entities/petentity.cpp
@@ -44,6 +44,7 @@ CPetEntity::CPetEntity(PETTYPE petType)
 	m_EcoSystem = SYSTEM_UNCLASSIFIED;
 	allegiance = ALLEGIANCE_PLAYER;
     m_MobSkillList = 0;
+    m_HasSpellScript = 0;
     PAI = std::make_unique<CAIContainer>(this, std::make_unique<CPathFind>(this), std::make_unique<CPetController>(this),
         std::make_unique<CTargetFind>(this));
 }


### PR DESCRIPTION
Not giving this an init value was causing there to be spirits
that sometimes did not cast. The value needs to be init to 0.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

This will prevent getting a spirit that doesn't cast, but the problem is, now they cast right away.

