### PR TITLE
Remove range check on Treasure Hunter

### DIFF
--- a/src/map/enmity_container.cpp
+++ b/src/map/enmity_container.cpp
@@ -436,7 +436,7 @@ int16 CEnmityContainer::GetHighestTH() const
         const EnmityObject_t& PEnmityObject = it->second;
         PEntity = PEnmityObject.PEnmityOwner;
 
-        if (PEntity != nullptr && !PEntity->isDead() && IsWithinEnmityRange(PEntity) && PEnmityObject.maxTH > THLvl)
+        if (PEntity != nullptr && !PEntity->isDead() && PEnmityObject.maxTH > THLvl)
             THLvl = PEnmityObject.maxTH;
     }
 


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

I believe the distance check added to Treasure Hunter on Topaz/DSP was due to myths at the time which have since been disproven. Of course TH in it's entirety needs to be reworked but this is a quick fix to remove an annoying "bug" if you will, for now.

Currently with this check you must be within 25-28 yalms for TH to apply to a mob or NM and removing it eliminates the need for that.

Source:
https://ffxiclopedia.fandom.com/wiki/Fan_Festival_2007_Live_Blog#Q.26A

They have also released more recent information on Treasure Hunter that disproves that that there was a range check as well as other myths/rumors.

