### PR TITLE
RoE - Phase 2!

### DIFF
--- a/scripts/globals/effects/healing.lua
+++ b/scripts/globals/effects/healing.lua
@@ -9,6 +9,7 @@ require("scripts/globals/quests")
 require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/zone")
+require("scripts/globals/roe")
 -----------------------------------
 
 function onEffectGain(target, effect)
@@ -50,10 +51,10 @@ function onEffectTick(target, effect)
                 target:addTP(HEALING_TP_CHANGE)
                 healHP = 10 + (healtime - 2) + target:getMod(tpz.mod.HPHEAL)
             end
-            
+
             -- Records of Eminence: Heal Without Using Magic
             if target:getEminenceProgress(4) and healHP > 0 and target:getHPP() < 100 then
-                npcUtil.completeRecord(target, 4, { sparks = 100, xp = 500 })
+                tpz.roe.onRecordTrigger(target, 4)
             end
 
             target:addHP(healHP)

--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -9,6 +9,7 @@ require("scripts/globals/utils")
 require("scripts/globals/zone")
 require("scripts/globals/msg")
 require("scripts/globals/npc_util")
+require("scripts/globals/roe")
 -----------------------------------
 
 tpz = tpz or {}
@@ -39,20 +40,6 @@ function onMobDeathEx(mob, player, isKiller, isWeaponSkillKill)
         end
     end
 
-    if player:getEminenceProgress(2) then
-        npcUtil.completeRecord(player, 2, { sparks = 100, xp = 500 })
-    end
-
-    -- Vanquish Multiple Enemies I - Eminence Record Example
-    -- (Will be replaced by proper record check systems when implemented.)
-    if player:getEminenceProgress(12) and player:checkKillCredit(mob) then
-        local progress = player:getEminenceProgress(12) + 1
-        if progress >= 200 then
-            npcUtil.completeRecord(player, 12, { sparks = 1000, xp = 5000, repeatable = true })
-        else
-            player:setEminenceProgress(12, progress, 200)
-        end
-    end
 end
 
 -------------------------------------------------

--- a/scripts/globals/npc_util.lua
+++ b/scripts/globals/npc_util.lua
@@ -398,59 +398,6 @@ function npcUtil.completeQuest(player, area, quest, params)
     player:completeQuest(area, quest)
     return true
 end
---[[ *******************************************************************************
-    Complete a record of eminence.
-    If record rewards items, and the player cannot carry them, return false.
-    Otherwise, return true.
-
-    Example of usage with params (all params are optional):
-        npcUtil.completeRecord(player, record#, {
-            item = { {640,2}, 641 },    -- see npcUtil.giveItem for formats
-            keyItem = tpz.ki.ZERUHN_REPORT,    -- see npcUtil.giveKeyItem for formats
-            sparks = 500,
-            xp = 1000
-        })
-******************************************************************************* --]]
-function npcUtil.completeRecord(player, record, params)
-    params = params or {}
-
-    if params["item"] ~= nil then
-        if not npcUtil.giveItem(player, params["item"]) then
-            return false
-        end
-    end
-
-    player:messageBasic(tpz.msg.basic.ROE_COMPLETE,record)
-
-    if params["sparks"] ~= nil and type(params["sparks"]) == "number" then
-        local bonus = 1
-        if player:getEminenceCompleted(record) then
-            player:addCurrency('spark_of_eminence', params["sparks"] * bonus * SPARKS_RATE)
-            player:messageBasic(tpz.msg.basic.ROE_RECEIVE_SPARKS, params["sparks"] * SPARKS_RATE, player:getCurrency("spark_of_eminence"))
-        else
-            bonus = 3
-            player:addCurrency('spark_of_eminence', params["sparks"] * bonus * SPARKS_RATE)
-            player:messageBasic(tpz.msg.basic.ROE_FIRST_TIME_SPARKS, params["sparks"] * bonus * SPARKS_RATE, player:getCurrency("spark_of_eminence"))
-        end
-    end
-
-    if params["xp"] ~= nil and type(params["xp"]) == "number" then
-        player:addExp(params["xp"] * ROE_EXP_RATE)
-    end
-
-    if params["keyItem"] ~= nil then
-        npcUtil.giveKeyItem(player, params["keyItem"])
-    end
-
-    -- successfully complete the record
-    if params["repeatable"] then
-        player:messageBasic(tpz.msg.basic.ROE_REPEAT_OR_CANCEL)
-        player:setEminenceCompleted(record, 1)
-    else
-        player:setEminenceCompleted(record)
-    end
-    return true
-end
 
 --[[ *******************************************************************************
     check whether trade has all required items

--- a/scripts/globals/regimes.lua
+++ b/scripts/globals/regimes.lua
@@ -1219,12 +1219,12 @@ tpz.regime.bookOnEventFinish = function(player, option, regimeType)
 
             -- Records of Eminence: Undertake a FoV Training Regime
             if player:getEminenceProgress(3) and regimeType == tpz.regime.type.FIELDS then
-                npcUtil.completeRecord(player, 3, { sparks = 100, xp = 500 })
+                tpz.roe.onRecordTrigger(player, 3)
             end
 
             -- Records of Eminence: Undertake a GoV Training Regime
             if player:getEminenceProgress(11) and regimeType == tpz.regime.type.GROUNDS then
-                npcUtil.completeRecord(player, 11, { sparks = 100, xp = 500 })
+                tpz.roe.onRecordTrigger(player, 11)
             end
         end
     end

--- a/scripts/globals/roe.lua
+++ b/scripts/globals/roe.lua
@@ -134,7 +134,7 @@ end
 function tpz.roe.onRecordTrigger(player, recordID, params)
     local entry = tpz.roe.records[recordID]
     if entry and entry:check(player, params) then
-        local progress = player:getEminenceProgress(recordID) + entry.increment
+        local progress = params.progress + entry.increment
         if progress >= entry.goal then
             completeRecord(player, recordID, entry.reward)
         else
@@ -285,8 +285,7 @@ tpz.roe.records =
         reward = { sparks = 1000, xp = 5000 , item = { 6181 } },
         check = function(self, player, params)
                 if params.dmg and params.dmg > 0 then
-                    local progress = player:getEminenceProgress(29)
-                    player:setEminenceProgress(29, progress + params.dmg)
+                    params.progress = params.progress + params.dmg
                     return true
                 end
                 return false
@@ -300,8 +299,7 @@ tpz.roe.records =
         reward = { sparks = 3000, xp = 7000 , item = { 6184 } },
         check = function(self, player, params)
                 if params.dmg and params.dmg > 0 then
-                    local progress = player:getEminenceProgress(30)
-                    player:setEminenceProgress(30, progress + params.dmg)
+                    params.progress = params.progress + params.dmg
                     return true
                 end
                 return false
@@ -315,8 +313,7 @@ tpz.roe.records =
         reward = { sparks = 3000, xp = 7000 , item = { 6184 } },
         check = function(self, player, params)
                 if params.dmg and params.dmg > 0 then
-                    local progress = player:getEminenceProgress(696)
-                    player:setEminenceProgress(696, progress + params.dmg)
+                    params.progress = params.progress + params.dmg
                     return true
                 end
                 return false
@@ -330,8 +327,7 @@ tpz.roe.records =
         reward = { sparks = 1000, xp = 1000, item = { {8711, 2} } },
         check = function(self, player, params)
                 if params.dmg and params.dmg > 0 then
-                    local progress = player:getEminenceProgress(33)
-                    player:setEminenceProgress(33, progress + params.dmg)
+                    params.progress = params.progress + params.dmg
                     return true
                 end
                 return false
@@ -345,8 +341,7 @@ tpz.roe.records =
         reward = { sparks = 3000, xp = 5000, item = { {8711, 4} } },
         check = function(self, player, params)
                 if params.dmg and params.dmg > 0 then
-                    local progress = player:getEminenceProgress(34)
-                    player:setEminenceProgress(34, progress + params.dmg)
+                    params.progress = params.progress + params.dmg
                     return true
                 end
                 return false
@@ -360,8 +355,7 @@ tpz.roe.records =
         reward = { sparks = 3000, xp = 5000, item = { {8711, 6} } },
         check = function(self, player, params)
                 if params.dmg and params.dmg > 0 then
-                    local progress = player:getEminenceProgress(697)
-                    player:setEminenceProgress(697, progress + params.dmg)
+                    params.progress = params.progress + params.dmg
                     return true
                 end
                 return false

--- a/scripts/globals/roe.lua
+++ b/scripts/globals/roe.lua
@@ -12,7 +12,8 @@ tpz.roe.triggers =
     wsuse = 2,
     lootitem = 3,
     synthsuccess = 4,
-    
+    dmgtaken = 5,
+    dmgdealt = 6,
 }
 local triggers = tpz.roe.triggers
 
@@ -37,6 +38,14 @@ end
 
 checks.mobxp = function(self, player, params)  -- Mob yields xp
      return (params.mob and player:checkKillCredit(params.mob)) and true or false
+end
+
+checks.dmgmin = function(self, player, params)  -- Mob yields xp
+     return (params.dmg and params.dmg >= self.reqs.dmgmin) and true or false
+end
+
+checks.dmgmax = function(self, player, params)  -- Mob yields xp
+     return (params.dmg and params.dmg <= self.reqs.dmgmax) and true or false
 end
 
 checks.zone = function(self, player, params)  -- Player in Zone
@@ -186,6 +195,159 @@ tpz.roe.records =
         goal = 750,
         reqs = { mobxp = true },
         reward = { sparks = 5000, xp = 10000 , item = { 6183 } },
+    },
+
+    [16  ] = { -- Deal 500+ Damage
+        trigger = triggers.dmgdealt,
+        goal = 200,
+        reqs = { dmgmin = 500 },
+        reward = { sparks = 1000, xp = 5000, unity = 100, repeatable = true},
+    },
+
+    [17  ] = { -- Deal 1000+ Damage
+        trigger = triggers.dmgdealt,
+        goal = 150,
+        reqs = { dmgmin = 1000 },
+        reward = { sparks = 1000, xp = 5000 },
+    },
+
+    [18  ] = { -- Deal 1500+ Damage
+        trigger = triggers.dmgdealt,
+        goal = 100,
+        reqs = { dmgmin = 1500 },
+        reward = { sparks = 1000, xp = 5000 },
+    },
+
+    [698 ] = { -- Deal 2000+ Damage
+        trigger = triggers.dmgdealt,
+        goal = 100,
+        reqs = { dmgmin = 2000 },
+        reward = { sparks = 2000, xp = 5000, item = { {8711, 6} } },
+    },
+
+    [19  ] = { -- Deal 10-20 Damage
+        trigger = triggers.dmgdealt,
+        goal = 10,
+        reqs = { dmgmin = 10, dmgmax = 20 },
+        reward = { sparks = 300, xp = 2500 },
+    },
+
+    [20  ] = { -- Deal 110-120 Damage
+        trigger = triggers.dmgdealt,
+        goal = 10,
+        reqs = { dmgmin = 110, dmgmax = 120 },
+        reward = { sparks = 300, xp = 1500 },
+    },
+
+    [21  ] = { -- Deal 310-320 Damage
+        trigger = triggers.dmgdealt,
+        goal = 10,
+        reqs = { dmgmin = 310, dmgmax = 320 },
+        reward = { sparks = 300, xp = 1500 },
+    },
+
+    [22  ] = { -- Deal 510-520 Damage
+        trigger = triggers.dmgdealt,
+        goal = 10,
+        reqs = { dmgmin = 510, dmgmax = 520 },
+        reward = { sparks = 300, xp = 1500 },
+    },
+
+    [23  ] = { -- Deal 1110-1120 Damage
+        trigger = triggers.dmgdealt,
+        goal = 10,
+        reqs = { dmgmin = 1110, dmgmax = 1120 },
+        reward = { sparks = 300, xp = 1500, item = { {8711, 2} } },
+    },
+
+    [29  ] = { -- Total Damage I
+        trigger = triggers.dmgdealt,
+        goal = 100000,
+        increment = 0,
+        reward = { sparks = 1000, xp = 5000 , item = { 6181 } },
+        check = function(self, player, params)
+                if params.dmg and params.dmg > 0 then
+                    local progress = player:getEminenceProgress(29)
+                    player:setEminenceProgress(29, progress + params.dmg)
+                    return true
+                end
+                return false
+            end
+    },
+
+    [30  ] = { -- Total Damage II
+        trigger = triggers.dmgdealt,
+        goal = 200000,
+        increment = 0,
+        reward = { sparks = 3000, xp = 7000 , item = { 6184 } },
+        check = function(self, player, params)
+                if params.dmg and params.dmg > 0 then
+                    local progress = player:getEminenceProgress(30)
+                    player:setEminenceProgress(30, progress + params.dmg)
+                    return true
+                end
+                return false
+            end
+    },
+
+    [696 ] = { -- Total Damage III
+        trigger = triggers.dmgdealt,
+        goal = 300000,
+        increment = 0,
+        reward = { sparks = 3000, xp = 7000 , item = { 6184 } },
+        check = function(self, player, params)
+                if params.dmg and params.dmg > 0 then
+                    local progress = player:getEminenceProgress(696)
+                    player:setEminenceProgress(696, progress + params.dmg)
+                    return true
+                end
+                return false
+            end
+    },
+
+    [33  ] = { -- Total Damage Taken I
+        trigger = triggers.dmgtaken,
+        goal = 10000,
+        increment = 0,
+        reward = { sparks = 1000, xp = 1000, item = { {8711, 2} } },
+        check = function(self, player, params)
+                if params.dmg and params.dmg > 0 then
+                    local progress = player:getEminenceProgress(33)
+                    player:setEminenceProgress(33, progress + params.dmg)
+                    return true
+                end
+                return false
+            end
+    },
+
+    [34  ] = { -- Total Damage Taken II
+        trigger = triggers.dmgtaken,
+        goal = 20000,
+        increment = 0,
+        reward = { sparks = 3000, xp = 5000, item = { {8711, 4} } },
+        check = function(self, player, params)
+                if params.dmg and params.dmg > 0 then
+                    local progress = player:getEminenceProgress(34)
+                    player:setEminenceProgress(34, progress + params.dmg)
+                    return true
+                end
+                return false
+            end
+    },
+
+    [697 ] = { -- Total Damage Taken III
+        trigger = triggers.dmgtaken,
+        goal = 30000,
+        increment = 0,
+        reward = { sparks = 3000, xp = 5000, item = { {8711, 6} } },
+        check = function(self, player, params)
+                if params.dmg and params.dmg > 0 then
+                    local progress = player:getEminenceProgress(697)
+                    player:setEminenceProgress(697, progress + params.dmg)
+                    return true
+                end
+                return false
+            end
     },
 
     [45  ] = { -- Weapon Skills 1

--- a/scripts/globals/roe.lua
+++ b/scripts/globals/roe.lua
@@ -8,12 +8,12 @@ tpz.roe = tpz.roe or {}
 
 tpz.roe.triggers = 
 {
-    mobkill = 1,
-    wsuse = 2,
-    lootitem = 3,
-    synthsuccess = 4,
-    dmgtaken = 5,
-    dmgdealt = 6,
+    mobKill = 1,        -- Player kills a Mob (Counts for mobs killed by partymembers)
+    wSkillUse = 2,      -- Player Weapon skill used
+    itemLooted = 3,     -- Player successfully loots an item
+    synthSuccess = 4,   -- Player synth success
+    dmgTaken = 5,       -- Player takes Damage
+    dmgDealt = 6,       -- Player deals Damage
 }
 local triggers = tpz.roe.triggers
 
@@ -24,44 +24,44 @@ local checks = tpz.roe.checks
 -- Some functions may specify custom handlers (ie. gain exp or deal dmg.)
 checks.masterCheck = function(self, player, params)
     for func in pairs(self.reqs) do
-      if not checks[func](self, player, params) then
-          return false
-      end
+        if not checks[func] or not checks[func](self, player, params) then
+            return false
+        end
     end
     return true
 end
 
 
-checks.mob = function(self, player, params)    -- Mob ID check
+checks.mobID = function(self, player, params)    -- Mob ID check
     return (params.mob and self.reqs.mob[params.mob:getID()]) and true or false
 end
 
-checks.mobxp = function(self, player, params)  -- Mob yields xp
+checks.mobXP = function(self, player, params)  -- Mob yields xp
      return (params.mob and player:checkKillCredit(params.mob)) and true or false
 end
 
-checks.dmgmin = function(self, player, params)  -- Minimum Dmg Dealt/Taken
-     return (params.dmg and params.dmg >= self.reqs.dmgmin) and true or false
+checks.dmgMin = function(self, player, params)  -- Minimum Dmg Dealt/Taken
+     return (params.dmg and params.dmg >= self.reqs.dmgMin) and true or false
 end
 
-checks.dmgmax = function(self, player, params)  -- Maximum Dmg Dealt/Taken
-     return (params.dmg and params.dmg <= self.reqs.dmgmax) and true or false
+checks.dmgMax = function(self, player, params)  -- Maximum Dmg Dealt/Taken
+     return (params.dmg and params.dmg <= self.reqs.dmgMax) and true or false
 end
 
 checks.zone = function(self, player, params)  -- Player in Zone
      return (self.reqs.zone[player:getZoneID()]) and true or false
 end
 
-checks.notzone = function(self, player, params)  -- Player not in Zone
-     return (not self.reqs.zone[player:getZoneID()]) and true or false
+checks.zoneNot = function(self, player, params)  -- Player not in Zone
+     return (not self.reqs.zoneNot[player:getZoneID()]) and true or false
 end
 
-checks.itemid = function(self, player, params)  -- itemid in set
-     return (params.itemid and self.reqs.itemid[params.itemid]) and true or false
+checks.itemID = function(self, player, params)  -- itemid in set
+     return (params.itemid and self.reqs.itemID[params.itemid]) and true or false
 end
 
-checks.levelsync = function(self, player, params)  -- Player is Level Sync'd
-     return self.reqs.levelsync and player:isLevelSync() and true or false
+checks.levelSync = function(self, player, params)  -- Player is Level Sync'd
+     return self.reqs.levelSync and player:isLevelSync() and true or false
 end
 
 
@@ -160,7 +160,7 @@ tpz.roe.records =
     },
 
     [2   ] = { -- Vanquish 1 Enemy
-        trigger = triggers.mobkill,
+        trigger = triggers.mobKill,
         reward =  { sparks = 100, xp = 500}       
     },
 
