### PR TITLE
Reduces Slave Globe EXP to 0

### DIFF
--- a/sql/mob_pool_mods.sql
+++ b/sql/mob_pool_mods.sql
@@ -164,6 +164,7 @@ INSERT INTO `mob_pool_mods` VALUES (3549,370,50,0);
 INSERT INTO `mob_pool_mods` VALUES (3598,368,70,0);
 INSERT INTO `mob_pool_mods` VALUES (3600,368,70,0);
 INSERT INTO `mob_pool_mods` VALUES (3601,368,70,0);
+INSERT INTO `mob_pool_mods` VALUES (3667,28,-100,1);
 INSERT INTO `mob_pool_mods` VALUES (3759,163,-100,0);
 INSERT INTO `mob_pool_mods` VALUES (3781,4,4,1);
 INSERT INTO `mob_pool_mods` VALUES (3784,2,-1,1); -- Stray GIL_MAX: don't drop gil


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Slave Globes as summoned by Mother Globe should give 0 exp when killed, right now they give full exp :(

Thanks to Nireya@GoldSaucer for reporting this.