### PR TITLE
Fix Undying Promise BCNM loot spawn condition

### DIFF
--- a/scripts/zones/QuBia_Arena/mobs/Ghul-I-Beaban.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Ghul-I-Beaban.lua
@@ -15,9 +15,6 @@ function reraiseGhul(mob, reraises, target)
     if target then
         mob:updateClaim(target)
     end
-    if reraises == 4 then
-        mob:getBattlefield():setLocalVar("lootSpawned", 0)
-    end
 end
 
 function onMobInitialize(mob)
@@ -46,4 +43,7 @@ function onMobInitialize(mob)
 end
 
 function onMobDeath(mob, player, isKiller)
+    if mob:getLocalVar("RERAISES") == 4 then
+        mob:getBattlefield():setLocalVar("lootSpawned", 0)
+    end
 end


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Fixes #1044 

Chest doesn't spawn until the 5th and final skeleton is killed now.