### PR TITLE
RoE repeat records + bug fixes

### DIFF
--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -46,7 +46,7 @@ function onMobDeathEx(mob, player, isKiller, isWeaponSkillKill)
     -- Vanquish Multiple Enemies I - Eminence Record Example
     -- (Will be replaced by proper record check systems when implemented.)
     if player:getEminenceProgress(12) and player:checkKillCredit(mob) then
-        local progress = player:getEminenceProgress(12) + 100
+        local progress = player:getEminenceProgress(12) + 1
         if progress >= 200 then
             npcUtil.completeRecord(player, 12, { sparks = 1000, xp = 5000, repeatable = true })
         else

--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -46,14 +46,13 @@ function onMobDeathEx(mob, player, isKiller, isWeaponSkillKill)
     -- Vanquish Multiple Enemies I - Eminence Record Example
     -- (Will be replaced by proper record check systems when implemented.)
     if player:getEminenceProgress(12) and player:checkKillCredit(mob) then
-        local progress = player:getEminenceProgress(12) + 1
+        local progress = player:getEminenceProgress(12) + 100
         if progress >= 200 then
-            npcUtil.completeRecord(player, 12, { sparks = 1000, xp = 5000 })
+            npcUtil.completeRecord(player, 12, { sparks = 1000, xp = 5000, repeatable = true })
         else
             player:setEminenceProgress(12, progress, 200)
         end
     end
-
 end
 
 -------------------------------------------------

--- a/scripts/globals/npc_util.lua
+++ b/scripts/globals/npc_util.lua
@@ -435,7 +435,7 @@ function npcUtil.completeRecord(player, record, params)
     end
 
     if params["xp"] ~= nil and type(params["xp"]) == "number" then
-        player:addExp(params["xp"] * EXP_RATE)
+        player:addExp(params["xp"] * ROE_EXP_RATE)
     end
 
     if params["keyItem"] ~= nil then
@@ -443,7 +443,12 @@ function npcUtil.completeRecord(player, record, params)
     end
 
     -- successfully complete the record
-    player:setEminenceCompleted(record)
+    if params["repeatable"] == true then
+        player:messageBasic(tpz.msg.basic.ROE_REPEAT_OR_CANCEL)
+        player:setEminenceCompleted(record, 1)
+    else
+        player:setEminenceCompleted(record)
+    end
     return true
 end
 

--- a/scripts/globals/npc_util.lua
+++ b/scripts/globals/npc_util.lua
@@ -443,7 +443,7 @@ function npcUtil.completeRecord(player, record, params)
     end
 
     -- successfully complete the record
-    if params["repeatable"] == true then
+    if params["repeatable"] then
         player:messageBasic(tpz.msg.basic.ROE_REPEAT_OR_CANCEL)
         player:setEminenceCompleted(record, 1)
     else

--- a/scripts/globals/settings.lua
+++ b/scripts/globals/settings.lua
@@ -62,6 +62,7 @@ GIL_RATE        = 1.000 -- Multiplies gil earned from quests.  Won't always disp
 BAYLD_RATE      = 1.000 -- Multiples bayld earned from quests.
 EXP_RATE        = 1.000 -- Multiplies exp earned from fov and quests.
 TABS_RATE       = 1.000 -- Multiplies tabs earned from fov.
+ROE_EXP_RATE    = 1.000 -- Multiplies exp earned from records of eminence.
 SPARKS_RATE     = 1.000 -- Multiplies sparks earned from records of eminence.
 CURE_POWER      = 1.000 -- Multiplies amount healed from Healing Magic, including the relevant Blue Magic.
 ELEMENTAL_POWER = 1.000 -- Multiplies damage dealt by Elemental and non-drain Dark Magic.

