### PR TITLE
fov_allow_alliance (conf setting) --> REGIME_REWARD_ALLIANCE (lua setting)

### DIFF
--- a/conf/default/map.conf
+++ b/conf/default/map.conf
@@ -74,7 +74,6 @@ ah_list_limit: 7
 exp_rate: 1.0
 exp_loss_rate: 1.0
 exp_party_gap_penalties: 1
-fov_allow_alliance: 1
 
 #Determines Vana'diel time epoch (886/1/1 Firesday)
 # current timestamp - vanadiel_time_epoch = vana'diel time

--- a/scripts/globals/regimes.lua
+++ b/scripts/globals/regimes.lua
@@ -1227,8 +1227,13 @@ tpz.regime.checkRegime = function(player, mob, regimeId, index, regimeType)
         return
     end
 
-    -- people in alliance get no regime credit unless REGIME_REWARD_ALLIANCE is 1 in scripts/globals/settings.lua
-    if REGIME_REWARD_ALLIANCE ~= 1 and player:checkSoloPartyAlliance() == 2 then
+    -- people in alliance get no fields credit unless FOV_REWARD_ALLIANCE is 1 in scripts/globals/settings.lua
+    if FOV_REWARD_ALLIANCE ~= 1 and regimeType == tpz.regime.type.FIELDS and player:checkSoloPartyAlliance() == 2 then
+        return
+    end
+
+    -- people in alliance get no grounds credit unless GOV_REWARD_ALLIANCE is 1 in scripts/globals/settings.lua
+    if GOV_REWARD_ALLIANCE ~= 1 and regimeType == tpz.regime.type.GROUNDS and player:checkSoloPartyAlliance() == 2 then
         return
     end
 

--- a/scripts/globals/regimes.lua
+++ b/scripts/globals/regimes.lua
@@ -1227,8 +1227,8 @@ tpz.regime.checkRegime = function(player, mob, regimeId, index, regimeType)
         return
     end
 
-    -- people in alliance get no Fields credit unless fov_allow_alliance is 1 in map.conf
-    if regimeType == tpz.regime.type.FIELDS and player:checkSoloPartyAlliance() == 2 and player:checkFovAllianceAllowed() ~= 1 then
+    -- people in alliance get no regime credit unless REGIME_REWARD_ALLIANCE is 1 in scripts/globals/settings.lua
+    if REGIME_REWARD_ALLIANCE ~= 1 and player:checkSoloPartyAlliance() == 2 then
         return
     end
 

--- a/scripts/globals/settings.lua
+++ b/scripts/globals/settings.lua
@@ -31,7 +31,8 @@ ENABLE_VOIDWATCH = 1 -- Not an expansion, but has its own storyline.
 ENABLE_FIELD_MANUALS  = 1 -- Enables Fields of Valor
 ENABLE_GROUNDS_TOMES  = 1 -- Enables Grounds of Valor
 REGIME_WAIT = 1 -- Make people wait till 00:00 game time as in retail. If it's 0, there is no wait time.
-REGIME_REWARD_ALLIANCE = 1 -- Allow Fields and Grounds of Valor rewards while being a member of an alliance.
+FOV_REWARD_ALLIANCE = 0 -- Allow Fields of Valor rewards while being a member of an alliance. (default retail behavior: 0)
+GOV_REWARD_ALLIANCE = 1 -- Allow Grounds of Valor rewards while being a member of an alliance. (default retail behavior: 1)
 
 -- TREASURE CASKETS
 -- Retail droprate = 0.1 (10%) with no other effects active

--- a/scripts/globals/settings.lua
+++ b/scripts/globals/settings.lua
@@ -31,6 +31,7 @@ ENABLE_VOIDWATCH = 1 -- Not an expansion, but has its own storyline.
 ENABLE_FIELD_MANUALS  = 1 -- Enables Fields of Valor
 ENABLE_GROUNDS_TOMES  = 1 -- Enables Grounds of Valor
 REGIME_WAIT = 1 -- Make people wait till 00:00 game time as in retail. If it's 0, there is no wait time.
+REGIME_REWARD_ALLIANCE = 1 -- Allow Fields and Grounds of Valor rewards while being a member of an alliance.
 
 -- TREASURE CASKETS
 -- Retail droprate = 0.1 (10%) with no other effects active

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -3104,7 +3104,7 @@ inline int32 CLuaBaseEntity::getTeleportMenu(lua_State *L)
         return 0;
     }
 
