### PR TITLE
Fix Dancing Chains to apply drown only in a 10y radius

### DIFF
--- a/scripts/globals/mobskills/dancing_chains.lua
+++ b/scripts/globals/mobskills/dancing_chains.lua
@@ -1,34 +1,20 @@
 ---------------------------------------------
 --  Dancing Chains
---
---  Description: Additional effect: Drown
---  Type: Magical
---  Utsusemi/Blink absorb: Ignores shadows
---  Range: Unknown cone
---  Notes:
+--  Description:  Applies AoE drown 15hp/sec
+--  Notes: Ignores shadows, 10' AoE radius
 ---------------------------------------------
+require("scripts/globals/monstertpmoves")
 require("scripts/globals/settings")
 require("scripts/globals/status")
-require("scripts/globals/monstertpmoves")
-
 ---------------------------------------------
+
 function onMobSkillCheck(target, mob, skill)
     return 0
 end
 
 function onMobWeaponSkill(target, mob, skill)
-
-    local numhits = 1
-    local accmod = 1
-    local dmgmod = 3
-    local info = MobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, TP_DMG_VARIES, 1, 2, 3)
-    local dmg = MobFinalAdjustments(info.dmg, mob, skill, target, tpz.attackType.PHYSICAL, tpz.damageType.BLUNT, info.hitslanded)
-
     local typeEffect = tpz.effect.DROWN
-    local power = mob:getMainLvl() / 3
 
-    MobPhysicalStatusEffectMove(mob, target, skill, typeEffect, power, 3, 60)
-
-    target:takeDamage(dmg, mob, tpz.attackType.PHYSICAL, tpz.damageType.BLUNT)
-    return dmg
+    skill:setMsg(MobStatusEffectMove(mob, target, typeEffect, 15, 0, 120))
+    return typeEffect
 end


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Dancing chains is not supposed to damage players, but it is supposed to apply a high drown effect to players in a 10y radius.

To be fixed: CURRENTLY our elemental hp/tic down debuffs get their stat debuff AND hp/tic debuff from the effect power.  Because the power for this is set at 15 hp/tic, the strength stat down is -33.  I doubt it was ever that strong, and this needs to be fixed eventually.

ALSO, the duration was a complete guess.  Needs verification if anyone can snag that... might as well grab the -str debuff amount too ^.^

Thanks to Nireya@GoldSaucer for reporting this.