### PR TITLE
add eminence migration to new dbtool

### DIFF
--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -20,6 +20,7 @@ from migrations import spell_family_column
 from migrations import mission_blob_extra
 from migrations import cop_mission_ids
 from migrations import extend_mission_log
+from migrations import eminence_blob
 # Append new migrations to this list and import above
 migrations = [
     unnamed_flags,
@@ -32,6 +33,7 @@ migrations = [
     extend_mission_log,
     mission_blob_extra,
     cop_mission_ids,
+    eminence_blob,
 ]
 # These are the default 'protected' files
 player_data = [


### PR DESCRIPTION
The dbtool didn't exist when the original RoE PR was opened and so the migration was setup for the older migrate.py. This means all canary migrations were failing due to the eminence migration not being run by the dbtool.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

