### PR TITLE
Add `!setmod` command to quickly manipulate modifiers on player/mobster/pet/fellow/trust entities

### DIFF
--- a/scripts/commands/setmod.lua
+++ b/scripts/commands/setmod.lua
@@ -1,0 +1,45 @@
+---------------------------------------------------------------------------------------------------
+-- func: setmod
+-- desc: Sets the specified modifier to the specified value on the cursor target or player
+---------------------------------------------------------------------------------------------------
+
+require("scripts/globals/status")
+
+cmdprops =
+{
+    permission = 1,
+    parameters = "sis"
+}
+
+function error(player, msg)
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!setmod {modifier} {amount} {optional target}")
+end
+
+function onTrigger(player, modifier, amount, target)
+    local modID = tonumber(modifier) or tpz.mod[string.upper(modifier)]
+    if not modID then
+        error(player, "No valid modifier found. ")
+        return
+    end
+
+    if not tonumber(amount) then
+        error(player, "Need an amount to set the modifier to! ")
+        return
+    end
+
+    if target then
+        target = GetPlayerByName(target)
+    else
+        target = player:getCursorTarget()
+    end
+
+    if not target or target:isNPC() then
+        error(player, "No valid target found. place cursor on a non-npc object or specify a player name. ")
+        return
+    end
+
+    local oldmod = player:getMod(modID)
+    player:setMod(modID, amount)
+    player:PrintToPlayer(string.format("Target name: %s (Target ID: %i) | Old %s modifier value: %i | New %s modifier value: %i", target:getName(), target:getID(), modifier, oldmod, modifier, amount))
+end


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

#967
* Note: Some modifiers expect to be on an item, not a player. This command can only apply mods directly to an entity.