@@ -181,105 +181,105 @@ tpz.roe.records =
   --------------------------------------------
     
     [12  ] = { -- Vanquish Multiple Enemies I - 200
-        trigger = triggers.mobkill,
+        trigger = triggers.mobKill,
         goal = 200,
-        reqs = { mobxp = true },
+        reqs = { mobXP = true },
         reward = { sparks = 1000, xp = 5000, unity = 100, repeatable = true },
     },
 
     [13  ] = { -- Vanquish Multiple Enemies II - 500
-        trigger = triggers.mobkill,
+        trigger = triggers.mobKill,
         goal = 500,
-        reqs = { mobxp = true },
+        reqs = { mobXP = true },
         reward = { sparks = 2000, xp = 6000 , item = { 6180 } },
     },
 
     [14  ] = { -- Vanquish Multiple Enemies III - 750
-        trigger = triggers.mobkill,
+        trigger = triggers.mobKill,
         goal = 750,
-        reqs = { mobxp = true },
+        reqs = { mobXP = true },
         reward = { sparks = 5000, xp = 10000 , item = { 6183 } },
     },
 
     [15  ] = { -- Level Sync to Vanquish I
-        trigger = triggers.mobkill,
+        trigger = triggers.mobKill,
         goal = 200,
-        reqs = { mobxp = true , levelsync = true},
+        reqs = { mobXP = true , levelSync = true},
         reward = { sparks = 2000, xp = 6000 , unity = 200 },
     },
 
     [117 ] = { -- Level Sync to Vanquish II
-        trigger = triggers.mobkill,
+        trigger = triggers.mobKill,
         goal = 20,
-        reqs = { mobxp = true , levelsync = true},
+        reqs = { mobXP = true , levelSync = true},
         reward = { sparks = 200, xp = 600 , unity = 20 , repeatable = true },
     },
 
     [16  ] = { -- Deal 500+ Damage
-        trigger = triggers.dmgdealt,
+        trigger = triggers.dmgDealt,
         goal = 200,
-        reqs = { dmgmin = 500 },
+        reqs = { dmgMin = 500 },
         reward = { sparks = 1000, xp = 5000, unity = 100, repeatable = true},
     },
 
     [17  ] = { -- Deal 1000+ Damage
-        trigger = triggers.dmgdealt,
+        trigger = triggers.dmgDealt,
         goal = 150,
-        reqs = { dmgmin = 1000 },
+        reqs = { dmgMin = 1000 },
         reward = { sparks = 1000, xp = 5000 },
     },
 
     [18  ] = { -- Deal 1500+ Damage
-        trigger = triggers.dmgdealt,
+        trigger = triggers.dmgDealt,
         goal = 100,
-        reqs = { dmgmin = 1500 },
+        reqs = { dmgMin = 1500 },
         reward = { sparks = 1000, xp = 5000 },
     },
 
     [698 ] = { -- Deal 2000+ Damage
-        trigger = triggers.dmgdealt,
+        trigger = triggers.dmgDealt,
         goal = 100,
-        reqs = { dmgmin = 2000 },
+        reqs = { dmgMin = 2000 },
         reward = { sparks = 2000, xp = 5000, item = { {8711, 6} } },
     },
 
     [19  ] = { -- Deal 10-20 Damage
-        trigger = triggers.dmgdealt,
+        trigger = triggers.dmgDealt,
         goal = 10,
-        reqs = { dmgmin = 10, dmgmax = 20 },
+        reqs = { dmgMin = 10, dmgMax = 20 },
         reward = { sparks = 300, xp = 2500 },
     },
 
     [20  ] = { -- Deal 110-120 Damage
-        trigger = triggers.dmgdealt,
+        trigger = triggers.dmgDealt,
         goal = 10,
-        reqs = { dmgmin = 110, dmgmax = 120 },
+        reqs = { dmgMin = 110, dmgMax = 120 },
         reward = { sparks = 300, xp = 1500 },
     },
 
     [21  ] = { -- Deal 310-320 Damage
-        trigger = triggers.dmgdealt,
+        trigger = triggers.dmgDealt,
         goal = 10,
-        reqs = { dmgmin = 310, dmgmax = 320 },
+        reqs = { dmgMin = 310, dmgMax = 320 },
         reward = { sparks = 300, xp = 1500 },
     },
 
     [22  ] = { -- Deal 510-520 Damage
-        trigger = triggers.dmgdealt,
+        trigger = triggers.dmgDealt,
         goal = 10,
-        reqs = { dmgmin = 510, dmgmax = 520 },
+        reqs = { dmgMin = 510, dmgMax = 520 },
         reward = { sparks = 300, xp = 1500 },
     },
 
     [23  ] = { -- Deal 1110-1120 Damage
-        trigger = triggers.dmgdealt,
+        trigger = triggers.dmgDealt,
         goal = 10,
-        reqs = { dmgmin = 1110, dmgmax = 1120 },
+        reqs = { dmgMin = 1110, dmgMax = 1120 },
         reward = { sparks = 300, xp = 1500, item = { {8711, 2} } },
     },
 
     [29  ] = { -- Total Damage I
-        trigger = triggers.dmgdealt,
+        trigger = triggers.dmgDealt,
         goal = 100000,
         increment = 0,
         reward = { sparks = 1000, xp = 5000 , item = { 6181 } },
@@ -294,7 +294,7 @@ tpz.roe.records =
     },
 
     [30  ] = { -- Total Damage II
-        trigger = triggers.dmgdealt,
+        trigger = triggers.dmgDealt,
         goal = 200000,
         increment = 0,
         reward = { sparks = 3000, xp = 7000 , item = { 6184 } },
@@ -309,7 +309,7 @@ tpz.roe.records =
     },
 
     [696 ] = { -- Total Damage III
-        trigger = triggers.dmgdealt,
+        trigger = triggers.dmgDealt,
         goal = 300000,
         increment = 0,
         reward = { sparks = 3000, xp = 7000 , item = { 6184 } },
@@ -324,7 +324,7 @@ tpz.roe.records =
     },
 
     [33  ] = { -- Total Damage Taken I
-        trigger = triggers.dmgtaken,
+        trigger = triggers.dmgTaken,
         goal = 10000,
         increment = 0,
         reward = { sparks = 1000, xp = 1000, item = { {8711, 2} } },
@@ -339,7 +339,7 @@ tpz.roe.records =
     },
 
     [34  ] = { -- Total Damage Taken II
-        trigger = triggers.dmgtaken,
+        trigger = triggers.dmgTaken,
         goal = 20000,
         increment = 0,
         reward = { sparks = 3000, xp = 5000, item = { {8711, 4} } },
@@ -354,7 +354,7 @@ tpz.roe.records =
     },
 
     [697 ] = { -- Total Damage Taken III
-        trigger = triggers.dmgtaken,
+        trigger = triggers.dmgTaken,
         goal = 30000,
         increment = 0,
         reward = { sparks = 3000, xp = 5000, item = { {8711, 6} } },
@@ -369,7 +369,7 @@ tpz.roe.records =
     },
 
     [45  ] = { -- Weapon Skills 1
-        trigger = triggers.wsuse,
+        trigger = triggers.wSkillUse,
         goal = 100,
         reward = { sparks = 500, xp = 2500 },
     },
@@ -379,7 +379,7 @@ tpz.roe.records =
   --------------------------------------------
 
     [57  ] = { -- Total Successful Synthesis Attempts
-        trigger = triggers.synthsuccess,
+        trigger = triggers.synthSuccess,
         goal = 30,
         reward = { sparks = 100, xp = 500, unity = 10, repeatable = true },
     },
@@ -389,58 +389,58 @@ tpz.roe.records =
   --------------------------------------------
 
     [71  ] = { -- Spoils - Fire Crystals
-        trigger = triggers.lootitem,
+        trigger = triggers.itemLooted,
         goal = 10,
-        reqs = { itemid = set{ 4096 } },
+        reqs = { itemID = set{ 4096 } },
         reward = { sparks = 200, xp = 1000, unity = 20, repeatable = true },
     },
 
     [72  ] = { -- Spoils - Ice Crystals
-        trigger = triggers.lootitem,
+        trigger = triggers.itemLooted,
         goal = 10,
-        reqs = { itemid = set{ 4097 } },
+        reqs = { itemID = set{ 4097 } },
         reward = { sparks = 200, xp = 1000, unity = 20, repeatable = true },
     },
 
     [73  ] = { -- Spoils - Wind Crystals
-        trigger = triggers.lootitem,
+        trigger = triggers.itemLooted,
         goal = 10,
-        reqs = { itemid = set{ 4098 } },
+        reqs = { itemID = set{ 4098 } },
         reward = { sparks = 200, xp = 1000, unity = 20, repeatable = true },
     },
 
     [74  ] = { -- Spoils - Earth Crystals
-        trigger = triggers.lootitem,
+        trigger = triggers.itemLooted,
         goal = 10,
-        reqs = { itemid = set{ 4099 } },
+        reqs = { itemID = set{ 4099 } },
         reward = { sparks = 200, xp = 1000, unity = 20, repeatable = true },
     },
 
     [75  ] = { -- Spoils - Lightning Crystals
-        trigger = triggers.lootitem,
+        trigger = triggers.itemLooted,
         goal = 10,
-        reqs = { itemid = set{ 4100 } },
+        reqs = { itemID = set{ 4100 } },
         reward = { sparks = 200, xp = 1000, unity = 20, repeatable = true },
     },
 
     [76  ] = { -- Spoils - Water Crystals
-        trigger = triggers.lootitem,
+        trigger = triggers.itemLooted,
         goal = 10,
-        reqs = { itemid = set{ 4101 } },
+        reqs = { itemID = set{ 4101 } },
         reward = { sparks = 200, xp = 1000, unity = 20, repeatable = true },
     },
 
     [77  ] = { -- Spoils - Light Crystals
-        trigger = triggers.lootitem,
+        trigger = triggers.itemLooted,
         goal = 10,
-        reqs = { itemid = set{ 4102 } },
+        reqs = { itemID = set{ 4102 } },
         reward = { sparks = 200, xp = 1000, unity = 20, repeatable = true },
     },
 
     [78  ] = { -- Spoils - Dark Crystals
-        trigger = triggers.lootitem,
+        trigger = triggers.itemLooted,
         goal = 10,
-        reqs = { itemid = set{ 4103 } },
+        reqs = { itemID = set{ 4103 } },
         reward = { sparks = 200, xp = 1000, unity = 20, repeatable = true },
     },
     
