### PR TITLE
Uragnite mixin

### DIFF
--- a/scripts/mixins/families/uragnite.lua
+++ b/scripts/mixins/families/uragnite.lua
@@ -1,0 +1,106 @@
+--[[
+https://ffxiclopedia.fandom.com/wiki/Category:Uragnites
+https://www.bg-wiki.com/bg/Category:Uragnite
+
+Uragnite mob can optionally be modified by calling tpz.mix.uragnite.config(mob, params) from within onMobSpawn.
+
+params is a table that can contain the following keys:
+    inShellSkillList : skill list given to mob when it enters shell (default: 250)
+    noShellSkillList : skill list given to mob when it exits shell (default: 251)
+    chanceToShell    : percent chance to enter shell when hit by a physical attack (default: 20)
+    timeInShellMin   : least time mob can stay in shell, in seconds (default: 30)
+    timeInShellMax   : most time mob can stay in shell, in seconds (default: 45)
+    inShellRegen     : amount of regen mob gets while in shell (default: 50)
+
+Example:
+
+tpz.mix.uragnite.config(mob, {
+    chanceToShell = 10,
+    timeInShellMin = 45,
+    timeInShellMin = 60,
+})
+
+--]]
+require("scripts/globals/mixins")
+require("scripts/globals/status")
+-----------------------------------
+
+tpz = tpz or {}
+tpz.mix = tpz.mix or {}
+tpz.mix.uragnite = tpz.mix.uragnite or {}
+
+g_mixins = g_mixins or {}
+g_mixins.families = g_mixins.families or {}
+
+local function enterShell(mob)
+    mob:AnimationSub(mob:AnimationSub() + 1)
+    mob:SetAutoAttackEnabled(false)
+    mob:addMod(tpz.mod.UDMGPHYS, -75)
+    mob:addMod(tpz.mod.UDMGRANGE, -75)
+    mob:addMod(tpz.mod.UDMGMAGIC, -75)
+    mob:addMod(tpz.mod.UDMGBREATH, -75)
+    mob:addMod(tpz.mod.REGEN, mob:getLocalVar("[uragnite]inShellRegen"))
+    mob:setMobMod(tpz.mobMod.SKILL_LIST, mob:getLocalVar("[uragnite]inShellSkillList"))
+    mob:setMobMod(tpz.mobMod.NO_MOVE, 1)
+end
+
+local function exitShell(mob)
+    mob:AnimationSub(mob:AnimationSub() - 1)
+    mob:SetAutoAttackEnabled(true)
+    mob:delMod(tpz.mod.UDMGPHYS, -75)
+    mob:delMod(tpz.mod.UDMGRANGE, -75)
+    mob:delMod(tpz.mod.UDMGMAGIC, -75)
+    mob:delMod(tpz.mod.UDMGBREATH, -75)
+    mob:delMod(tpz.mod.REGEN, mob:getLocalVar("[uragnite]inShellRegen"))
+    mob:setMobMod(tpz.mobMod.SKILL_LIST, mob:getLocalVar("[uragnite]noShellSkillList"))
+    mob:setMobMod(tpz.mobMod.NO_MOVE, 0)
+end
+
+tpz.mix.uragnite.config = function(mob, params)
+    if params.inShellSkillList and type(params.inShellSkillList) == "number" then
+        mob:setLocalVar("[uragnite]inShellSkillList", params.inShellSkillList)
+    end
+    if params.noShellSkillList and type(params.noShellSkillList) == "number" then
+        mob:setLocalVar("[uragnite]noShellSkillList", params.noShellSkillList)
+    end
+    if params.chanceToShell and type(params.chanceToShell) == "number" then
+        mob:setLocalVar("[uragnite]chanceToShell", params.chanceToShell)
+    end
+    if params.timeInShellMin and type(params.timeInShellMin) == "number" then
+        mob:setLocalVar("[uragnite]timeInShellMin", params.timeInShellMin)
+    end
+    if params.timeInShellMax and type(params.timeInShellMax) == "number" then
+        mob:setLocalVar("[uragnite]timeInShellMax", params.timeInShellMax)
+    end
+    if params.inShellRegen and type(params.inShellRegen) == "number" then
+        mob:setLocalVar("[uragnite]inShellRegen", params.inShellRegen)
+    end
+end
+
+g_mixins.families.uragnite = function(mob)
+
+    -- at spawn, give mob default skill lists for in-shell and out-of-shell states
+    -- these defaults can be overwritten by using tpz.mix.uragnite.config() in onMobSpawn.
+    mob:addListener("SPAWN", "URAGNITE_SPAWN", function(mob)
+        mob:setLocalVar("[uragnite]noShellSkillList", 251)
+        mob:setLocalVar("[uragnite]inShellSkillList", 250)
+        mob:setLocalVar("[uragnite]chanceToShell", 20)
+        mob:setLocalVar("[uragnite]timeInShellMin", 30)
+        mob:setLocalVar("[uragnite]timeInShellMax", 45)
+        mob:setLocalVar("[uragnite]inShellRegen", 50)
+    end)
+
+    mob:addListener("TAKE_DAMAGE", "URAGNITE_TAKE_DAMAGE", function(mob, amount, attacker, attackType, damageType)
+        if attackType == tpz.attackType.PHYSICAL then
+            if math.random(100) <= mob:getLocalVar("[uragnite]chanceToShell") and bit.band(mob:AnimationSub(), 1) == 0 then
+                enterShell(mob)
+                local timeInShell = math.random(mob:getLocalVar("[uragnite]timeInShellMin"), mob:getLocalVar("[uragnite]timeInShellMax"))
+                mob:timer(timeInShell * 1000, function(mob)
+                    exitShell(mob)
+                end)
+            end
+        end
+    end)
+end
+
+return g_mixins.families.uragnite

