### PR TITLE
Remove Blue Ribbon Blues quest timed wait

### DIFF
--- a/scripts/zones/Windurst_Waters/npcs/Kerutoto.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Kerutoto.lua
@@ -86,20 +86,10 @@ function onTrigger(player, npc)
         local blueRibbonProg = player:getCharVar("BlueRibbonBluesProg")
         if (player:hasItem(12521)) then
             player:startEvent(362)--362
-        elseif (blueRibbonProg == 2 and needZone == false) then
-            local timerDay = player:getCharVar("BlueRibbonBluesTimer_Day")
-            local currentDay = VanadielDayOfTheYear()
-
-            if (player:getCharVar("BlueRibbonBluesTimer_Year") < VanadielYear()) then
-                player:startEvent(360) --  go to the grave  360
-            elseif (timerDay + 1 == VanadielDayOfTheYear() and player:getCharVar("BlueRibbonBluesTimer_Hour") <= VanadielHour()) then
-                player:startEvent(360) --  go to the grave  360
-            elseif (timerDay + 2 <=  VanadielDayOfTheYear()) then
-                player:startEvent(360) --  go to the grave  360
-            else
-                player:startEvent(359) -- Thanks for the ribbon 359
-            end
-
+        elseif blueRibbonProg == 2 and needZone == false then
+            player:startEvent(360) --  go to the grave  360
+        elseif blueRibbonProg == 2 then
+            player:startEvent(359) -- Thanks for the ribbon 359
         elseif (blueRibbonProg == 3) then
             if (player:hasItem(13569)) then
                 player:startEvent(361, 0, 13569) -- remidner, go to the grave
@@ -168,9 +158,6 @@ function onEventFinish(player, csid, option)
     elseif (csid == 358 or csid == 365) then
         player:tradeComplete()
         player:setCharVar("BlueRibbonBluesProg", 2)
-        player:setCharVar("BlueRibbonBluesTimer_Hour", VanadielHour())
-        player:setCharVar("BlueRibbonBluesTimer_Year", VanadielYear())
-        player:setCharVar("BlueRibbonBluesTimer_Day", VanadielDayOfTheYear())
         player:needToZone(true)
         if (csid == 358) then
             player:addGil(GIL_RATE*3600)
@@ -178,9 +165,6 @@ function onEventFinish(player, csid, option)
     elseif (csid == 360) then
         if (player:getFreeSlotsCount() >= 1) then
             player:setCharVar("BlueRibbonBluesProg", 3)
-            player:setCharVar("BlueRibbonBluesTimer_Hour", 0)
-            player:setCharVar("BlueRibbonBluesTimer_Year", 0)
-            player:setCharVar("BlueRibbonBluesTimer_Day", 0)
             player:addItem(13569)
             player:messageSpecial(ID.text.ITEM_OBTAINED, 13569)
         else


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

The in game wait timer was removed from Blue Ribbon Blues quest in 2014/2015.  Updating Kerutoto to reflect this so players don't wonder what they did wrong (nothing).

This hasn't been tested, but it should be 100% good to go.  Thanks to rbrashear12@GoldSaucer for reporting it.