@@ -449,165 +449,165 @@ tpz.roe.records =
   ----------------------------------------
 
     [239 ] = { -- Conflict: Jugner Forest
-        trigger = triggers.mobkill,
+        trigger = triggers.mobKill,
         goal = 10,
         reqs = { zone = set{104} },
         reward = { sparks = 12, xp = 600, unity = 5, item = { {4381, 12} }, repeatable = true },
     },
 
     [240 ] = { -- Subjugation: King Arthro
-        trigger = triggers.mobkill,
-        reqs = { mob = set{17093094, 17203216} },
+        trigger = triggers.mobKill,
+        reqs = { mobID = set{17093094, 17203216} },
         reward = { sparks = 500, xp = 1000 },
     },
 
     [241 ] = { -- Conflict: Batallia Downs
-        trigger = triggers.mobkill,
+        trigger = triggers.mobKill,
         goal = 10,
         reqs = { zone = set{105} },
         reward = { sparks = 13, xp = 650, unity = 5, item = { 13685 }, repeatable = true },
     },
 
     [242 ] = { -- Subjugation: Lumber Jack
-        trigger = triggers.mobkill,
-        reqs = { mob = set{17207308, 17093074} },
+        trigger = triggers.mobKill,
+        reqs = { mobID = set{17207308, 17093074} },
         reward = { sparks = 500, xp = 1000 },
     },
 
     [243 ] = { -- Conflict: Eldieme Necropolis
-        trigger = triggers.mobkill,
+        trigger = triggers.mobKill,
         goal = 10,
         reqs = { zone = set{195} },
         reward = { sparks = 14, xp = 100, unity = 5, item = { 13198 }, repeatable = true },
     },
 
     [244 ] = { -- Subjugation: Cwn Cyrff
-        trigger = triggers.mobkill,
-        reqs = { mob = set{17093049, 17576054} },
+        trigger = triggers.mobKill,
+        reqs = { mobID = set{17093049, 17576054} },
         reward = { sparks = 250, xp = 800 },
     },
 
     [245 ] = { -- Conflict: Davoi
-        trigger = triggers.mobkill,
+        trigger = triggers.mobKill,
         goal = 10,
         reqs = { zone = set{149} },
         reward = { sparks = 13, xp = 650, unity = 5, item = { 12554 }, repeatable = true },
     },
 
     [246 ] = { -- Subjugation: Hawkeyed Dnatbat
-        trigger = triggers.mobkill,
-        reqs = { mob = set{17125433, 17387567} },
+        trigger = triggers.mobKill,
+        reqs = { mobID = set{17125433, 17387567} },
         reward = { sparks = 250, xp = 600 },
     },
 
     [247 ] = { -- Conflict: N. Gustaberg
-        trigger = triggers.mobkill,
+        trigger = triggers.mobKill,
         goal = 10,
         reqs = { zone = set{106} },
         reward = { sparks = 10, xp = 500, unity = 5, item = { 4488 }, repeatable = true },
     },
 
     [248 ] = { -- Subjugation: Maighdean Uaine
-        trigger = triggers.mobkill,
-        reqs = { mob = set{17211702, 17092912} },
+        trigger = triggers.mobKill,
+        reqs = { mobID = set{17211702, 17092912} },
         reward = { sparks = 250, xp = 500 },
     },
 
     [249 ] = { -- Conflict: S. Gustaberg
-        trigger = triggers.mobkill,
+        trigger = triggers.mobKill,
         goal = 10,
         reqs = { zone = set{107} },
         reward = { sparks = 10, xp = 500, unity = 5, item = { 12592 }, repeatable = true },
     },
 
     [250 ] = { -- Subjugation: Carnero
-        trigger = triggers.mobkill,
-        reqs = { mob = set{17092839, 17215613, 17215626} },
+        trigger = triggers.mobKill,
+        reqs = { mobID = set{17092839, 17215613, 17215626} },
         reward = { sparks = 250, xp = 500 },
     },
 
     [251 ] = { -- Conflict: Zeruhn Mines
-        trigger = triggers.mobkill,
+        trigger = triggers.mobKill,
         goal = 10,
         reqs = { zone = set{172} },
         reward = { sparks = 10, xp = 100, unity = 5, item = { 13335 }, repeatable = true },
     },
 
     [252 ] = { -- Conflict: Palborough Mines
-        trigger = triggers.mobkill,
+        trigger = triggers.mobKill,
         goal = 10,
         reqs = { zone = set{143} },
         reward = { sparks = 10, xp = 500, unity = 5, item = { 13330 }, repeatable = true },
     },
     
     [253 ] = { -- Subjugation: Zi-Ghi Bone-eater
-        trigger = triggers.mobkill,
-        reqs = { mob = set{17363208} },
+        trigger = triggers.mobKill,
+        reqs = { mobID = set{17363208} },
         reward = { sparks = 250, xp = 500 },
     },
 
     [254 ] = { -- Conflict: Dangruf Wadi
-        trigger = triggers.mobkill,
+        trigger = triggers.mobKill,
         goal = 10,
         reqs = { zone = set{191} },
         reward = { sparks = 10, xp = 100, unity = 5, item = { 13473 }, repeatable = true },
     },
 
     [255 ] = { -- Subjugation: Teporingo
-        trigger = triggers.mobkill,
-        reqs = { mob = set{17093017, 17559584} },
+        trigger = triggers.mobKill,
+        reqs = { mobID = set{17093017, 17559584} },
         reward = { sparks = 250, xp = 500 },
     },
 
     [256 ] = { -- Conflict: Pashhow Marshlands
-        trigger = triggers.mobkill,
+        trigger = triggers.mobKill,
         goal = 10,
         reqs = { zone = set{109} },
         reward = { sparks = 12, xp = 600, unity = 5, item = { {5721, 12} }, repeatable = true },
     },
 
     [257 ] = { -- Subjugation: Ni'Zho Bladebender
-        trigger = triggers.mobkill,
-        reqs = { mob = set{17223797} },
+        trigger = triggers.mobKill,
+        reqs = { mobID = set{17223797} },
         reward = { sparks = 250, xp = 700 },
     },
     
     [258 ] = { -- Conflict: Rolanberry Fields
-        trigger = triggers.mobkill,
+        trigger = triggers.mobKill,
         goal = 10,
         reqs = { zone = set{110} },
         reward = { sparks = 12, xp = 600, unity = 5, item = { 15487 }, repeatable = true },
     },
 
     [259 ] = { -- Subjugation: Simurgh
-        trigger = triggers.mobkill,
-        reqs = { mob = set{17228242, 17092905} },
+        trigger = triggers.mobKill,
+        reqs = { mobID = set{17228242, 17092905} },
         reward = { sparks = 250, xp = 1000 },
     },
     
     [260 ] = { -- Conflict: Crawler's Nest
-        trigger = triggers.mobkill,
+        trigger = triggers.mobKill,
         goal = 10,
         reqs = { zone = set{197} },
         reward = { sparks = 14, xp = 100, unity = 5, item = { 13271 }, repeatable = true },
     },
 
     [261 ] = { -- Subjugation: Demonic Tiphia
-        trigger = triggers.mobkill,
-        reqs = { mob = set{17093057, 17584398} },
+        trigger = triggers.mobKill,
+        reqs = { mobID = set{17093057, 17584398} },
         reward = { sparks = 250, xp = 800 },
     },
 
     [262 ] = { -- Conflict: Beadeaux
-        trigger = triggers.mobkill,
+        trigger = triggers.mobKill,
         goal = 10,
         reqs = { zone = set{147} },
         reward = { sparks = 13, xp = 650, unity = 5, item = { 13703 }, repeatable = true },
     },
 
     [263 ] = { -- Subjugation: Zo'Khu Blackcloud
-        trigger = triggers.mobkill,
-        reqs = { mob = set{17379564} },
+        trigger = triggers.mobKill,
+        reqs = { mobID = set{17379564} },
         reward = { sparks = 250, xp = 700 },
     },
 

--- a/scripts/globals/roe.lua
+++ b/scripts/globals/roe.lua
@@ -11,6 +11,8 @@ tpz.roe.triggers =
     mobkill = 1,
     wsuse = 2,
     lootitem = 3,
+    synthsuccess = 4,
+    
 }
 local triggers = tpz.roe.triggers
 
@@ -193,7 +195,17 @@ tpz.roe.records =
     },
 
   --------------------------------------------
-  -- Combat (Wide Area) -> Spoils I --
+  -- Crafting: General                      --
+  --------------------------------------------
+
+    [57  ] = { -- Total Successful Synthesis Attempts
+        trigger = triggers.synthsuccess,
+        goal = 30,
+        reward = { sparks = 100, xp = 500, unity = 10, repeatable = true },
+    },
+
+  --------------------------------------------
+  -- Combat (Wide Area) -> Spoils I         --
   --------------------------------------------
 
     [71  ] = { -- Spoils - Fire Crystals

--- a/scripts/globals/roe.lua
+++ b/scripts/globals/roe.lua
@@ -40,11 +40,11 @@ checks.mobxp = function(self, player, params)  -- Mob yields xp
      return (params.mob and player:checkKillCredit(params.mob)) and true or false
 end
 
-checks.dmgmin = function(self, player, params)  -- Mob yields xp
+checks.dmgmin = function(self, player, params)  -- Minimum Dmg Dealt/Taken
      return (params.dmg and params.dmg >= self.reqs.dmgmin) and true or false
 end
 
-checks.dmgmax = function(self, player, params)  -- Mob yields xp
+checks.dmgmax = function(self, player, params)  -- Maximum Dmg Dealt/Taken
      return (params.dmg and params.dmg <= self.reqs.dmgmax) and true or false
 end
 
@@ -58,6 +58,10 @@ end
 
 checks.itemid = function(self, player, params)  -- itemid in set
      return (params.itemid and self.reqs.itemid[params.itemid]) and true or false
+end
+
+checks.levelsync = function(self, player, params)  -- Player is Level Sync'd
+     return self.reqs.levelsync and player:isLevelSync() and true or false
 end
 
 
@@ -195,6 +199,20 @@ tpz.roe.records =
         goal = 750,
         reqs = { mobxp = true },
         reward = { sparks = 5000, xp = 10000 , item = { 6183 } },
+    },
+
+    [15  ] = { -- Level Sync to Vanquish I
+        trigger = triggers.mobkill,
+        goal = 200,
+        reqs = { mobxp = true , levelsync = true},
+        reward = { sparks = 2000, xp = 6000 , unity = 200 },
+    },
+
+    [117 ] = { -- Level Sync to Vanquish II
+        trigger = triggers.mobkill,
+        goal = 20,
+        reqs = { mobxp = true , levelsync = true},
+        reward = { sparks = 200, xp = 600 , unity = 20 , repeatable = true },
     },
 
     [16  ] = { -- Deal 500+ Damage

--- a/scripts/globals/roe.lua
+++ b/scripts/globals/roe.lua
@@ -85,7 +85,7 @@ local defaults = {
         })
      *************************************************************************** --]]
 local function completeRecord(player, record, params)
-    params = params or {}
+    local params = params or {}
 
     if not player:getEminenceCompleted(record) and params["item"] then
         if not npcUtil.giveItem(player, params["item"]) then

