### PR TITLE
Fix conditional logic in doesToolBreak and pickItem

### DIFF
--- a/scripts/globals/helm.lua
+++ b/scripts/globals/helm.lua
@@ -1321,7 +1321,7 @@ local function doesToolBreak(player, info)
         roll = roll + (player:getMod(mod) / 10)
     end
 
-    if roll < _G[info.settingBreak] then
+    if roll <= _G[info.settingBreak] then
         player:tradeComplete()
         return true
     end
@@ -1333,7 +1333,7 @@ function pickItem(player, info)
     local zoneId = player:getZoneID()
 
     -- found nothing
-    if math.random(100) >= _G[info.settingRate] then
+    if math.random(100) > _G[info.settingRate] then
         return 0
     end
 


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

I was just doing some HELM testing on my test server to ensure the mods were properly scripted for break rates, and I noticed a small issue with comparing the random roll to the player's break rate.

If you have break rate on the server set to 100%, there's a 1/100 chance that you would have NOT broken with the old script.  Similarly, for determining if the player got an item if item chance was set to 100%, there was a 1/100 chance the player would not receive an item.

Now at all setting possibilities, the break rate and item pick rate will function as intended.