--- a/scripts/zones/Bibiki_Bay/mobs/Coralline_Uragnite.lua
+++ b/scripts/zones/Bibiki_Bay/mobs/Coralline_Uragnite.lua
@@ -1,0 +1,9 @@
+-----------------------------------
+-- Area: Bibiki Bay
+--  Mob: Coralline Uragnite
+-----------------------------------
+mixins = {require("scripts/mixins/families/uragnite")}
+-----------------------------------
+
+function onMobDeath(mob, player, isKiller)
+end

--- a/scripts/zones/Dynamis-Buburimu/mobs/Nightmare_Uragnite.lua
+++ b/scripts/zones/Dynamis-Buburimu/mobs/Nightmare_Uragnite.lua
@@ -2,7 +2,10 @@
 -- Area: Dynamis - Buburimu
 --  Mob: Nightmare Uragnite
 -----------------------------------
-mixins = {require("scripts/mixins/dynamis_dreamland")}
+mixins = {
+    require("scripts/mixins/dynamis_dreamland"),
+    require("scripts/mixins/families/uragnite")
+}
 -----------------------------------
 
 function onMobSpawn(mob)

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -1123,12 +1123,12 @@ INSERT INTO `mob_skill_lists` VALUES ('Troll',246,1746);
 -- INSERT INTO `mob_skill_lists` VALUES ('Troll',246,1748);
 -- INSERT INTO `mob_skill_lists` VALUES ('Troll',246,1749);
 -- 247: Tube
--- 248 to 250: free
-INSERT INTO `mob_skill_lists` VALUES ('Uragnite',251,1571);
-INSERT INTO `mob_skill_lists` VALUES ('Uragnite',251,1572);
-INSERT INTO `mob_skill_lists` VALUES ('Uragnite',251,1573);
-INSERT INTO `mob_skill_lists` VALUES ('Uragnite',251,1574);
-INSERT INTO `mob_skill_lists` VALUES ('Uragnite',251,1575);
+-- 248 to 249: free
+INSERT INTO `mob_skill_lists` VALUES ('Uragnite_shell',250,1571); -- gas_shell
+INSERT INTO `mob_skill_lists` VALUES ('Uragnite_shell',250,1572); -- venom_shell
+INSERT INTO `mob_skill_lists` VALUES ('Uragnite',251,1573); -- palsynyxis
+INSERT INTO `mob_skill_lists` VALUES ('Uragnite',251,1574); -- painful_whip
+INSERT INTO `mob_skill_lists` VALUES ('Uragnite',251,1575); -- suctorial_tentacle
 INSERT INTO `mob_skill_lists` VALUES ('Vampyr',252,2106);
 INSERT INTO `mob_skill_lists` VALUES ('Vampyr',252,2107);
 INSERT INTO `mob_skill_lists` VALUES ('Vampyr',252,2108);