--- a/scripts/globals/roe.lua
+++ b/scripts/globals/roe.lua
@@ -1,0 +1,436 @@
+------------------------------------
+-- Records of Eminence
+------------------------------------
+require("scripts/globals/status")
+
+tpz = tpz or {}
+tpz.roe = tpz.roe or {}
+
+tpz.roe.triggers = 
+{
+    mobkill = 1,
+    wsuse = 2,
+    lootitem = 3,
+}
+local triggers = tpz.roe.triggers
+
+tpz.roe.checks = {}
+local checks = tpz.roe.checks
+
+-- Main general check function for all-purpose use.
+-- Some functions may specify custom handlers (ie. gain exp or deal dmg.)
+checks.masterCheck = function(self, player, params)
+    for func in pairs(self.reqs) do
+      if not checks[func](self, player, params) then
+          return false
+      end
+    end
+    return true
+end
+
+
+checks.mob = function(self, player, params)    -- Mob ID check
+    return (params.mob and self.reqs.mob[params.mob:getID()]) and true or false
+end
+
+checks.mobxp = function(self, player, params)  -- Mob yields xp
+     return (params.mob and player:checkKillCredit(params.mob)) and true or false
+end
+
+checks.zone = function(self, player, params)  -- Player in Zone
+     return (self.reqs.zone[player:getZoneID()]) and true or false
+end
+
+checks.notzone = function(self, player, params)  -- Player not in Zone
+     return (not self.reqs.zone[player:getZoneID()]) and true or false
+end
+
+checks.itemid = function(self, player, params)  -- itemid in set
+     return (params.itemid and self.reqs.itemid[params.itemid]) and true or false
+end
+
+
+local defaults = {
+    check = checks.masterCheck, -- Check function should return true/false
+    increment = 1,              -- Amount to increment per successful check
+    goal = 1,                   -- Progress goal
+    reqs = {},                  -- Other requirements. List of function names from above, with required values.
+}
+
+--[[ **************************************************************************
+    Complete a record of eminence. This is for internal roe use only.
+    If record rewards items, and the player cannot carry them, return false.
+    Otherwise, return true.
+    Example of usage with params (all params are optional):
+        npcUtil.completeRecord(player, record#, {
+            item = { {640,2}, 641 },          -- see npcUtil.giveItem for formats (Only given on first completion)
+            keyItem = tpz.ki.ZERUHN_REPORT,   -- see npcUtil.giveKeyItem for formats
+            sparks = 500,
+            xp = 1000
+        })
+     *************************************************************************** --]]
+local function completeRecord(player, record, params)
+    params = params or {}
+
+    if not player:getEminenceCompleted(record) and params["item"] then
+        if not npcUtil.giveItem(player, params["item"]) then
+            player:messageBasic(tpz.msg.basic.ROE_UNABLE_BONUS_ITEM)
+            return false
+        end
+    end
+
+    player:messageBasic(tpz.msg.basic.ROE_COMPLETE,record)
+
+    if params["sparks"] ~= nil and type(params["sparks"]) == "number" then
+        local bonus = 1
+        if player:getEminenceCompleted(record) then
+            player:addCurrency('spark_of_eminence', params["sparks"] * bonus * SPARKS_RATE)
+            player:messageBasic(tpz.msg.basic.ROE_RECEIVE_SPARKS, params["sparks"] * SPARKS_RATE, player:getCurrency("spark_of_eminence"))
+        else
+            bonus = 3
+            player:addCurrency('spark_of_eminence', params["sparks"] * bonus * SPARKS_RATE)
+            player:messageBasic(tpz.msg.basic.ROE_FIRST_TIME_SPARKS, params["sparks"] * bonus * SPARKS_RATE, player:getCurrency("spark_of_eminence"))
+        end
+    end
+
+    if params["xp"] ~= nil and type(params["xp"]) == "number" then
+        player:addExp(params["xp"] * ROE_EXP_RATE)
+    end
+
+    if params["keyItem"] ~= nil then
+        npcUtil.giveKeyItem(player, params["keyItem"])
+    end
+
+    -- successfully complete the record
+    if params["repeatable"] then
+        player:messageBasic(tpz.msg.basic.ROE_REPEAT_OR_CANCEL)
+        player:setEminenceCompleted(record, 1)
+    else
+        player:setEminenceCompleted(record)
+    end
+    return true
+end
+
+
+-- *** onRecordTrigger is the primary entry point for all record calls. ***
+-- Even records which are completed through Lua scripts should point here and
+-- have record information entered in the table below. This keeps everything neat.
+
+function tpz.roe.onRecordTrigger(player, recordID, params)
+    local entry = tpz.roe.records[recordID]
+    if entry and entry:check(player, params) then
+        local progress = player:getEminenceProgress(recordID) + entry.increment
+        if progress >= entry.goal then
+            completeRecord(player, recordID, entry.reward)
+        else
+            player:setEminenceProgress(recordID, progress, entry.goal)
+        end
+    end
+end
+tpz.roe.completeRecord = tpz.roe.onRecordTrigger
+
+
+-- All implemented records must have their entries in this table.
+-- Records not in this table can't be taken.
+
+tpz.roe.records = 
+{
+
+  ----------------------------------------
+  -- Tutorial -> Basics                 --
+  ----------------------------------------
+
+    [1   ] = { -- First Step Forward
+        reward =  { item = { {4376,6} }, keyItem = tpz.ki.MEMORANDOLL, sparks = 100, xp = 300 }
+    },
+
+    [2   ] = { -- Vanquish 1 Enemy
+        trigger = triggers.mobkill,
+        reward =  { sparks = 100, xp = 500}       
+    },
+
+    [3   ] = { -- Undertake a FoV Training Regime
+        reward =  { sparks = 100, xp = 500}       
+    },
+
+    [4   ] = { -- Heal without magic
+        reward =  { sparks = 100, xp = 500}       
+    },
+
+    [11  ] = { -- Undertake a GoV Training Regime
+        reward =  { sparks = 100, xp = 500}       
+    },
+    
+  --------------------------------------------
+  -- Combat (Wide Area) -> Combat (General) --
+  --------------------------------------------
+    
+    [12  ] = { -- Vanquish Multiple Enemies I - 200
+        trigger = triggers.mobkill,
+        goal = 200,
+        reqs = { mobxp = true },
+        reward = { sparks = 1000, xp = 5000, unity = 100, repeatable = true },
+    },
+
+    [13  ] = { -- Vanquish Multiple Enemies II - 500
+        trigger = triggers.mobkill,
+        goal = 500,
+        reqs = { mobxp = true },
+        reward = { sparks = 2000, xp = 6000 , item = { 6180 } },
+    },
+
+    [14  ] = { -- Vanquish Multiple Enemies III - 750
+        trigger = triggers.mobkill,
+        goal = 750,
+        reqs = { mobxp = true },
+        reward = { sparks = 5000, xp = 10000 , item = { 6183 } },
+    },
+
+    [45  ] = { -- Weapon Skills 1
+        trigger = triggers.wsuse,
+        goal = 100,
+        reward = { sparks = 500, xp = 2500 },
+    },
+
+  --------------------------------------------
+  -- Combat (Wide Area) -> Spoils I --
+  --------------------------------------------
+
+    [71  ] = { -- Spoils - Fire Crystals
+        trigger = triggers.lootitem,
+        goal = 10,
+        reqs = { itemid = set{ 4096 } },
+        reward = { sparks = 200, xp = 1000, unity = 20, repeatable = true },
+    },
+
+    [72  ] = { -- Spoils - Ice Crystals
+        trigger = triggers.lootitem,
+        goal = 10,
+        reqs = { itemid = set{ 4097 } },
+        reward = { sparks = 200, xp = 1000, unity = 20, repeatable = true },
+    },
+
+    [73  ] = { -- Spoils - Wind Crystals
+        trigger = triggers.lootitem,
+        goal = 10,
+        reqs = { itemid = set{ 4098 } },
+        reward = { sparks = 200, xp = 1000, unity = 20, repeatable = true },
+    },
+
+    [74  ] = { -- Spoils - Earth Crystals
+        trigger = triggers.lootitem,
+        goal = 10,
+        reqs = { itemid = set{ 4099 } },
+        reward = { sparks = 200, xp = 1000, unity = 20, repeatable = true },
+    },
+
+    [75  ] = { -- Spoils - Lightning Crystals
+        trigger = triggers.lootitem,
+        goal = 10,
+        reqs = { itemid = set{ 4100 } },
+        reward = { sparks = 200, xp = 1000, unity = 20, repeatable = true },
+    },
+
+    [76  ] = { -- Spoils - Water Crystals
+        trigger = triggers.lootitem,
+        goal = 10,
+        reqs = { itemid = set{ 4101 } },
+        reward = { sparks = 200, xp = 1000, unity = 20, repeatable = true },
+    },
+
+    [77  ] = { -- Spoils - Light Crystals
+        trigger = triggers.lootitem,
+        goal = 10,
+        reqs = { itemid = set{ 4102 } },
+        reward = { sparks = 200, xp = 1000, unity = 20, repeatable = true },
+    },
+
+    [78  ] = { -- Spoils - Dark Crystals
+        trigger = triggers.lootitem,
+        goal = 10,
+        reqs = { itemid = set{ 4103 } },
+        reward = { sparks = 200, xp = 1000, unity = 20, repeatable = true },
+    },
+    
+  ----------------------------------------
+  -- Combat (Region) - Original Areas 2 --
+  ----------------------------------------
+
+    [239 ] = { -- Conflict: Jugner Forest
+        trigger = triggers.mobkill,
+        goal = 10,
+        reqs = { zone = set{104} },
+        reward = { sparks = 12, xp = 600, unity = 5, item = { {4381, 12} }, repeatable = true },
+    },
+
+    [240 ] = { -- Subjugation: King Arthro
+        trigger = triggers.mobkill,
+        reqs = { mob = set{17093094, 17203216} },
+        reward = { sparks = 500, xp = 1000 },
+    },
+
+    [241 ] = { -- Conflict: Batallia Downs
+        trigger = triggers.mobkill,
+        goal = 10,
+        reqs = { zone = set{105} },
+        reward = { sparks = 13, xp = 650, unity = 5, item = { 13685 }, repeatable = true },
+    },
+
+    [242 ] = { -- Subjugation: Lumber Jack
+        trigger = triggers.mobkill,
+        reqs = { mob = set{17207308, 17093074} },
+        reward = { sparks = 500, xp = 1000 },
+    },
+
+    [243 ] = { -- Conflict: Eldieme Necropolis
+        trigger = triggers.mobkill,
+        goal = 10,
+        reqs = { zone = set{195} },
+        reward = { sparks = 14, xp = 100, unity = 5, item = { 13198 }, repeatable = true },
+    },
+
+    [244 ] = { -- Subjugation: Cwn Cyrff
+        trigger = triggers.mobkill,
+        reqs = { mob = set{17093049, 17576054} },
+        reward = { sparks = 250, xp = 800 },
+    },
+
+    [245 ] = { -- Conflict: Davoi
+        trigger = triggers.mobkill,
+        goal = 10,
+        reqs = { zone = set{149} },
+        reward = { sparks = 13, xp = 650, unity = 5, item = { 12554 }, repeatable = true },
+    },
+
+    [246 ] = { -- Subjugation: Hawkeyed Dnatbat
+        trigger = triggers.mobkill,
+        reqs = { mob = set{17125433, 17387567} },
+        reward = { sparks = 250, xp = 600 },
+    },
+
+    [247 ] = { -- Conflict: N. Gustaberg
+        trigger = triggers.mobkill,
+        goal = 10,
+        reqs = { zone = set{106} },
+        reward = { sparks = 10, xp = 500, unity = 5, item = { 4488 }, repeatable = true },
+    },
+
+    [248 ] = { -- Subjugation: Maighdean Uaine
+        trigger = triggers.mobkill,
+        reqs = { mob = set{17211702, 17092912} },
+        reward = { sparks = 250, xp = 500 },
+    },
+
+    [249 ] = { -- Conflict: S. Gustaberg
+        trigger = triggers.mobkill,
+        goal = 10,
+        reqs = { zone = set{107} },
+        reward = { sparks = 10, xp = 500, unity = 5, item = { 12592 }, repeatable = true },
+    },
+
+    [250 ] = { -- Subjugation: Carnero
+        trigger = triggers.mobkill,
+        reqs = { mob = set{17092839, 17215613, 17215626} },
+        reward = { sparks = 250, xp = 500 },
+    },
+
+    [251 ] = { -- Conflict: Zeruhn Mines
+        trigger = triggers.mobkill,
+        goal = 10,
+        reqs = { zone = set{172} },
+        reward = { sparks = 10, xp = 100, unity = 5, item = { 13335 }, repeatable = true },
+    },
+
+    [252 ] = { -- Conflict: Palborough Mines
+        trigger = triggers.mobkill,
+        goal = 10,
+        reqs = { zone = set{143} },
+        reward = { sparks = 10, xp = 500, unity = 5, item = { 13330 }, repeatable = true },
+    },
+    
+    [253 ] = { -- Subjugation: Zi-Ghi Bone-eater
+        trigger = triggers.mobkill,
+        reqs = { mob = set{17363208} },
+        reward = { sparks = 250, xp = 500 },
+    },
+
+    [254 ] = { -- Conflict: Dangruf Wadi
+        trigger = triggers.mobkill,
+        goal = 10,
+        reqs = { zone = set{191} },
+        reward = { sparks = 10, xp = 100, unity = 5, item = { 13473 }, repeatable = true },
+    },
+
+    [255 ] = { -- Subjugation: Teporingo
+        trigger = triggers.mobkill,
+        reqs = { mob = set{17093017, 17559584} },
+        reward = { sparks = 250, xp = 500 },
+    },
+
+    [256 ] = { -- Conflict: Pashhow Marshlands
+        trigger = triggers.mobkill,
+        goal = 10,
+        reqs = { zone = set{109} },
+        reward = { sparks = 12, xp = 600, unity = 5, item = { {5721, 12} }, repeatable = true },
+    },
+
+    [257 ] = { -- Subjugation: Ni'Zho Bladebender
+        trigger = triggers.mobkill,
+        reqs = { mob = set{17223797} },
+        reward = { sparks = 250, xp = 700 },
+    },
+    
+    [258 ] = { -- Conflict: Rolanberry Fields
+        trigger = triggers.mobkill,
+        goal = 10,
+        reqs = { zone = set{110} },
+        reward = { sparks = 12, xp = 600, unity = 5, item = { 15487 }, repeatable = true },
+    },
+
+    [259 ] = { -- Subjugation: Simurgh
+        trigger = triggers.mobkill,
+        reqs = { mob = set{17228242, 17092905} },
+        reward = { sparks = 250, xp = 1000 },
+    },
+    
+    [260 ] = { -- Conflict: Crawler's Nest
+        trigger = triggers.mobkill,
+        goal = 10,
+        reqs = { zone = set{197} },
+        reward = { sparks = 14, xp = 100, unity = 5, item = { 13271 }, repeatable = true },
+    },
+
+    [261 ] = { -- Subjugation: Demonic Tiphia
+        trigger = triggers.mobkill,
+        reqs = { mob = set{17093057, 17584398} },
+        reward = { sparks = 250, xp = 800 },
+    },
+
+    [262 ] = { -- Conflict: Beadeaux
+        trigger = triggers.mobkill,
+        goal = 10,
+        reqs = { zone = set{147} },
+        reward = { sparks = 13, xp = 650, unity = 5, item = { 13703 }, repeatable = true },
+    },
+
+    [263 ] = { -- Subjugation: Zo'Khu Blackcloud
+        trigger = triggers.mobkill,
+        reqs = { mob = set{17379564} },
+        reward = { sparks = 250, xp = 700 },
+    },
+
+}
+
+ -- Apply defaults for records
+for i,v in pairs(tpz.roe.records) do
+    setmetatable(v, { __index = defaults })
+end
+
+ -- Register triggers
+for i,v in pairs(tpz.roe.triggers) do
+    RoeRegisterHandler(v)
+end
+
+-- Build global map of implemented records.
+-- This is used to deny taking records which aren't implemented in the above table.
+RoeParseRecords(tpz.roe.records)

--- a/scripts/zones/Bastok_Markets/npcs/Isakoth.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Isakoth.lua
@@ -7,6 +7,7 @@ require("scripts/globals/msg")
 require("scripts/globals/keyitems")
 require("scripts/globals/sparkshop")
 require("scripts/globals/npc_util")
+require("scripts/globals/roe")
 local ID = require("scripts/zones/Bastok_Markets/IDs")
 
 function onTrade(player,npc,trade)
@@ -29,12 +30,7 @@ end
 
 function onEventFinish(player,csid,option)
     if csid == 24 and option == 1 then
-        npcUtil.completeRecord(player, 1, {
-            item = { {4376,6} },
-            keyItem = tpz.ki.MEMORANDOLL,
-            sparks = 100,
-            xp = 300
-        })
+        tpz.roe.onRecordTrigger(player, 1)
         player:messageBasic(tpz.msg.basic.ROE_BONUS_ITEM_PLURAL,4376,6)
     end
 end

--- a/scripts/zones/Southern_San_dOria/npcs/Rolandienne.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Rolandienne.lua
@@ -28,12 +28,7 @@ end
 
 function onEventFinish(player,csid,option)
     if csid == 993 and option == 1 then
-        npcUtil.completeRecord(player, 1, {
-            item = { {4376,6} },
-            keyItem = tpz.ki.MEMORANDOLL,
-            sparks = 100,
-            xp = 300
-        })
+        tpz.roe.onRecordTrigger(player, 1)
         player:messageBasic(tpz.msg.basic.ROE_BONUS_ITEM_PLURAL,4376,6)
     end
 end

--- a/scripts/zones/Western_Adoulin/npcs/Eternal_Flame.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Eternal_Flame.lua
@@ -28,12 +28,7 @@ end
 
 function onEventFinish(player,csid,option)
     if csid == 5079 and option == 1 then
-        npcUtil.completeRecord(player, 1, {
-            item = { {4376,6} },
-            keyItem = tpz.ki.MEMORANDOLL,
-            sparks = 100,
-            xp = 300
-        })
+        tpz.roe.onRecordTrigger(player, 1)
         player:messageBasic(tpz.msg.basic.ROE_BONUS_ITEM_PLURAL,4376,6)
     end
 end

--- a/scripts/zones/Windurst_Woods/npcs/Fhelm_Jobeizat.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Fhelm_Jobeizat.lua
@@ -28,12 +28,7 @@ end
 
 function onEventFinish(player, csid, option)
     if csid == 848 and option == 1 then
-        npcUtil.completeRecord(player, 1, {
-            item = { {4376,6} },
-            keyItem = tpz.ki.MEMORANDOLL,
-            sparks = 100,
-            xp = 300
-        })
+        tpz.roe.onRecordTrigger(player, 1)
         player:messageBasic(tpz.msg.basic.ROE_BONUS_ITEM_PLURAL, 4376, 6)
     end
 end

--- a/src/map/ai/controllers/player_controller.cpp
+++ b/src/map/ai/controllers/player_controller.cpp
@@ -33,6 +33,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "../../latent_effect_container.h"
 #include "../../status_effect_container.h"
 #include "../../weapon_skill.h"
+#include "../../roe.h"
 
 CPlayerController::CPlayerController(CCharEntity* _PChar) :
     CController(_PChar)
@@ -191,6 +192,7 @@ bool CPlayerController::WeaponSkill(uint16 targid, uint16 wsid)
                 PChar->pushPacket(new CMessageBasicPacket(PChar, PTarget, 0, 0, MSGBASIC_CANNOT_SEE));
                 return false;
             }
+            roeutils::event(ROE_WSKILL_USE, PChar, RoeDatagram("mob", (CMobEntity*)PTarget));
 
             return CController::WeaponSkill(targid, wsid);
         }

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -24,26 +24,26 @@
 
 #include "battleentity.h"
 
-#include "../lua/luautils.h"
-#include "../utils/battleutils.h"
-#include "../items/item_weapon.h"
-#include "../status_effect_container.h"
-#include "../recast_container.h"
 #include "../ai/ai_container.h"
 #include "../ai/states/attack_state.h"
-#include "../ai/states/magic_state.h"
 #include "../ai/states/death_state.h"
-#include "../ai/states/raise_state.h"
-#include "../ai/states/inactive_state.h"
-#include "../ai/states/weaponskill_state.h"
 #include "../ai/states/despawn_state.h"
-#include "../roe.h"
+#include "../ai/states/inactive_state.h"
+#include "../ai/states/magic_state.h"
+#include "../ai/states/raise_state.h"
+#include "../ai/states/weaponskill_state.h"
 #include "../attack.h"
 #include "../attackround.h"
-#include "../weapon_skill.h"
+#include "../items/item_weapon.h"
+#include "../lua/luautils.h"
 #include "../packets/action.h"
+#include "../recast_container.h"
+#include "../roe.h"
+#include "../status_effect_container.h"
+#include "../utils/battleutils.h"
 #include "../utils/petutils.h"
 #include "../utils/puppetutils.h"