-	lua_newtable(L);
+    lua_newtable(L);
 
     for (uint8 x = 0; x < 10; x++)
     {
@@ -3853,7 +3853,7 @@ inline int32 CLuaBaseEntity::breakLinkshell(lua_State* L)
     bool found = false;
 
     int32 ret = Sql_Query(SqlHandle, "SELECT broken, linkshellid FROM linkshells WHERE name = '%s'", lsname);
-	if( ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0 && Sql_NextRow(SqlHandle) == SQL_SUCCESS)
+    if( ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0 && Sql_NextRow(SqlHandle) == SQL_SUCCESS)
     {
         uint8 broken = Sql_GetUIntData(SqlHandle,0);
         if (broken)
@@ -6530,7 +6530,7 @@ inline int32 CLuaBaseEntity::completeMission(lua_State *L)
 *  Function: setMissionLogEx()
 *  Purpose : Sets mission log extra data to correctly track progress in branching missions.
 *  Example : player:setMissionLogEx(tpz.mission.log_id.COP, tpz.mission.logEx.ULMIA, 14)
-*  Notes   : 
+*  Notes   :
 ************************************************************************/
 
 inline int32 CLuaBaseEntity::setMissionLogEx(lua_State *L)
@@ -9075,24 +9075,6 @@ inline int32 CLuaBaseEntity::checkSoloPartyAlliance(lua_State *L)
 }
 
 /************************************************************************
-*  Function: checkFovAllianceAllowed()
-*  Purpose : Returns true if server owner has enabled FoV alliances
-*  Example : if (player:checkFovAllianceAllowed() == 1) then
-*  Notes   :
-************************************************************************/
-
-inline int32 CLuaBaseEntity::checkFovAllianceAllowed(lua_State *L)
-{
-    TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
-    TPZ_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
-
-    uint8 FovAlliance = map_config.fov_allow_alliance;
-
-    lua_pushinteger(L, FovAlliance);
-    return 1;
-}
-
-/************************************************************************
 *  Function: checkKillCredit()
 *  Purpose : Used to determine if kill counts towards regimes/etc.
 *  Example : if (player:checkKillCredit(mob)) then
@@ -10024,7 +10006,7 @@ int32 CLuaBaseEntity::checkImbuedItems(lua_State* L)
 *  Function: isDualWielding()
 *  Purpose : Returns true if entity is wielding two weapons
 *  Example : if player:isDualWielding() then
-*  Notes   : 
+*  Notes   :
 ************************************************************************/
 
 inline int32 CLuaBaseEntity::isDualWielding(lua_State* L)
@@ -14549,7 +14531,6 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
 
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,checkSoloPartyAlliance),
 
-    LUNAR_DECLARE_METHOD(CLuaBaseEntity,checkFovAllianceAllowed),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,checkKillCredit),
 
     // Instances

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -432,7 +432,6 @@ public:
 
     int32 checkSoloPartyAlliance(lua_State*);        // Check if Player is in Party or Alliance 0=Solo 1=Party 2=Alliance
 
-    int32 checkFovAllianceAllowed(lua_State*);       // checks the map config, 1 if alliance is allowed to farm Fov pages
     int32 checkKillCredit(lua_State*);
 
     // Instances

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1128,10 +1128,6 @@ int32 map_config_read(const int8* cfgName)
         {
             map_config.exp_party_gap_penalties = (uint8)atof(w2);
         }
-        else if (strcmp(w1, "fov_allow_alliance") == 0)
-        {
-            map_config.fov_allow_alliance = (uint8)atof(w2);
-        }
         else if (strcmp(w1, "mob_tp_multiplier") == 0)
         {
             map_config.mob_tp_multiplier = (float)atof(w2);

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -83,7 +83,6 @@ struct map_config_t
     float  exp_rate;                  // множитель получаемого опыта
     float  exp_loss_rate;             // same as exp rate but applies when player dies
     uint8  exp_party_gap_penalties;   // if 1 Party Gap Penalties will apply
-    uint8  fov_allow_alliance;        // if 1 allow alliance to farm fov pages
     float  exp_retain;                // percentage of normally lost experience to retain upon death
     int8   exp_loss_level;            // Minimum main job level at which a character may lose experience points.
     bool   level_sync_enable;         // Enable/disable Level Sync


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

This setting was used in the core for nothing other than being exposed to LUA via checkFovAllianceAllowed binding.

This PR:

* moves the setting into scripts/globals/settings.lua
* makes the setting affect both RoV and GoV.  Requested by Lusiphur.  I can split this into two settings if desired.
