### PR TITLE
Increase Serket rage timer to 30 minutes

### DIFF
--- a/scripts/zones/Garlaige_Citadel/mobs/Serket.lua
+++ b/scripts/zones/Garlaige_Citadel/mobs/Serket.lua
@@ -11,6 +11,10 @@ function onMobInitialize(mob)
     mob:setMobMod(tpz.mobMod.DRAW_IN, 1)
 end
 
+function onMobSpawn(mob)
+    mob:setLocalVar("[rage]timer", 1800) -- 30 minutes
+end
+
 function onMobDeath(mob, player, isKiller)
     player:addTitle(tpz.title.SERKET_BREAKER)
 end


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Serket rage timer currently defaults at 20 minutes, but it should be 30.
https://ffxiclopedia.fandom.com/wiki/Serket

Thanks to Eren@GoldSaucer for reporting.