+#include "../weapon_skill.h"
 
 CBattleEntity::CBattleEntity()
 {
@@ -522,9 +522,9 @@ int32 CBattleEntity::takeDamage(int32 amount, CBattleEntity* attacker /* = nullp
     PAI->EventHandler.triggerListener("TAKE_DAMAGE", this, amount, attacker, (uint16)attackType, (uint16)damageType);
 
     //RoE Damage Taken Trigger
-    if(this->objtype == TYPE_PC)
+    if (this->objtype == TYPE_PC)
         roeutils::event(ROE_EVENT::ROE_DMGTAKEN, static_cast<CCharEntity*>(this), RoeDatagram("dmg", amount));
-    else if(PLastAttacker && PLastAttacker->objtype == TYPE_PC)
+    else if (PLastAttacker && PLastAttacker->objtype == TYPE_PC)
         roeutils::event(ROE_EVENT::ROE_DMGDEALT, static_cast<CCharEntity*>(attacker), RoeDatagram("dmg", amount));
 
     return addHP(-amount);

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -37,6 +37,7 @@
 #include "../ai/states/inactive_state.h"
 #include "../ai/states/weaponskill_state.h"
 #include "../ai/states/despawn_state.h"
+#include "../roe.h"
 #include "../attack.h"
 #include "../attackround.h"
 #include "../weapon_skill.h"
@@ -519,6 +520,13 @@ int32 CBattleEntity::takeDamage(int32 amount, CBattleEntity* attacker /* = nullp
 {
     PLastAttacker = attacker;
     PAI->EventHandler.triggerListener("TAKE_DAMAGE", this, amount, attacker, (uint16)attackType, (uint16)damageType);
+
+    //RoE Damage Taken Trigger
+    if(this->objtype == TYPE_PC)
+        roeutils::event(ROE_EVENT::ROE_DMGTAKEN, static_cast<CCharEntity*>(this), RoeDatagram("dmg", amount));
+    else if(PLastAttacker && PLastAttacker->objtype == TYPE_PC)
+        roeutils::event(ROE_EVENT::ROE_DMGDEALT, static_cast<CCharEntity*>(attacker), RoeDatagram("dmg", amount));
+
     return addHP(-amount);
 }
 
@@ -1624,6 +1632,7 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
                 }
 
                 actionTarget.param = battleutils::TakePhysicalDamage(this, PTarget, attack.GetAttackType(), attack.GetDamage(), attack.IsBlocked(), attack.GetWeaponSlot(), 1, attackRound.GetTAEntity(), true, true);
+
                 if (actionTarget.param < 0)
                 {
                     actionTarget.param = -(actionTarget.param);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -6740,6 +6740,12 @@ inline int32 CLuaBaseEntity::getEminenceProgress(lua_State *L)
 
     TPZ_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isnumber(L, 1));
 
+    if(m_PBaseEntity->objtype != TYPE_PC)
+    {
+        lua_pushnil(L);
+        return 1;
+    }
+
     CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
     uint16 recordID = (uint16)lua_tointeger(L, 1);
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -50,6 +50,7 @@
 #include "../mobskill.h"
 #include "../mob_spell_container.h"
 #include "../recast_container.h"
+#include "../roe.h"
 #include "../spell.h"
 #include "../status_effect_container.h"
 #include "../timetriggers.h"
@@ -6659,14 +6660,14 @@ inline int32 CLuaBaseEntity::setEminenceCompleted(lua_State *L)
 
     if (repeat)
     {
-        charutils::SetEminenceRecordProgress(PChar, recordID, 0);
+        roeutils::SetEminenceRecordProgress(PChar, recordID, 0);
     }
     else
     {
-        charutils::DelEminenceRecord(PChar, recordID);
+        roeutils::DelEminenceRecord(PChar, recordID);
     }
 
-    charutils::SetEminenceRecordCompletion(PChar, recordID, status);
+    roeutils::SetEminenceRecordCompletion(PChar, recordID, status);
 
     return 0;
 }
@@ -6688,7 +6689,7 @@ inline int32 CLuaBaseEntity::getEminenceCompleted(lua_State *L)
     CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
     uint16 recordID = (uint16)lua_tointeger(L, 1);
 
-    lua_pushboolean(L, (bool)charutils::GetEminenceRecordCompletion(PChar, recordID));
+    lua_pushboolean(L, (bool)roeutils::GetEminenceRecordCompletion(PChar, recordID));
 
     return 1;
 }
@@ -6712,7 +6713,7 @@ inline int32 CLuaBaseEntity::setEminenceProgress(lua_State *L)
     uint16 recordID = (uint16)lua_tointeger(L, 1);
     uint32 progress = (uint32)lua_tointeger(L, 2);
 
-    bool result = charutils::SetEminenceRecordProgress(PChar, recordID, progress);
+    bool result = roeutils::SetEminenceRecordProgress(PChar, recordID, progress);
     lua_pushboolean(L, result);
 
     uint32 total = lua_tointeger(L, 3);
@@ -6742,9 +6743,9 @@ inline int32 CLuaBaseEntity::getEminenceProgress(lua_State *L)
     CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
     uint16 recordID = (uint16)lua_tointeger(L, 1);
 
-    if(charutils::HasEminenceRecord(PChar, recordID))
+    if(roeutils::HasEminenceRecord(PChar, recordID))
     {
-        uint32 progress = charutils::GetEminenceRecordProgress(PChar, recordID);
+        uint32 progress = roeutils::GetEminenceRecordProgress(PChar, recordID);
         lua_pushinteger(L, progress);
     } else {
         lua_pushnil(L);
@@ -9174,6 +9175,27 @@ inline int32 CLuaBaseEntity::disableLevelSync(lua_State* L)
 
     PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, new CCharSyncPacket(PChar));
     return 0;
+}
+
+/************************************************************************
+*  Function: isLevelSync()
+*  Purpose :
+*  Example : player:isLevelSync()
+*  Notes   :
+************************************************************************/
+
+inline int32 CLuaBaseEntity::isLevelSync(lua_State* L)
+{
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+
+    CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
+
+    if (PChar->PParty)
+        lua_pushboolean(L, PChar->PParty->GetSyncTarget() != PChar);
+    else
+        lua_pushboolean(L, false);
+
+    return 1;
 }
 
 /************************************************************************
@@ -14677,6 +14699,7 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
 
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,reloadParty),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,disableLevelSync),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,isLevelSync),
 
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,checkSoloPartyAlliance),
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -9191,7 +9191,7 @@ inline int32 CLuaBaseEntity::isLevelSync(lua_State* L)
     CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
 
     if (PChar->PParty)
-        lua_pushboolean(L, PChar->PParty->GetSyncTarget() != PChar);
+        lua_pushboolean(L, (PChar->PParty->GetSyncTarget() && PChar->PParty->GetSyncTarget() != PChar) );
     else
         lua_pushboolean(L, false);
 

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -434,6 +434,7 @@ public:
 
     int32 reloadParty(lua_State* L);
     int32 disableLevelSync(lua_State* L);
+    int32 isLevelSync(lua_State* L);
 
     int32 checkSoloPartyAlliance(lua_State*);        // Check if Player is in Party or Alliance 0=Solo 1=Party 2=Alliance
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -47,6 +47,7 @@
 #include "../party.h"
 #include "../alliance.h"
 #include "../entities/mobentity.h"
+#include "../roe.h"
 #include "../spell.h"
 #include "../weapon_skill.h"
 #include "../vana_time.h"
@@ -2794,6 +2795,8 @@ namespace luautils
         TPZ_DEBUG_BREAK_IF(PMob == nullptr);
 
         CCharEntity* PChar = dynamic_cast<CCharEntity*>(PKiller);
+
+        roeutils::event(ROE_MOBKILL, (CCharEntity*)PKiller, RoeDatagram("mob", (CMobEntity*)PMob));
 
         if (PChar && PMob->objtype == TYPE_MOB)
         {

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -47,6 +47,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "packet_system.h"
 #include "party.h"
 #include "utils/petutils.h"
+#include "roe.h"
 #include "spell.h"
 #include "time_server.h"
 #include "transport.h"
@@ -222,6 +223,7 @@ int32 do_init(int32 argc, char** argv)
     battleutils::LoadSkillChainDamageModifiers();
     petutils::LoadPetList();
     mobutils::LoadCustomMods();
+    roeutils::init();
 
     ShowStatus("do_init: loading zones");
     zoneutils::LoadZoneList();

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -44,6 +44,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "utils/jailutils.h"
 #include "linkshell.h"
 #include "map.h"
+#include "roe.h"
 #include "entities/mobentity.h"
 #include "entities/npcentity.h"
 #include "entities/charentity.h"
@@ -6053,7 +6054,7 @@ void SmallPacket0x10B(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x10C(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
-    charutils::AddEminenceRecord(PChar, data.ref<uint32>(0x04));
+    roeutils::AddEminenceRecord(PChar, data.ref<uint32>(0x04));
     PChar->pushPacket(new CRoeSparkUpdatePacket(PChar));
     return;
 }
@@ -6066,7 +6067,7 @@ void SmallPacket0x10C(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x10D(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
-    charutils::DelEminenceRecord(PChar, data.ref<uint32>(0x04));
+    roeutils::DelEminenceRecord(PChar, data.ref<uint32>(0x04));
     PChar->pushPacket(new CRoeSparkUpdatePacket(PChar));
     return;
 }

--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -181,6 +181,11 @@ namespace roeutils
         return event(eventID, PChar, RoeDatagramList{ data });
     }
 
+    bool event(ROE_EVENT eventID, CCharEntity* PChar)  // shorthand for no-datagram calls.
+    {
+        return event(eventID, PChar, RoeDatagramList{});
+    }
+
     void SetEminenceRecordCompletion(CCharEntity* PChar, uint16 recordID, bool newStatus)
     {
         uint8 page = recordID / 8;

--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -111,6 +111,7 @@ namespace roeutils
 
             lua_pop(L, 1);
         }
+        ShowInfo("\nRoEUtils: %d record entries parsed & available.", RoeBitmaps.ImplementedRecords.count());
         return 0;
     }
 

--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -23,10 +23,10 @@
 */
 
 #include "../common/lua/lunar.h"
-#include <src/map/lua/luautils.h>
-#include <src/map/packets/chat_message.h>
-#include <src/map/roe.h>
-#include <src/map/utils/charutils.h>
+#include "lua/luautils.h"
+#include "packets/chat_message.h"
+#include "roe.h"
+#include "utils/charutils.h"
 
 #include "packets/roe_sparkupdate.h"
 #include "packets/roe_update.h"

--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -1,0 +1,310 @@
+/*
+ * roe.cpp
+ *      Author: Kreidos | github.com/kreidos
+ *
+===========================================================================
+
+  Copyright (c) 2020 Topaz Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "../common/lua/lunar.h"
+#include <src/map/lua/luautils.h>
+#include <src/map/packets/chat_message.h>
+#include <src/map/roe.h>
+#include <src/map/utils/charutils.h>
+
+#include "packets/roe_sparkupdate.h"
+#include "packets/roe_update.h"
+#include "packets/roe_questlog.h"
+
+std::array<RoeCheckHandler, ROE_NONE> RoeHandlers;
+RoeCache roeutils::RoeBitmaps;
+
+namespace roeutils
+{
+    void init()
+    {
+        lua_State* L = luautils::LuaHandle;
+        lua_register(L, "RoeRegisterHandler", roeutils::RegisterHandler);
+        lua_register(L, "RoeParseRecords", roeutils::ParseRecords);
+        RoeHandlers.fill(RoeCheckHandler());
+    }
+
+    int32 RegisterHandler(lua_State* L)
+    {
+        if (lua_gettop(L) < 1 || ! lua_isnumber(L, 1))
+        {
+            ShowError("ROEUtils: Invalid call to RegisterHandler.");
+        }
+
+        // Get Handler Event Type
+        auto event = lua_tointeger(L, 1);
+        if (event == 0 || event >= ROE_NONE)
+        {
+            ShowError("ROEUtils: Unknown Record trigger index %d.", event);
+            return 0;
+        }
+
+        RoeHandlers[event] = RoeCheckHandler();
+
+        // Build caching bitset from records
+        lua_getglobal(L, "tpz"); lua_getfield(L, -1, "roe"); lua_getfield(L, -1, "records");
+        lua_pushnil(L);
+        while(lua_next(L, -2) != 0)
+        {
+            lua_getfield(L, -1, "trigger");
+            uint32 recordID = lua_tointeger(L, -3);
+            uint32 trigger = lua_tointeger(L, -1);
+            lua_pop(L, 2);
+            if (trigger == event)
+                RoeHandlers[event].bitmap.set(recordID);
+        }
+
+//        ShowDebug("\nRegistered RoE Handler %d... ", evtype);
+
+        return 0;
+    }
+
+    int32 ParseRecords(lua_State* L)
+    {
+        roeutils::RoeBitmaps.ImplementedRecords.reset();
+        roeutils::RoeBitmaps.RepeatableRecords.reset();
+
+        if(lua_isnil(L, -1) || !lua_istable(L,-1))
+            return 0;
+
+        // Build caching bitsets from records
+        lua_pushnil(L);
+        while(lua_next(L, -2) != 0)
+        {
+            // Set Implemented bit.
+            uint32 recordID = lua_tointeger(L, -2);
+            roeutils::RoeBitmaps.ImplementedRecords.set(recordID);
+
+            // Set repeatability bit
+            lua_getfield(L, -1, "reward");
+            if(!lua_isnil(L, -1))
+            {
+                lua_getfield(L, -1, "repeatable");
+                if (lua_toboolean(L, -1))
+                {
+                    roeutils::RoeBitmaps.RepeatableRecords.set(recordID);
+                }
+                lua_pop(L, 1);
+            }
+            lua_pop(L, 1);
+
+            lua_pop(L, 1);
+        }
+        return 0;
+    }
+
+    bool event(ROE_EVENT eventID, CCharEntity* PChar, RoeDatagramList payload)
+    {
+        if(! PChar)
+        	return false;
+
+        RoeCheckHandler& handler = RoeHandlers[eventID];
+
+        // Bail if player has no records of this type.
+        if ((PChar->m_eminenceCache.activemap & handler.bitmap).none())
+            return 0;
+
+        lua_State* L = luautils::LuaHandle;
+        lua_getglobal(L, "tpz"); lua_getfield(L, -1, "roe");
+
+        // Call onRecordTrigger for each record of this type
+        for(int i = 0; PChar->m_eminenceLog.active[i] != 0; i++)
+        {
+            // Check record is of this type
+            if(handler.bitmap.test(PChar->m_eminenceLog.active[i]))
+            {
+                lua_getfield(L, -1, "onRecordTrigger");
+                uint8 args {0};
+
+                CLuaBaseEntity LuaAllyEntity(PChar);
+                Lunar<CLuaBaseEntity>::push(L, &LuaAllyEntity);
+                args++;
+
+                lua_pushinteger(L, PChar->m_eminenceLog.active[i]);
+                args++;
+
+                lua_newtable(L);
+                for (auto datagram: payload)
+                {
+                    lua_pushstring(L, datagram.param.c_str());
+                    switch(datagram.type)
+                    {
+                        case RoeDatagramPayload::mob:
+                        {
+                            CLuaBaseEntity LuaMobEntity((CMobEntity*)datagram.data.mobEntity);
+                            Lunar<CLuaBaseEntity>::push(L, &LuaMobEntity);
+                            break;
+                        }
+                        case RoeDatagramPayload::uinteger:
+                        {
+                            lua_pushinteger(L, datagram.data.uinteger);
+                            break;
+                        }
+                    }
+                    lua_settable(L, -3);
+                    args++;
+                }
+
+                if (lua_pcall(L, args, 0, 0))
+                {
+                    ShowError("roeutils::onRecordTrigger: %s\n", lua_tostring(L, -1));
+                    lua_pop(L, 1);
+                }
+            }
+        }
+        return true;
+    }
+
+    bool event(ROE_EVENT eventID, CCharEntity* PChar, RoeDatagram data)  // shorthand for single-datagram calls.
+    {
+        return event(eventID, PChar, RoeDatagramList{ data });
+    }
+
+    void SetEminenceRecordCompletion(CCharEntity* PChar, uint16 recordID, bool newStatus)
+    {
+        uint8 page = recordID / 8;
+        uint8 bit = recordID % 8;
+        if(newStatus)
+            PChar->m_eminenceLog.complete[page] |= (1 << bit);
+        else
+            PChar->m_eminenceLog.complete[page] &= ~(1 << bit);
+
+        for(int i = 0; i < 4; i++)
+        {
+            PChar->pushPacket(new CRoeQuestLogPacket(PChar, i));
+        }
+        charutils::SaveEminenceData(PChar);
+    }
+
+    bool GetEminenceRecordCompletion(CCharEntity* PChar, uint16 recordID)
+    {
+        uint8 page = recordID / 8;
+        uint8 bit = recordID % 8;
+        return PChar->m_eminenceLog.complete[page] & (1 << bit);
+    }
+
+    bool AddEminenceRecord(CCharEntity* PChar, uint16 recordID)
+    {
+        // TODO: Time limited records aren't implemented yet and can't be accepted normally.
+        //       For now we are refusing their IDs outright and protecting its slot from use here.
+        if(recordID > 2047)
+        {
+            std::string message = "Special Event/Timed Records can not be taken.";
+            PChar->pushPacket(new CChatMessagePacket(PChar, MESSAGE_NS_SAY, message, "RoE System") );
+            return false;
+        }
+
+        // We deny taking records which aren't implemented in the Lua
+        if(! roeutils::RoeBitmaps.ImplementedRecords.test(recordID))
+        {
+            std::string message = "The record #" + std::to_string(recordID) + " is not implemented at this time.";
+            PChar->pushPacket(new CChatMessagePacket(PChar, MESSAGE_NS_SAY, message, "RoE System") );
+            return false;
+        }
+
+        // Prevent packet-injection for re-taking completed records which aren't marked repeatable.
+        if(roeutils::GetEminenceRecordCompletion(PChar, recordID) && !roeutils::RoeBitmaps.RepeatableRecords.test(recordID))
+            return false;
+
+        // Per above, this i < 30 is correct.
+        for(int i = 0; i < 30; i++)
+        {
+            if(PChar->m_eminenceLog.active[i] == 0)
+            {
+                PChar->m_eminenceLog.active[i] = recordID;
+                PChar->m_eminenceCache.activemap.set(recordID);
+
+                PChar->pushPacket(new CRoeUpdatePacket(PChar));
+                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, recordID, 0, MSGBASIC_ROE_START));
+                charutils::SaveEminenceData(PChar);
+                return true;
+            }
+            else if(PChar->m_eminenceLog.active[i] == recordID)
+            {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    bool DelEminenceRecord(CCharEntity* PChar, uint16 recordID)
+    {
+        for(int i = 0; i < 31; i++)
+        {
+            if(PChar->m_eminenceLog.active[i] == recordID)
+            {
+                PChar->m_eminenceLog.active[i] = 0;
+                PChar->m_eminenceLog.progress[i] = 0;
+                PChar->m_eminenceCache.activemap.reset(recordID);
+                // Shift entries up so records are shown in retail-accurate order.
+                for(int j = i; j < 29 && PChar->m_eminenceLog.active[j+1] != 0; j++)
+                {
+                    std::swap(PChar->m_eminenceLog.active[j], PChar->m_eminenceLog.active[j+1]);
+                    std::swap(PChar->m_eminenceLog.progress[j], PChar->m_eminenceLog.progress[j+1]);
+                }
+                PChar->pushPacket(new CRoeUpdatePacket(PChar));
+                charutils::SaveEminenceData(PChar);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool HasEminenceRecord(CCharEntity* PChar, uint16 recordID)
+    {
+        return PChar->m_eminenceCache.activemap.test(recordID);
+    }
+
+    uint32 GetEminenceRecordProgress(CCharEntity* PChar, uint16 recordID)
+    {
+        for(int i = 0; i < 31; i++)
+        {
+            if(PChar->m_eminenceLog.active[i] == recordID)
+            {
+                return PChar->m_eminenceLog.progress[i];
+            }
+        }
+        return 0;
+    }
+
+    bool SetEminenceRecordProgress(CCharEntity* PChar, uint16 recordID, uint32 progress)
+    {
+        for(int i = 0; i < 31; i++)
+        {
+            if(PChar->m_eminenceLog.active[i] == recordID)
+            {
+                if(PChar->m_eminenceLog.progress[i] == progress)
+                    return true;
+
+                PChar->m_eminenceLog.progress[i] = progress;
+                PChar->pushPacket(new CRoeUpdatePacket(PChar));
+                charutils::SaveEminenceData(PChar);
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+} /* namespace roe */

--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -119,7 +119,7 @@ int32 ParseRecords(lua_State* L)
 
 bool event(ROE_EVENT eventID, CCharEntity* PChar, RoeDatagramList payload)
 {
-    if (!PChar)
+    if (!PChar || PChar->objtype != TYPE_PC)
         return false;
 
     RoeCheckHandler& handler = RoeHandlers[eventID];

--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -145,10 +145,17 @@ bool event(ROE_EVENT eventID, CCharEntity* PChar, RoeDatagramList payload)
             Lunar<CLuaBaseEntity>::push(L, &LuaAllyEntity);
             args++;
 
+            // Record #
             lua_pushinteger(L, PChar->m_eminenceLog.active[i]);
             args++;
 
+            // param table
             lua_newtable(L);
+            args++;
+
+            lua_pushinteger(L, PChar->m_eminenceLog.progress[i]);
+            lua_setfield(L, -2, "progress");
+
             for (auto& datagram : payload)
             {
                 lua_pushstring(L, datagram.param.c_str());
@@ -167,7 +174,6 @@ bool event(ROE_EVENT eventID, CCharEntity* PChar, RoeDatagramList payload)
                 }
                 }
                 lua_settable(L, -3);
-                args++;
             }
 
             if (lua_pcall(L, args, 0, 0))

--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -22,295 +22,297 @@
 ===========================================================================
 */
 
+#include "roe.h"
 #include "../common/lua/lunar.h"
 #include "lua/luautils.h"
 #include "packets/chat_message.h"
-#include "roe.h"
 #include "utils/charutils.h"
 
+#include "packets/roe_questlog.h"
 #include "packets/roe_sparkupdate.h"
 #include "packets/roe_update.h"
-#include "packets/roe_questlog.h"
 
 std::array<RoeCheckHandler, ROE_NONE> RoeHandlers;
 RoeCache roeutils::RoeBitmaps;
 
 namespace roeutils
 {
-    void init()
+void init()
+{
+    lua_State* L = luautils::LuaHandle;
+    lua_register(L, "RoeRegisterHandler", roeutils::RegisterHandler);
+    lua_register(L, "RoeParseRecords", roeutils::ParseRecords);
+    RoeHandlers.fill(RoeCheckHandler());
+}
+
+int32 RegisterHandler(lua_State* L)
+{
+    if (lua_gettop(L) < 1 || !lua_isnumber(L, 1))
     {
-        lua_State* L = luautils::LuaHandle;
-        lua_register(L, "RoeRegisterHandler", roeutils::RegisterHandler);
-        lua_register(L, "RoeParseRecords", roeutils::ParseRecords);
-        RoeHandlers.fill(RoeCheckHandler());
+        ShowError("ROEUtils: Invalid call to RegisterHandler.");
     }
 
-    int32 RegisterHandler(lua_State* L)
+    // Get Handler Event Type
+    auto event = lua_tointeger(L, 1);
+    if (event == 0 || event >= ROE_NONE)
     {
-        if (lua_gettop(L) < 1 || ! lua_isnumber(L, 1))
-        {
-            ShowError("ROEUtils: Invalid call to RegisterHandler.");
-        }
-
-        // Get Handler Event Type
-        auto event = lua_tointeger(L, 1);
-        if (event == 0 || event >= ROE_NONE)
-        {
-            ShowError("ROEUtils: Unknown Record trigger index %d.", event);
-            return 0;
-        }
-
-        RoeHandlers[event] = RoeCheckHandler();
-
-        // Build caching bitset from records
-        lua_getglobal(L, "tpz"); lua_getfield(L, -1, "roe"); lua_getfield(L, -1, "records");
-        lua_pushnil(L);
-        while(lua_next(L, -2) != 0)
-        {
-            lua_getfield(L, -1, "trigger");
-            uint32 recordID = lua_tointeger(L, -3);
-            uint32 trigger = lua_tointeger(L, -1);
-            lua_pop(L, 2);
-            if (trigger == event)
-                RoeHandlers[event].bitmap.set(recordID);
-        }
-
-//        ShowDebug("\nRegistered RoE Handler %d... ", evtype);
-
+        ShowError("ROEUtils: Unknown Record trigger index %d.", event);
         return 0;
     }
 
-    int32 ParseRecords(lua_State* L)
+    RoeHandlers[event] = RoeCheckHandler();
+
+    // Build caching bitset from records
+    lua_getglobal(L, "tpz");
+    lua_getfield(L, -1, "roe");
+    lua_getfield(L, -1, "records");
+    lua_pushnil(L);
+    while (lua_next(L, -2) != 0)
     {
-        roeutils::RoeBitmaps.ImplementedRecords.reset();
-        roeutils::RoeBitmaps.RepeatableRecords.reset();
+        lua_getfield(L, -1, "trigger");
+        uint32 recordID = lua_tointeger(L, -3);
+        uint32 trigger = lua_tointeger(L, -1);
+        lua_pop(L, 2);
+        if (trigger == event)
+            RoeHandlers[event].bitmap.set(recordID);
+    }
 
-        if(lua_isnil(L, -1) || !lua_istable(L,-1))
-            return 0;
+    //        ShowDebug("\nRegistered RoE Handler %d... ", evtype);
 
-        // Build caching bitsets from records
-        lua_pushnil(L);
-        while(lua_next(L, -2) != 0)
+    return 0;
+}
+
+int32 ParseRecords(lua_State* L)
+{
+    roeutils::RoeBitmaps.ImplementedRecords.reset();
+    roeutils::RoeBitmaps.RepeatableRecords.reset();
+
+    if (lua_isnil(L, -1) || !lua_istable(L, -1))
+        return 0;
+
+    // Build caching bitsets from records
+    lua_pushnil(L);
+    while (lua_next(L, -2) != 0)
+    {
+        // Set Implemented bit.
+        uint32 recordID = lua_tointeger(L, -2);
+        roeutils::RoeBitmaps.ImplementedRecords.set(recordID);
+
+        // Set repeatability bit
+        lua_getfield(L, -1, "reward");
+        if (!lua_isnil(L, -1))
         {
-            // Set Implemented bit.
-            uint32 recordID = lua_tointeger(L, -2);
-            roeutils::RoeBitmaps.ImplementedRecords.set(recordID);
-
-            // Set repeatability bit
-            lua_getfield(L, -1, "reward");
-            if(!lua_isnil(L, -1))
+            lua_getfield(L, -1, "repeatable");
+            if (lua_toboolean(L, -1))
             {
-                lua_getfield(L, -1, "repeatable");
-                if (lua_toboolean(L, -1))
+                roeutils::RoeBitmaps.RepeatableRecords.set(recordID);
+            }
+            lua_pop(L, 1);
+        }
+        lua_pop(L, 1);
+
+        lua_pop(L, 1);
+    }
+    // ShowInfo("\nRoEUtils: %d record entries parsed & available.", RoeBitmaps.ImplementedRecords.count());
+    return 0;
+}
+
+bool event(ROE_EVENT eventID, CCharEntity* PChar, RoeDatagramList payload)
+{
+    if (!PChar)
+        return false;
+
+    RoeCheckHandler& handler = RoeHandlers[eventID];
+
+    // Bail if player has no records of this type.
+    if ((PChar->m_eminenceCache.activemap & handler.bitmap).none())
+        return 0;
+
+    lua_State* L = luautils::LuaHandle;
+    lua_getglobal(L, "tpz");
+    lua_getfield(L, -1, "roe");
+
+    // Call onRecordTrigger for each record of this type
+    for (int i = 0; PChar->m_eminenceLog.active[i] != 0; i++)
+    {
+        // Check record is of this type
+        if (handler.bitmap.test(PChar->m_eminenceLog.active[i]))
+        {
+            lua_getfield(L, -1, "onRecordTrigger");
+            uint8 args { 0 };
+
+            CLuaBaseEntity LuaAllyEntity(PChar);
+            Lunar<CLuaBaseEntity>::push(L, &LuaAllyEntity);
+            args++;
+
+            lua_pushinteger(L, PChar->m_eminenceLog.active[i]);
+            args++;
+
+            lua_newtable(L);
+            for (auto& datagram : payload)
+            {
+                lua_pushstring(L, datagram.param.c_str());
+                switch (datagram.type)
                 {
-                    roeutils::RoeBitmaps.RepeatableRecords.set(recordID);
+                case RoeDatagramPayload::mob:
+                {
+                    CLuaBaseEntity LuaMobEntity(datagram.data.mobEntity);
+                    Lunar<CLuaBaseEntity>::push(L, &LuaMobEntity);
+                    break;
                 }
+                case RoeDatagramPayload::uinteger:
+                {
+                    lua_pushinteger(L, datagram.data.uinteger);
+                    break;
+                }
+                }
+                lua_settable(L, -3);
+                args++;
+            }
+
+            if (lua_pcall(L, args, 0, 0))
+            {
+                ShowError("roeutils::onRecordTrigger: %s\n", lua_tostring(L, -1));
                 lua_pop(L, 1);
             }
-            lua_pop(L, 1);
-
-            lua_pop(L, 1);
         }
-        ShowInfo("\nRoEUtils: %d record entries parsed & available.", RoeBitmaps.ImplementedRecords.count());
-        return 0;
     }
+    return true;
+}
 
-    bool event(ROE_EVENT eventID, CCharEntity* PChar, RoeDatagramList payload)
+bool event(ROE_EVENT eventID, CCharEntity* PChar, RoeDatagram data) // shorthand for single-datagram calls.
+{
+    return event(eventID, PChar, RoeDatagramList { data });
+}
+
+bool event(ROE_EVENT eventID, CCharEntity* PChar) // shorthand for no-datagram calls.
+{
+    return event(eventID, PChar, RoeDatagramList {});
+}
+
+void SetEminenceRecordCompletion(CCharEntity* PChar, uint16 recordID, bool newStatus)
+{
+    uint8 page = recordID / 8;
+    uint8 bit = recordID % 8;
+    if (newStatus)
+        PChar->m_eminenceLog.complete[page] |= (1 << bit);
+    else
+        PChar->m_eminenceLog.complete[page] &= ~(1 << bit);
+
+    for (int i = 0; i < 4; i++)
     {
-        if(! PChar)
-        	return false;
-
-        RoeCheckHandler& handler = RoeHandlers[eventID];
-
-        // Bail if player has no records of this type.
-        if ((PChar->m_eminenceCache.activemap & handler.bitmap).none())
-            return 0;
-
-        lua_State* L = luautils::LuaHandle;
-        lua_getglobal(L, "tpz"); lua_getfield(L, -1, "roe");
-
-        // Call onRecordTrigger for each record of this type
-        for(int i = 0; PChar->m_eminenceLog.active[i] != 0; i++)
-        {
-            // Check record is of this type
-            if(handler.bitmap.test(PChar->m_eminenceLog.active[i]))
-            {
-                lua_getfield(L, -1, "onRecordTrigger");
-                uint8 args {0};
-
-                CLuaBaseEntity LuaAllyEntity(PChar);
-                Lunar<CLuaBaseEntity>::push(L, &LuaAllyEntity);
-                args++;
-
-                lua_pushinteger(L, PChar->m_eminenceLog.active[i]);
-                args++;
-
-                lua_newtable(L);
-                for (auto& datagram: payload)
-                {
-                    lua_pushstring(L, datagram.param.c_str());
-                    switch(datagram.type)
-                    {
-                        case RoeDatagramPayload::mob:
-                        {
-                            CLuaBaseEntity LuaMobEntity(datagram.data.mobEntity);
-                            Lunar<CLuaBaseEntity>::push(L, &LuaMobEntity);
-                            break;
-                        }
-                        case RoeDatagramPayload::uinteger:
-                        {
-                            lua_pushinteger(L, datagram.data.uinteger);
-                            break;
-                        }
-                    }
-                    lua_settable(L, -3);
-                    args++;
-                }
-
-                if (lua_pcall(L, args, 0, 0))
-                {
-                    ShowError("roeutils::onRecordTrigger: %s\n", lua_tostring(L, -1));
-                    lua_pop(L, 1);
-                }
-            }
-        }
-        return true;
+        PChar->pushPacket(new CRoeQuestLogPacket(PChar, i));
     }
+    charutils::SaveEminenceData(PChar);
+}
 
-    bool event(ROE_EVENT eventID, CCharEntity* PChar, RoeDatagram data)  // shorthand for single-datagram calls.
+bool GetEminenceRecordCompletion(CCharEntity* PChar, uint16 recordID)
+{
+    uint8 page = recordID / 8;
+    uint8 bit = recordID % 8;
+    return PChar->m_eminenceLog.complete[page] & (1 << bit);
+}
+
+bool AddEminenceRecord(CCharEntity* PChar, uint16 recordID)
+{
+    // TODO: Time limited records aren't implemented yet and can't be accepted normally.
+    //       For now we are refusing their IDs outright and protecting its slot from use here.
+    if (recordID > 2047)
     {
-        return event(eventID, PChar, RoeDatagramList{ data });
-    }
-
-    bool event(ROE_EVENT eventID, CCharEntity* PChar)  // shorthand for no-datagram calls.
-    {
-        return event(eventID, PChar, RoeDatagramList{});
-    }
-
-    void SetEminenceRecordCompletion(CCharEntity* PChar, uint16 recordID, bool newStatus)
-    {
-        uint8 page = recordID / 8;
-        uint8 bit = recordID % 8;
-        if(newStatus)
-            PChar->m_eminenceLog.complete[page] |= (1 << bit);
-        else
-            PChar->m_eminenceLog.complete[page] &= ~(1 << bit);
-
-        for(int i = 0; i < 4; i++)
-        {
-            PChar->pushPacket(new CRoeQuestLogPacket(PChar, i));
-        }
-        charutils::SaveEminenceData(PChar);
-    }
-
-    bool GetEminenceRecordCompletion(CCharEntity* PChar, uint16 recordID)
-    {
-        uint8 page = recordID / 8;
-        uint8 bit = recordID % 8;
-        return PChar->m_eminenceLog.complete[page] & (1 << bit);
-    }
-
-    bool AddEminenceRecord(CCharEntity* PChar, uint16 recordID)
-    {
-        // TODO: Time limited records aren't implemented yet and can't be accepted normally.
-        //       For now we are refusing their IDs outright and protecting its slot from use here.
-        if(recordID > 2047)
-        {
-            std::string message = "Special Event/Timed Records can not be taken.";
-            PChar->pushPacket(new CChatMessagePacket(PChar, MESSAGE_NS_SAY, message, "RoE System") );
-            return false;
-        }
-
-        // We deny taking records which aren't implemented in the Lua
-        if(! roeutils::RoeBitmaps.ImplementedRecords.test(recordID))
-        {
-            std::string message = "The record #" + std::to_string(recordID) + " is not implemented at this time.";
-            PChar->pushPacket(new CChatMessagePacket(PChar, MESSAGE_NS_SAY, message, "RoE System") );
-            return false;
-        }
-
-        // Prevent packet-injection for re-taking completed records which aren't marked repeatable.
-        if(roeutils::GetEminenceRecordCompletion(PChar, recordID) && !roeutils::RoeBitmaps.RepeatableRecords.test(recordID))
-            return false;
-
-        // Per above, this i < 30 is correct.
-        for(int i = 0; i < 30; i++)
-        {
-            if(PChar->m_eminenceLog.active[i] == 0)
-            {
-                PChar->m_eminenceLog.active[i] = recordID;
-                PChar->m_eminenceCache.activemap.set(recordID);
-
-                PChar->pushPacket(new CRoeUpdatePacket(PChar));
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, recordID, 0, MSGBASIC_ROE_START));
-                charutils::SaveEminenceData(PChar);
-                return true;
-            }
-            else if(PChar->m_eminenceLog.active[i] == recordID)
-            {
-                return false;
-            }
-        }
+        std::string message = "Special Event/Timed Records can not be taken.";
+        PChar->pushPacket(new CChatMessagePacket(PChar, MESSAGE_NS_SAY, message, "RoE System"));
         return false;
     }
 
-    bool DelEminenceRecord(CCharEntity* PChar, uint16 recordID)
+    // We deny taking records which aren't implemented in the Lua
+    if (!roeutils::RoeBitmaps.ImplementedRecords.test(recordID))
     {
-        for(int i = 0; i < 31; i++)
-        {
-            if(PChar->m_eminenceLog.active[i] == recordID)
-            {
-                PChar->m_eminenceLog.active[i] = 0;
-                PChar->m_eminenceLog.progress[i] = 0;
-                PChar->m_eminenceCache.activemap.reset(recordID);
-                // Shift entries up so records are shown in retail-accurate order.
-                for(int j = i; j < 29 && PChar->m_eminenceLog.active[j+1] != 0; j++)
-                {
-                    std::swap(PChar->m_eminenceLog.active[j], PChar->m_eminenceLog.active[j+1]);
-                    std::swap(PChar->m_eminenceLog.progress[j], PChar->m_eminenceLog.progress[j+1]);
-                }
-                PChar->pushPacket(new CRoeUpdatePacket(PChar));
-                charutils::SaveEminenceData(PChar);
-                return true;
-            }
-        }
+        std::string message = "The record #" + std::to_string(recordID) + " is not implemented at this time.";
+        PChar->pushPacket(new CChatMessagePacket(PChar, MESSAGE_NS_SAY, message, "RoE System"));
         return false;
     }
 
-    bool HasEminenceRecord(CCharEntity* PChar, uint16 recordID)
-    {
-        return PChar->m_eminenceCache.activemap.test(recordID);
-    }
-
-    uint32 GetEminenceRecordProgress(CCharEntity* PChar, uint16 recordID)
-    {
-        for(int i = 0; i < 31; i++)
-        {
-            if(PChar->m_eminenceLog.active[i] == recordID)
-            {
-                return PChar->m_eminenceLog.progress[i];
-            }
-        }
-        return 0;
-    }
-
-    bool SetEminenceRecordProgress(CCharEntity* PChar, uint16 recordID, uint32 progress)
-    {
-        for(int i = 0; i < 31; i++)
-        {
-            if(PChar->m_eminenceLog.active[i] == recordID)
-            {
-                if(PChar->m_eminenceLog.progress[i] == progress)
-                    return true;
-
-                PChar->m_eminenceLog.progress[i] = progress;
-                PChar->pushPacket(new CRoeUpdatePacket(PChar));
-                charutils::SaveEminenceData(PChar);
-                return true;
-            }
-        }
+    // Prevent packet-injection for re-taking completed records which aren't marked repeatable.
+    if (roeutils::GetEminenceRecordCompletion(PChar, recordID) && !roeutils::RoeBitmaps.RepeatableRecords.test(recordID))
         return false;
-    }
 
+    // Per above, this i < 30 is correct.
+    for (int i = 0; i < 30; i++)
+    {
+        if (PChar->m_eminenceLog.active[i] == 0)
+        {
+            PChar->m_eminenceLog.active[i] = recordID;
+            PChar->m_eminenceCache.activemap.set(recordID);
+
+            PChar->pushPacket(new CRoeUpdatePacket(PChar));
+            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, recordID, 0, MSGBASIC_ROE_START));
+            charutils::SaveEminenceData(PChar);
+            return true;
+        }
+        else if (PChar->m_eminenceLog.active[i] == recordID)
+        {
+            return false;
+        }
+    }
+    return false;
+}
+
+bool DelEminenceRecord(CCharEntity* PChar, uint16 recordID)
+{
+    for (int i = 0; i < 31; i++)
+    {
+        if (PChar->m_eminenceLog.active[i] == recordID)
+        {
+            PChar->m_eminenceLog.active[i] = 0;
+            PChar->m_eminenceLog.progress[i] = 0;
+            PChar->m_eminenceCache.activemap.reset(recordID);
+            // Shift entries up so records are shown in retail-accurate order.
+            for (int j = i; j < 29 && PChar->m_eminenceLog.active[j + 1] != 0; j++)
+            {
+                std::swap(PChar->m_eminenceLog.active[j], PChar->m_eminenceLog.active[j + 1]);
+                std::swap(PChar->m_eminenceLog.progress[j], PChar->m_eminenceLog.progress[j + 1]);
+            }
+            PChar->pushPacket(new CRoeUpdatePacket(PChar));
+            charutils::SaveEminenceData(PChar);
+            return true;
+        }
+    }
+    return false;
+}
+
+bool HasEminenceRecord(CCharEntity* PChar, uint16 recordID)
+{
+    return PChar->m_eminenceCache.activemap.test(recordID);
+}
+
+uint32 GetEminenceRecordProgress(CCharEntity* PChar, uint16 recordID)
+{
+    for (int i = 0; i < 31; i++)
+    {
+        if (PChar->m_eminenceLog.active[i] == recordID)
+        {
+            return PChar->m_eminenceLog.progress[i];
+        }
+    }
+    return 0;
+}
+
+bool SetEminenceRecordProgress(CCharEntity* PChar, uint16 recordID, uint32 progress)
+{
+    for (int i = 0; i < 31; i++)
+    {
+        if (PChar->m_eminenceLog.active[i] == recordID)
+        {
+            if (PChar->m_eminenceLog.progress[i] == progress)
+                return true;
+
+            PChar->m_eminenceLog.progress[i] = progress;
+            PChar->pushPacket(new CRoeUpdatePacket(PChar));
+            charutils::SaveEminenceData(PChar);
+            return true;
+        }
+    }
+    return false;
+}
 
 } /* namespace roe */

