### PR TITLE
Change mobskill blood drain to remove 1 shadow instead of ignoring them

### DIFF
--- a/scripts/globals/mobskills/blood_drain.lua
+++ b/scripts/globals/mobskills/blood_drain.lua
@@ -14,9 +14,12 @@ end
 function onMobWeaponSkill(target, mob, skill)
     local dmgmod = 1
     local info = MobMagicalMove(mob, target, skill, mob:getWeaponDmg()*2, tpz.magic.ele.DARK, dmgmod, TP_MAB_BONUS, 1)
-    local dmg = MobFinalAdjustments(info.dmg, mob, skill, target, tpz.attackType.MAGICAL, tpz.damageType.DARK, MOBPARAM_IGNORE_SHADOWS)
 
-        skill:setMsg(MobPhysicalDrainMove(mob, target, skill, MOBDRAIN_HP, dmg))
-
+    if mob:getPool() == 256 then -- Asanbosam (pool id 256) uses a modified blood drain that ignores shadows
+        local dmg = MobFinalAdjustments(info.dmg, mob, skill, target, tpz.attackType.MAGICAL, tpz.damageType.DARK, MOBPARAM_IGNORE_SHADOWS)
+    else
+        local dmg = MobFinalAdjustments(info.dmg, mob, skill, target, tpz.attackType.MAGICAL, tpz.damageType.DARK, MOBPARAM_1_SHADOW)
+    end
+    skill:setMsg(MobPhysicalDrainMove(mob, target, skill, MOBDRAIN_HP, dmg))
     return dmg
 end


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

It appears that 99.9% of giant bats using blood drain should remove a shadow instead of ignoring shadows and hitting:
https://ffxiclopedia.fandom.com/wiki/Asanbosam
"Blood Drain: Modified version that ignores Utsusemi. Single target Drain."