### PR TITLE
[fix] regimes always rewarding alliance members, regardless of fov_allow_alliance value

### DIFF
--- a/scripts/globals/regimes.lua
+++ b/scripts/globals/regimes.lua
@@ -1228,7 +1228,7 @@ tpz.regime.checkRegime = function(player, mob, regimeId, index, regimeType)
     end
 
     -- people in alliance get no Fields credit unless fov_allow_alliance is 1 in map.conf
-    if regimeType == tpz.regime.type.FIELDS and player:checkSoloPartyAlliance() == 2 and not player:checkFovAllianceAllowed() == 1 then
+    if regimeType == tpz.regime.type.FIELDS and player:checkSoloPartyAlliance() == 2 and player:checkFovAllianceAllowed() ~= 1 then
         return
     end
 

--- a/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20m.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20m.lua
@@ -35,7 +35,7 @@ end
 
 function onEventUpdate(player, csid, option, target)
 
-    if not csid == 405 then
+    if csid ~= 405 then
         return
     end
 


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

LUA processes `not` before `==` so this check was always failing.