--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -146,14 +146,14 @@ namespace roeutils
                 args++;
 
                 lua_newtable(L);
-                for (auto datagram: payload)
+                for (auto& datagram: payload)
                 {
                     lua_pushstring(L, datagram.param.c_str());
                     switch(datagram.type)
                     {
                         case RoeDatagramPayload::mob:
                         {
-                            CLuaBaseEntity LuaMobEntity((CMobEntity*)datagram.data.mobEntity);
+                            CLuaBaseEntity LuaMobEntity(datagram.data.mobEntity);
                             Lunar<CLuaBaseEntity>::push(L, &LuaMobEntity);
                             break;
                         }

--- a/src/map/roe.h
+++ b/src/map/roe.h
@@ -45,6 +45,8 @@ enum ROE_EVENT
     ROE_WSKILL_USE = 2,
     ROE_LOOTITEM = 3,
     ROE_SYNTHSUCCESS = 4,
+    ROE_DMGTAKEN = 5,
+    ROE_DMGDEALT = 6,
     ROE_NONE // End of enum marker and OOB checkpost. Do not move or remove, place any new types above.
 };
 

--- a/src/map/roe.h
+++ b/src/map/roe.h
@@ -44,6 +44,7 @@ enum ROE_EVENT
     ROE_MOBKILL = 1,
     ROE_WSKILL_USE = 2,
     ROE_LOOTITEM = 3,
+    ROE_SYNTHSUCCESS = 4,
     ROE_NONE // End of enum marker and OOB checkpost. Do not move or remove, place any new types above.
 };
 
