### PR TITLE
Removes MDEF mod from Ahriman family

### DIFF
--- a/sql/mob_family_mods.sql
+++ b/sql/mob_family_mods.sql
@@ -38,7 +38,7 @@ CREATE TABLE `mob_family_mods` (
 LOCK TABLES `mob_family_mods` WRITE;
 /*!40000 ALTER TABLE `mob_family_mods` DISABLE KEYS */;
 INSERT INTO `mob_family_mods` VALUES (175,29,50,0);
-INSERT INTO `mob_family_mods` VALUES (4,29,25,0);
+INSERT INTO `mob_family_mods` VALUES (4,29,20,0);
 INSERT INTO `mob_family_mods` VALUES (4,7,60,1);
 INSERT INTO `mob_family_mods` VALUES (74,29,25,0);
 INSERT INTO `mob_family_mods` VALUES (61,29,25,0);
@@ -130,7 +130,6 @@ INSERT INTO `mob_family_mods` VALUES (481,41,988,1);
 INSERT INTO `mob_family_mods` VALUES (481,42,989,1);
 
 -- Adjust magic damage taken
-INSERT INTO `mob_family_mods` VALUES (4,389,-25,0);
 INSERT INTO `mob_family_mods` VALUES (112,389,25,0);
 INSERT INTO `mob_family_mods` VALUES (61,389,-25,0);
 INSERT INTO `mob_family_mods` VALUES (74,389,-25,0);


### PR DESCRIPTION
…T mod

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Fixes #259

Teo confirmed that on retail ahriman just have the -25% magic damage taken mod... MDEF can just be removed.