### PR TITLE
Fix Seismostomp Mob ability

### DIFF
--- a/scripts/globals/mobskills/seismostomp.lua
+++ b/scripts/globals/mobskills/seismostomp.lua
@@ -15,30 +15,20 @@ function onMobSkillCheck(target, mob, skill)
 end
 
 function onMobWeaponSkill(target, mob, skill)
-
     local numhits = 1
     local accmod = 1
     local dmgmod = 2.3
 
-    if (mob:isMobType(MOBTYPE_NOTORIOUS)) then
+    if mob:isMobType(MOBTYPE_NOTORIOUS) then
         dmgmod = dmgmod + math.random()
     end
 
     local info = MobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, TP_NO_EFFECT)
-
-    local shadows = info.hitslanded
-
-    -- wipe shadows
-    if (mob:isMobType(MOBTYPE_NOTORIOUS)) then
-        shadows = MOBPARAM_WIPE_SHADOWS
-    end
-
-    local dmg = MobFinalAdjustments(info.dmg, mob, skill, target, tpz.attackType.PHYSICAL, tpz.damageType.BLUNT, shadows)
-
+    local shadows_removed = math.random(2)
+    local dmg = MobFinalAdjustments(info.dmg, mob, skill, target, tpz.attackType.PHYSICAL, tpz.damageType.BLUNT, shadows_removed)
     local typeEffect = tpz.effect.STUN
 
     MobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
-
     target:takeDamage(dmg, mob, tpz.attackType.PHYSICAL, tpz.damageType.BLUNT)
     return dmg
 end


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Previously this ability was wiping all shadows if the mob classified as an NM but that's not how it should work. Time Extensions also classify as "Notorious Monsters" so they were wiping all shadows with their Seismostomps. This fix corrects this and makes Seismostomp absorb either 1 or 2 shadows as shown in the video evidence below.

https://ffxiclopedia.fandom.com/wiki/Category:Simulacra
![Screenshot_184](https://user-images.githubusercontent.com/17558211/91667269-4d0d4080-ead1-11ea-84bb-00becb5b7239.png)

https://www.bg-wiki.com/bg/Mu%27Sha_Effigy
"Advisable for DDs to sub nin to absorb Seismostomp with Utsusemi as back to back use of this move can result in death" is on
most of the Dynamis statue NM pages. As well as the NM fought in the video evidence below.

Source video to show it absorbs 1-2 shadows randomly (watch the battle mod log with the NIN tank's shadows):
https://youtu.be/gEyhDflh_2g?t=1517

Thanks to Tankfest for help with this.




