### PR TITLE
Fix Indomitable Spirit exploit and correct quest wait timer

### DIFF
--- a/scripts/zones/Rabao/npcs/Irmilant.lua
+++ b/scripts/zones/Rabao/npcs/Irmilant.lua
@@ -2,6 +2,7 @@
 -- Area: Rabao
 --  NPC: Irmilant
 -- Starts and Ends Quests: The Immortal Lu Shang and Indomitable Spirit
+-- !pos 3.78 9.54 56.21 247
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/settings")
@@ -24,15 +25,15 @@ end
 function onTrigger(player, npc)
     local Indomitable = player:getQuestStatus(OUTLANDS, tpz.quest.id.outlands.INDOMITABLE_SPIRIT)
     local ImmortalLuShang = player:getQuestStatus(OUTLANDS, tpz.quest.id.outlands.THE_IMMORTAL_LU_SHANG)
-    local realday = tonumber(os.date("%j")) -- %M for next minute, %j for next day
+    local indomitableTimer = player:getCharVar("IndomitableSpiritTimer")
 
     if player:hasItem(489) == true and (ImmortalLuShang == QUEST_AVAILABLE or ImmortalLuShang == QUEST_COMPLETED) then
         player:startEvent(77) --Offer the quest if the player has the broken rod
-    elseif player:hasKeyItem(tpz.ki.SERPENT_RUMORS) == true and (Indomitable == QUEST_AVAILABLE or Indomitable == QUEST_COMPLETED) then
+    elseif player:hasKeyItem(tpz.ki.SERPENT_RUMORS) == true and Indomitable == QUEST_AVAILABLE then
         player:startEvent(131) --Begins Indomitable Spirit
-    elseif (Indomitable == QUEST_ACCEPTED or Indomitable == QUEST_COMPLETED) and realday == player:getCharVar("IndomitableSpiritVar") then
-        player:startEvent(133) --Asks the player to wait
-    elseif (Indomitable == QUEST_ACCEPTED or Indomitable == QUEST_COMPLETED) and realday ~= player:getCharVar("IndomitableSpiritVar") then
+    elseif indomitableTimer ~= 0 and indomitableTimer == getConquestTally() then
+        player:startEvent(133) --Asks the player to wait (next CQ tally)
+    elseif indomitableTimer ~= 0 then
         player:startEvent(134) --Ends the Quest
     elseif Indomitable == QUEST_COMPLETED then
         player:startEvent(135) --Dialogue for those who have completed Indomitable Spirit
@@ -53,8 +54,8 @@ function onEventFinish(player, csid, option)
         player:addQuest(OUTLANDS, tpz.quest.id.outlands.INDOMITABLE_SPIRIT)
     elseif csid == 132 then
         player:confirmTrade()
-        player:setCharVar("IndomitableSpiritVar", os.date("%j")) -- %M for next minute, %j for next day
+        player:setCharVar("IndomitableSpiritTimer", getConquestTally()) -- Player must wait until next CQ tally
     elseif csid == 134 then
-        npcUtil.completeQuest(player, OUTLANDS, tpz.quest.id.outlands.INDOMITABLE_SPIRIT, {item=17011, fameArea=RABAO, fame=100, title=tpz.title.INDOMITABLE_FISHER})
+        npcUtil.completeQuest(player, OUTLANDS, tpz.quest.id.outlands.INDOMITABLE_SPIRIT, {item=17011, fameArea=RABAO, fame=100, title=tpz.title.INDOMITABLE_FISHER, var="IndomitableSpiritTimer"})
     end
 end


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Fixes #1057 

Fixes a logic error in his script that allowed players to double trigger this npc to get a free ebisu.

Also makes the timer respect next CQ, not next day as it was originally scripted.

Thanks to Lusiphur for reporting the issue and assisting with the fix ^.^

Testing:
```
1. Gave myself KI Serpent Rumors, ensured quest is not in log
2. Talked to Irmilant, he gave me the dialogue for quest accept, quest shows up in log now.
3. Talked to him several more times, did not give Ebisu as expected, always gives general dialogue.
4. Traded him Saber Shoot and Opal Silk, he correctly gave quest trade dialogue.  Received IndomitableSpiritTimer variable == 1599487200
5. Talked to several times, he always gives "Wait" dialogue.
6. I manually subtracted 1 from my charVar, IndomitableSpiritTimer, to simulate that I got my variable before this current CQ cycle
7. Talked to him again, received dialogue for quest complete, received ebisu rod, and quest shows completed in log.  charVar was cleared from database.
8. Talked to him many times again, always received new general dialogue for those that have completed this quest.
9. Tossed Ebisu rod I just got.
10. Traded the two items needed again, then repeated steps 5-8.
```