@@ -3593,13 +3593,13 @@ INSERT INTO `mob_skill_lists` VALUES ('Lightning_Wyvern',1138,817); -- Dread Shr
 INSERT INTO `mob_skill_lists` VALUES ('Lightning_Wyvern',1138,818); -- Tail Crush
 INSERT INTO `mob_skill_lists` VALUES ('Lightning_Wyvern',1138,820); -- Thunder Breath
 INSERT INTO `mob_skill_lists` VALUES ('Chaos_Wyvern',1139,813); -- Dispelling Wind
-INSERT INTO `mob_skill_lists` VALUES ('Chaos_Wyvern',1139,814); -- Deadly Drive 
+INSERT INTO `mob_skill_lists` VALUES ('Chaos_Wyvern',1139,814); -- Deadly Drive
 INSERT INTO `mob_skill_lists` VALUES ('Chaos_Wyvern',1139,815); -- Wind Wall
 INSERT INTO `mob_skill_lists` VALUES ('Chaos_Wyvern',1139,816); -- Fang Rush
 INSERT INTO `mob_skill_lists` VALUES ('Chaos_Wyvern',1139,817); -- Dread Shriek
 INSERT INTO `mob_skill_lists` VALUES ('Chaos_Wyvern',1139,818); -- Tail Crush
 INSERT INTO `mob_skill_lists` VALUES ('Chaos_Wyvern',1139,822); -- Chaos Breath
-INSERT INTO `mob_skill_lists` VALUES ('Blizzard_Wyvern',1140,813); -- Dispelling Wind 
+INSERT INTO `mob_skill_lists` VALUES ('Blizzard_Wyvern',1140,813); -- Dispelling Wind
 INSERT INTO `mob_skill_lists` VALUES ('Blizzard_Wyvern',1140,814); -- Deadly Drive
 INSERT INTO `mob_skill_lists` VALUES ('Blizzard_Wyvern',1140,815); -- Wind Wall
 INSERT INTO `mob_skill_lists` VALUES ('Blizzard_Wyvern',1140,816); -- Fang Rush
@@ -3607,7 +3607,7 @@ INSERT INTO `mob_skill_lists` VALUES ('Blizzard_Wyvern',1140,817); -- Dread Shri
 INSERT INTO `mob_skill_lists` VALUES ('Blizzard_Wyvern',1140,818); -- Tail Crush
 INSERT INTO `mob_skill_lists` VALUES ('Blizzard_Wyvern',1140,819); -- Blizzard Breath
 
-INSERT INTO `mob_skill_lists` VALUES ('Luopan',1141,3045); -- Concentric Pulse 
+INSERT INTO `mob_skill_lists` VALUES ('Luopan',1141,3045); -- Concentric Pulse
 INSERT INTO `mob_skill_lists` VALUES ('Luopan',1141,3051); -- Mending Halation
 INSERT INTO `mob_skill_lists` VALUES ('Luopan',1141,3052); -- Radial Arcana
 


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Creates uragnite mixin and applies to Coralline and Nightmare uragnites.  Mixin includes:

* shell mode, wherein uragnite
    * changes AnimationSub
    * ceases attacking or moving
    * takes greatly reduced damage
    * gains regen
    * uses shell skills
* physical attacks have a chance to push uragnite into shell mode
* uragnite leaves shell mode after some time
* an optional config function that lets you set custom values for most of these things

Fixes #985 
