### PR TITLE
Improves Golden-Tongued Culberry behavior

### DIFF
--- a/scripts/zones/PsoXja/mobs/Golden-Tongued_Culberry.lua
+++ b/scripts/zones/PsoXja/mobs/Golden-Tongued_Culberry.lua
@@ -7,10 +7,18 @@ local ID = require("scripts/zones/PsoXja/IDs")
 require("scripts/globals/status")
 -----------------------------------
 
+function onMobInitialize(mob)
+    mob:setMobMod(tpz.mobMod.MAGIC_COOL, 6)
+end
+
 function onMobFight(mob, target)
     mob:SetAutoAttackEnabled(false)
     mob:SetMobAbilityEnabled(false)
-    mob:setMobMod(tpz.mobMod.MAGIC_COOL, 6)
+    if target:isPet() then
+        mob:setMod(dsp.mod.FASTCAST, 100)
+        mob:castSpell(367, target) -- Insta-death any pet with most enmity.
+        mob:setMod(dsp.mod.FASTCAST, 10)
+    end
 end
 
 function onMobDeath(mob, player, isKiller)


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Instead of golden-tongue remaining stationary at spawn, he will now follow players and max range cast.  His cast timer is also much more accurate to retail; he gets a cast in every 10-18 seconds, instead of every 5 seconds like he was before (completely broken).

Thanks to Eren@GoldSaucer and Zaz@GoldSaucer for reporting this.