### PR TITLE
Adds scripting for Azure Lore ability to give the effect.

### DIFF
--- a/scripts/globals/abilities/azure_lore.lua
+++ b/scripts/globals/abilities/azure_lore.lua
@@ -1,0 +1,18 @@
+-----------------------------------
+-- Ability: Azure Lore
+-- Enhances the effect of blue magic spells. 
+-- Obtained: Blue Mage Level 1
+-- Recast Time: 1:00:00
+-- Duration: 0:00:30
+-----------------------------------
+require("scripts/globals/settings")
+require("scripts/globals/status")
+-----------------------------------
+
+function onAbilityCheck(player, target, ability)
+    return 0, 0
+end
+
+function onUseAbility(player, target, ability)
+    player:addStatusEffect(tpz.effect.AZURE_LORE, 1, 0, 30)
+end


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Azure lore is one of the 1 hour abilities a player can use to unlock SCH through the quest "A Little Knowledge".  One of the players on Gold Saucer used the ability and tried to unlock sch, but the ability wasn't scripted and therefore didn't give the effect, so the player was confused about what was going on.  Though I doubt the effect does much of anything, now it's applied when a player uses the ability.