@@ -100,6 +101,7 @@ namespace roeutils
 
     bool event(ROE_EVENT eventID, CCharEntity* PChar, RoeDatagramList payload);
     bool event(ROE_EVENT eventID, CCharEntity* PChar, RoeDatagram payload);
+    bool event(ROE_EVENT eventID, CCharEntity* PChar);
 
     void    SetEminenceRecordCompletion(CCharEntity* PChar, uint16 recordID, bool newStatus);
     bool    GetEminenceRecordCompletion(CCharEntity* PChar, uint16 recordID);

--- a/src/map/roe.h
+++ b/src/map/roe.h
@@ -1,0 +1,114 @@
+/*
+ * roe.h
+ *      Author: Kreidos | github.com/kreidos
+ *
+===========================================================================
+
+  Copyright (c) 2020 Topaz Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#ifndef SRC_MAP_ROE_H_
+#define SRC_MAP_ROE_H_
+
+#include <array>
+#include <bitset>
+#include <vector>
+
+#include "../common/cbasetypes.h"
+#include "ai/helpers/event_handler.h"
+#include "packets/weather.h"
+
+struct lua_State;
+
+class CItemContainer;
+
+class CBaseEntity;
+
+enum ROE_EVENT
+{
+    ROE_MOBKILL = 1,
+    ROE_WSKILL_USE = 2,
+    ROE_LOOTITEM = 3,
+    ROE_NONE // End of enum marker and OOB checkpost. Do not move or remove, place any new types above.
+};
+
+struct RoeCache
+{
+        std::bitset<4096> ImplementedRecords;
+        std::bitset<4096> RepeatableRecords;
+};
+
+struct RoeCheckHandler
+{
+    std::bitset<4096> bitmap;
+};
+
+extern std::array<RoeCheckHandler, ROE_NONE> RoeHandlers;
+
+enum class RoeDatagramPayload
+{
+    mob,
+    uinteger,
+};
+
+struct RoeDatagram
+{
+    RoeDatagramPayload type;
+    std::string param;
+    union data {
+        uint32 uinteger;
+        CMobEntity* mobEntity;
+        CItem* item;
+    } data;
+
+    RoeDatagram(std::string param, uint32 id){
+        this->type = RoeDatagramPayload::uinteger;
+        this->param = param;
+        this->data.uinteger = id;
+    }
+    RoeDatagram(std::string param, CMobEntity* PMob){
+        this->type = RoeDatagramPayload::mob;
+        this->param = param;
+        this->data.mobEntity = PMob;
+    }
+};
+
+typedef std::vector<RoeDatagram> RoeDatagramList;
+
+namespace roeutils
+{
+    extern RoeCache RoeBitmaps;
+
+    void init();
+    int32 RegisterHandler(lua_State* L);
+    int32 ParseRecords(lua_State* L);
+
+    bool event(ROE_EVENT eventID, CCharEntity* PChar, RoeDatagramList payload);
+    bool event(ROE_EVENT eventID, CCharEntity* PChar, RoeDatagram payload);
+
+    void    SetEminenceRecordCompletion(CCharEntity* PChar, uint16 recordID, bool newStatus);
+    bool    GetEminenceRecordCompletion(CCharEntity* PChar, uint16 recordID);
+    bool    AddEminenceRecord(CCharEntity* PChar, uint16 recordID);
+    bool    DelEminenceRecord(CCharEntity* PChar, uint16 recordID);
+    bool    HasEminenceRecord(CCharEntity* PChar, uint16 recordID);
+    bool    SetEminenceRecordProgress(CCharEntity* PChar, uint16 recordID, uint32 progress);
+    uint32  GetEminenceRecordProgress(CCharEntity* PChar, uint16 recordID);
+
+} /* namespace roe */
+
+#endif /* SRC_MAP_ROE_H_ */