--- a/scripts/globals/sparkshop.lua
+++ b/scripts/globals/sparkshop.lua
@@ -230,7 +230,7 @@ local optionToItem = {
         [44] = { cost =  70, id = 15163 }, -- Seer's crown
         [45] = { cost = 234, id = 14424 }, -- Seer's tunic
         [46] = { cost =  97, id = 14856 }, -- Seer's mitts
-        [31] = { cost = 137, id = 14325 }, -- Seer's slacks
+        [47] = { cost = 137, id = 14325 }, -- Seer's slacks
         [48] = { cost = 157, id = 15313 }, -- Seer's pumps
         [49] = { cost =  83, id = 12292 }, -- Mahogany shield
         [50] = { cost =  70, id = 12414 }, -- Turtle shield

--- a/scripts/zones/Windurst_Woods/npcs/Fhelm_Jobeizat.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Fhelm_Jobeizat.lua
@@ -13,7 +13,7 @@ end
 
 function onTrigger(player,npc)
     if player:getEminenceProgress(1) then
-        player:startEvent(848)
+        player:startEvent(848,0,player:getGil())
     elseif player:hasKeyItem(tpz.ki.MEMORANDOLL) == false then
         player:startEvent(849)
     else

--- a/scripts/zones/Windurst_Woods/npcs/Fhelm_Jobeizat.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Fhelm_Jobeizat.lua
@@ -8,25 +8,25 @@ require("scripts/globals/keyitems")
 require("scripts/globals/sparkshop")
 local ID = require("scripts/zones/Windurst_Woods/IDs")
 
-function onTrade(player,npc,trade)
+function onTrade(player, npc, trade)
 end
 
-function onTrigger(player,npc)
+function onTrigger(player, npc)
     if player:getEminenceProgress(1) then
-        player:startEvent(848,0,player:getGil())
+        player:startEvent(848, 0, player:getGil())
     elseif player:hasKeyItem(tpz.ki.MEMORANDOLL) == false then
         player:startEvent(849)
     else
         player:messageSpecial(ID.text.TRRRADE_IN_SPARKS)
-        tpz.sparkshop.onTrigger(player,npc,850)
+        tpz.sparkshop.onTrigger(player, npc, 850)
     end
 end
 
-function onEventUpdate(player,csid,option)
-    tpz.sparkshop.onEventUpdate(player,csid,option)
+function onEventUpdate(player, csid, option)
+    tpz.sparkshop.onEventUpdate(player, csid, option)
 end
 
-function onEventFinish(player,csid,option)
+function onEventFinish(player, csid, option)
     if csid == 848 and option == 1 then
         npcUtil.completeRecord(player, 1, {
             item = { {4376,6} },
@@ -34,6 +34,6 @@ function onEventFinish(player,csid,option)
             sparks = 100,
             xp = 300
         })
-        player:messageBasic(tpz.msg.basic.ROE_BONUS_ITEM_PLURAL,4376,6)
+        player:messageBasic(tpz.msg.basic.ROE_BONUS_ITEM_PLURAL, 4376, 6)
     end
 end

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -6647,16 +6647,24 @@ inline int32 CLuaBaseEntity::setEminenceCompleted(lua_State *L)
 
     bool repeat = false;
     if (lua_gettop(L) > 1)
+    {
         repeat = lua_tointeger(L, 2) != 0;
+    }
 
     bool status = true;
     if (lua_gettop(L) > 2)
+    {
         status = lua_tointeger(L, 3) != 0;
+    }
 
     if (repeat)
+    {
         charutils::SetEminenceRecordProgress(PChar, recordID, 0);
+    }
     else
+    {
         charutils::DelEminenceRecord(PChar, recordID);
+    }
 
     charutils::SetEminenceRecordCompletion(PChar, recordID, status);
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -6653,7 +6653,9 @@ inline int32 CLuaBaseEntity::setEminenceCompleted(lua_State *L)
     if (lua_gettop(L) > 2)
         status = lua_tointeger(L, 3) != 0;
 
-    if (!repeat)
+    if (repeat)
+        charutils::SetEminenceRecordProgress(PChar, recordID, 0);
+    else
         charutils::DelEminenceRecord(PChar, recordID);
 
     charutils::SetEminenceRecordCompletion(PChar, recordID, status);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -6631,7 +6631,8 @@ inline int32 CLuaBaseEntity::getMissionLogEx(lua_State *L)
 *  Function: setEminenceCompleted()
 *  Purpose :
 *  Example : player:setEminenceCompleted(1)
-*  Notes   : optional arg 2 can set completion state explicitly (1/0)
+*  Notes   : optional arg 1 flags for repeat record (1/0) (Does not remove from log)
+*            optional arg 2 can set completion state explicitly (1/0)
 ************************************************************************/
 
 inline int32 CLuaBaseEntity::setEminenceCompleted(lua_State *L)
@@ -6644,13 +6645,17 @@ inline int32 CLuaBaseEntity::setEminenceCompleted(lua_State *L)
     CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
     uint16 recordID = (uint16)lua_tointeger(L, 1);
 
-    bool status;
-    if (lua_gettop(L) < 2)
-        status = true;
-    else
-        status = lua_tointeger(L, 2) != 0;
+    bool repeat = false;
+    if (lua_gettop(L) > 1)
+        repeat = lua_tointeger(L, 2) != 0;
 
-    charutils::DelEminenceRecord(PChar, recordID);
+    bool status = true;
+    if (lua_gettop(L) > 2)
+        status = lua_tointeger(L, 3) != 0;
+
+    if (!repeat)
+        charutils::DelEminenceRecord(PChar, recordID);
+
     charutils::SetEminenceRecordCompletion(PChar, recordID, status);
 
     return 0;


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

This PR lays the framework for repeatable records, allowing the current record number 12 (kill 200 monsters) to properly repeat.
Also general fixes for bugs pointed out to me in discord.

Selecting Chain Mitts no longer gives Seer's Slacks in the spark shop
Fhelm Jobeizat's initial RoE quest dialogue now displays either 11,111 gil or player's current gil, whichever is higher.
Also added an independent exp modifier for RoE to global settings.