--- a/src/map/roe.h
+++ b/src/map/roe.h
@@ -52,8 +52,8 @@ enum ROE_EVENT
 
 struct RoeCache
 {
-        std::bitset<4096> ImplementedRecords;
-        std::bitset<4096> RepeatableRecords;
+    std::bitset<4096> ImplementedRecords;
+    std::bitset<4096> RepeatableRecords;
 };
 
 struct RoeCheckHandler
@@ -79,12 +79,14 @@ struct RoeDatagram
         CItem* item;
     } data;
 
-    RoeDatagram(std::string param, uint32 id){
+    RoeDatagram(std::string param, uint32 id)
+    {
         this->type = RoeDatagramPayload::uinteger;
         this->param = param;
         this->data.uinteger = id;
     }
-    RoeDatagram(std::string param, CMobEntity* PMob){
+    RoeDatagram(std::string param, CMobEntity* PMob)
+    {
         this->type = RoeDatagramPayload::mob;
         this->param = param;
         this->data.mobEntity = PMob;
@@ -95,23 +97,23 @@ typedef std::vector<RoeDatagram> RoeDatagramList;
 
 namespace roeutils
 {
-    extern RoeCache RoeBitmaps;
+extern RoeCache RoeBitmaps;
 
-    void init();
-    int32 RegisterHandler(lua_State* L);
-    int32 ParseRecords(lua_State* L);
+void init();
+int32 RegisterHandler(lua_State* L);
+int32 ParseRecords(lua_State* L);
 
-    bool event(ROE_EVENT eventID, CCharEntity* PChar, RoeDatagramList payload);
-    bool event(ROE_EVENT eventID, CCharEntity* PChar, RoeDatagram payload);
-    bool event(ROE_EVENT eventID, CCharEntity* PChar);
+bool event(ROE_EVENT eventID, CCharEntity* PChar, RoeDatagramList payload);
+bool event(ROE_EVENT eventID, CCharEntity* PChar, RoeDatagram payload);
+bool event(ROE_EVENT eventID, CCharEntity* PChar);
 
-    void    SetEminenceRecordCompletion(CCharEntity* PChar, uint16 recordID, bool newStatus);
-    bool    GetEminenceRecordCompletion(CCharEntity* PChar, uint16 recordID);
-    bool    AddEminenceRecord(CCharEntity* PChar, uint16 recordID);
-    bool    DelEminenceRecord(CCharEntity* PChar, uint16 recordID);
-    bool    HasEminenceRecord(CCharEntity* PChar, uint16 recordID);
-    bool    SetEminenceRecordProgress(CCharEntity* PChar, uint16 recordID, uint32 progress);
-    uint32  GetEminenceRecordProgress(CCharEntity* PChar, uint16 recordID);
+void SetEminenceRecordCompletion(CCharEntity* PChar, uint16 recordID, bool newStatus);
+bool GetEminenceRecordCompletion(CCharEntity* PChar, uint16 recordID);
+bool AddEminenceRecord(CCharEntity* PChar, uint16 recordID);
+bool DelEminenceRecord(CCharEntity* PChar, uint16 recordID);
+bool HasEminenceRecord(CCharEntity* PChar, uint16 recordID);
+bool SetEminenceRecordProgress(CCharEntity* PChar, uint16 recordID, uint32 progress);
+uint32 GetEminenceRecordProgress(CCharEntity* PChar, uint16 recordID);
 
 } /* namespace roe */
 

--- a/src/map/treasure_pool.cpp
+++ b/src/map/treasure_pool.cpp
@@ -19,6 +19,7 @@
 ===========================================================================
 */
 
+#include "roe.h"
 #include "../common/showmsg.h"
 #include "../common/timer.h"
 
@@ -495,6 +496,8 @@ void CTreasurePool::TreasureWon(CCharEntity* winner, uint8 SlotID)
     TPZ_DEBUG_BREAK_IF(m_PoolItems[SlotID].ID == 0);
 
     m_PoolItems[SlotID].TimeStamp = get_server_start_time();
+    // TODO: ROE Item Gain (Variadic needed)
+    roeutils::event(ROE_EVENT::ROE_LOOTITEM, winner, RoeDatagram("itemid", m_PoolItems[SlotID].ID));
 
     for (uint32 i = 0; i < members.size(); ++i)
     {

--- a/src/map/treasure_pool.cpp
+++ b/src/map/treasure_pool.cpp
@@ -496,7 +496,7 @@ void CTreasurePool::TreasureWon(CCharEntity* winner, uint8 SlotID)
     TPZ_DEBUG_BREAK_IF(m_PoolItems[SlotID].ID == 0);
 
     m_PoolItems[SlotID].TimeStamp = get_server_start_time();
-    // TODO: ROE Item Gain (Variadic needed)
+
     roeutils::event(ROE_EVENT::ROE_LOOTITEM, winner, RoeDatagram("itemid", m_PoolItems[SlotID].ID));
 
     for (uint32 i = 0; i < members.size(); ++i)

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -26,6 +26,8 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "../../common/utils.h"
 
 #include <math.h>
+#include <src/map/packets/chat_message.h>
+#include <src/map/packets/roe_sparkupdate.h>
 #include <stdio.h>
 #include <string.h>
 #include <array>
@@ -61,9 +63,6 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "../packets/message_special.h"
 #include "../packets/message_standard.h"
 #include "../packets/quest_mission_log.h"
-#include "../packets/roe_sparkupdate.h"
-#include "../packets/roe_update.h"
-#include "../packets/roe_questlog.h"
 #include "../packets/server_ip.h"
 
 #include "../ability.h"
@@ -5020,112 +5019,6 @@ namespace charutils
 
         if (strcmp(type, "spark_of_eminence") == 0)
             PChar->pushPacket(new CRoeSparkUpdatePacket(PChar));
-    }
-
-    void SetEminenceRecordCompletion(CCharEntity* PChar, uint16 recordID, bool newStatus)
-    {
-        uint8 page = recordID / 8;
-        uint8 bit = recordID % 8;
-        if(newStatus)
-            PChar->m_eminenceLog.complete[page] |= (1 << bit);
-        else
-            PChar->m_eminenceLog.complete[page] &= ~(1 << bit);
-
-        for(int i = 0; i < 4; i++)
-        {
-            PChar->pushPacket(new CRoeQuestLogPacket(PChar, i));
-        }
-        charutils::SaveEminenceData(PChar);
-    }
-
-    bool GetEminenceRecordCompletion(CCharEntity* PChar, uint16 recordID)
-    {
-        uint8 page = recordID / 8;
-        uint8 bit = recordID % 8;
-        return PChar->m_eminenceLog.complete[page] & (1 << bit);
-    }
-
-    bool AddEminenceRecord(CCharEntity* PChar, uint16 recordID)
-    {
-        // TODO: Time limited records aren't implemented yet and can't be accepted normally.
-        //       For now we are refusing their IDs outright and protecting its slot from use here.
-        if(recordID > 2047)
-            return false;
-
-        // Per above, this i < 30 is correct.
-        for(int i = 0; i < 30; i++)
-        {
-            if(PChar->m_eminenceLog.active[i] == 0)
-            {
-                PChar->m_eminenceLog.active[i] = recordID;
-                PChar->m_eminenceCache.activemap.set(recordID);
-
-                PChar->pushPacket(new CRoeUpdatePacket(PChar));
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, recordID, 0, MSGBASIC_ROE_START));
-                SaveEminenceData(PChar);
-                return true;
-            }
-            else if(PChar->m_eminenceLog.active[i] == recordID)
-            {
-                return false;
-            }
-        }
-        return false;
-    }
-
-    bool DelEminenceRecord(CCharEntity* PChar, uint16 recordID)
-    {
-        for(int i = 0; i < 31; i++)
-        {
-            if(PChar->m_eminenceLog.active[i] == recordID)
-            {
-                PChar->m_eminenceLog.active[i] = 0;
-                PChar->m_eminenceLog.progress[i] = 0;
-                PChar->m_eminenceCache.activemap.reset(recordID);
-                // Shift entries up so records are shown in retail-accurate order.
-                for(int j = i; j < 29 && PChar->m_eminenceLog.active[j+1] != 0; j++)
-                {
-                    std::swap(PChar->m_eminenceLog.active[j], PChar->m_eminenceLog.active[j+1]);
-                    std::swap(PChar->m_eminenceLog.progress[j], PChar->m_eminenceLog.progress[j+1]);
-                }
-                PChar->pushPacket(new CRoeUpdatePacket(PChar));
-                charutils::SaveEminenceData(PChar);
-                return true;
-            }
-        }
-        return false;
-    }
-
-    bool HasEminenceRecord(CCharEntity* PChar, uint16 recordID)
-    {
-        return PChar->m_eminenceCache.activemap.test(recordID);
-    }
-
-    uint32 GetEminenceRecordProgress(CCharEntity* PChar, uint16 recordID)
-    {
-        for(int i = 0; i < 31; i++)
-        {
-            if(PChar->m_eminenceLog.active[i] == recordID)
-            {
-                return PChar->m_eminenceLog.progress[i];
-            }
-        }
-        return 0;
-    }
-
-    bool SetEminenceRecordProgress(CCharEntity* PChar, uint16 recordID, uint32 progress)
-    {
-        for(int i = 0; i < 31; i++)
-        {
-            if(PChar->m_eminenceLog.active[i] == recordID)
-            {
-                PChar->m_eminenceLog.progress[i] = progress;
-                PChar->pushPacket(new CRoeUpdatePacket(PChar));
-                charutils::SaveEminenceData(PChar);
-                return true;
-            }
-        }
-        return false;
     }
 
     int32 GetPoints(CCharEntity* PChar, const char* type)

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -26,8 +26,6 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "../../common/utils.h"
 
 #include <math.h>
-#include <src/map/packets/chat_message.h>
-#include <src/map/packets/roe_sparkupdate.h>
 #include <stdio.h>
 #include <string.h>
 #include <array>
@@ -63,6 +61,8 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "../packets/message_special.h"
 #include "../packets/message_standard.h"
 #include "../packets/quest_mission_log.h"
+#include "../packets/chat_message.h"
+#include "../packets/roe_sparkupdate.h"
 #include "../packets/server_ip.h"
 
 #include "../ability.h"

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -174,14 +174,6 @@ namespace charutils
     void	SavePlayTime(CCharEntity* PChar);							// Saves this characters total play time.
     bool	hasMogLockerAccess(CCharEntity* PChar);						// true if have access, false otherwise.
 
-    void    SetEminenceRecordCompletion(CCharEntity* PChar, uint16 recordID, bool newStatus);
-    bool    GetEminenceRecordCompletion(CCharEntity* PChar, uint16 recordID);
-    bool    AddEminenceRecord(CCharEntity* PChar, uint16 recordID);
-    bool    DelEminenceRecord(CCharEntity* PChar, uint16 recordID);
-    bool    HasEminenceRecord(CCharEntity* PChar, uint16 recordID);
-    bool    SetEminenceRecordProgress(CCharEntity* PChar, uint16 recordID, uint32 progress);
-    uint32  GetEminenceRecordProgress(CCharEntity* PChar, uint16 recordID);
-
     float  AddExpBonus(CCharEntity* PChar, float exp);
 
     void    RemoveAllEquipment(CCharEntity* PChar);

--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -41,6 +41,7 @@
 #include "../trade_container.h"
 #include "../vana_time.h"
 #include "../anticheat.h"
+#include "../roe.h"
 
 #include "charutils.h"
 #include "itemutils.h"
@@ -922,6 +923,7 @@ int32 doSynthResult(CCharEntity* PChar)
         {
             PChar->pushPacket(new CSynthMessagePacket(PChar, SYNTH_SUCCESS, itemID, quantity));
         }
+        roeutils::event(ROE_EVENT::ROE_SYNTHSUCCESS, PChar, RoeDatagram("itemid", itemID));
     }
 
     doSynthSkillUp(PChar);

--- a/win32/vcxproj/topaz_game.vcxproj
+++ b/win32/vcxproj/topaz_game.vcxproj
@@ -687,6 +687,8 @@
     <ClCompile Include="..\..\src\map\party.cpp" />
     <ClCompile Include="..\..\src\map\recast_container.cpp" />
     <ClCompile Include="..\..\src\map\region.cpp" />
+    <ClCompile Include="..\..\src\map\roe.h" />
+    <ClCompile Include="..\..\src\map\roe.cpp" />
     <ClCompile Include="..\..\src\map\spell.cpp" />
     <ClCompile Include="..\..\src\map\status_effect.cpp" />
     <ClCompile Include="..\..\src\map\status_effect_container.cpp" />


### PR DESCRIPTION
Where to even begin with this one?? This update has something for everyone, and beyond this point it's mostly a matter of adding more records. The core system should support all future phase 3 development desires. This leans into the more Lua-forward design methodologies under development through other PRs (1 short entry in the Lua table is very often all that's needed to completely implement a record.) while also allowing Core handling of trigger events and determining callback eligibility for greatest performance.

### What's new?!
- Highly flexible and Core RoE record + check handling system (roeutils)
- Dynamic (and optional) registration and automatic calling of record check functions from Core based on trigger conditions.
- ~~36~~ 54 new records of various types
- Records implemented in Lua are automatically tracked by Core, and unimplemented records can no longer be taken. (Message will be displayed saying so, with the record # if you want to help add it yourself)

#### What's adding a record look like?
Every record must have an entry in the `tpz.roe.records` table or players won't be able to take it; Core is called to scrub this table to determine which records are available. Even a minimal entry is sufficient, and all values are optional. Here's one table entry as an example.
```lua
    [71  ] = { -- Spoils - Fire Crystals
        trigger = triggers.lootitem,
        goal = 10,
        reqs = { itemid = set{ 4096 } },
        reward = { sparks = 200, xp = 1000, unity = 20, repeatable = true },
    },
```
**Trigger** - triggers are a way to register your record in core based on an event occurring. By selecting one, core will then call your function when a player *has* that trial active, and the appropriate event has actually occurred. This is optional, and many records which are manually handled through other Lua scripts and don't need core registration won't use one.
**Reqs** - Each key should be the name of a function in the tpz.roe.checks table. All must pass in order for the trial to be considered "successful" and any number of them (or none) can be specified.
**reward** - The only entry I consider "completely necessary". Table of reward parameters used when completed. See `completeRecord` in `roeutils` for all format options.
There are more additional parameters, support for custom inline/anon functions and default parameters available for advanced use.

#### Which records work?
It will tell you if you try and take records which aren't implemented and refuse, so try! The full list is anything in `tpz.roe.records` (roe.lua) but here's a few of the new ones:
- 95% of Combat (Wide Area)
- 100% of Combat (Region) -> Original Areas 2, (about 24 records)
- 33% of Spoils I -> (Loot crystals - 8 records)

#### And?
Probably a dozen more things I forgot to mention.
###### This space intentionally left blank





<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

