### PR TITLE
CI Improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y software-properties-common clang-format-10 luajit-5.1-dev luarocks
+        sudo apt-get install -y software-properties-common clang-format luajit-5.1-dev luarocks
     - name: Lua Checks
       run: |
         sh travis_lua.sh
@@ -128,7 +128,9 @@ jobs:
         else
             echo "Problem with formatting!"
             echo "To fix this locally, run: git diff -U0 --no-color ${{ github.event.pull_request.base.ref }}..HEAD -- '*.cpp' '*.h' | clang-format-diff -p1 -i"
-
+            echo "Windows and Linux installation instructions for these tools are available here:"
+            echo "https://github.com/project-topaz/topaz/wiki/Developer-Workflow"
+            echo "" 
             echo "$diff" 
 
             exit -1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
         sh travis_lua.sh
     - name: Clang Format (C++ files)
       run: |
-        clang-format-10 --version
+        clang-format --version
         echo "Base Ref: ${{ github.event.pull_request.base.ref }}"
         echo "Base SHA: ${{ github.event.pull_request.base.sha }}"
         echo "Head Ref: ${{ github.event.pull_request.head.ref }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
         echo "Base SHA: ${{ github.event.pull_request.base.sha }}"
         echo "Head Ref: ${{ github.event.pull_request.head.ref }}"
         echo "Head SHA: ${{ github.event.pull_request.head.sha }}"
-        diff=`git diff -U0 --no-color ${{ github.event.pull_request.base.ref }}..HEAD -- '*.cpp' '*.h' | clang-format-diff -p1`
+        diff=`git diff -U0 --no-color ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} -- '*.cpp' '*.h' | clang-format-diff -p1`
 
         if [ -z "$diff" ]
         then
@@ -170,13 +170,7 @@ jobs:
           echo -e "Importing $f into the database..."
           mysql tpzdb -h 127.0.0.1 -uroot -proot < $f
         done
-    - name: Create account
-      run: |
-        mysql tpzdb -h 127.0.0.1 -uroot -proot -f -e "INSERT INTO accounts (`id`, `login`, `password`) VALUES (1, 'test', PASSWORD('test'));"
-        mysql tpzdb -h 127.0.0.1 -uroot -proot -f -e "INSERT INTO chars(charid, accid, charname, pos_zone, nation, gmlevel) VALUES(1, 1, 'Test', 139, 0, 5);"
-        mysql tpzdb -h 127.0.0.1 -uroot -proot -f -e "INSERT INTO char_look(charid, face, race, size) VALUES(1, 1, 1, 1);"
-        mysql tpzdb -h 127.0.0.1 -uroot -proot -f -e "INSERT INTO char_stats(charid, mjob, mlvl, sjob, slvl) VALUES(1, 4, 75, 3, 37);"
-        mysql tpzdb -h 127.0.0.1 -uroot -proot -f -e "UPDATE char_jobs SET blm = 75, whm = 37 WHERE charid = 1;"
+        mysql tpzdb -h 127.0.0.1 -uroot -proot -e "SHOW tables"
     - name: Copy confs
       run: |
         cp conf/default/* conf/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
           "%MSBUILD_PATH%\MSBuild.exe" win32/topaz.sln /property:Platform=x64
 
   Style_Checks:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: github.event_name == 'pull_request'
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,22 +113,23 @@ jobs:
     - name: Lua Checks
       run: |
         sh travis_lua.sh
-    - name: Clang Format
+    - name: Clang Format (C++ files)
       run: |
         clang-format-10 --version
+        echo "Base Ref: ${{ github.event.pull_request.base.ref }}"
         echo "Base SHA: ${{ github.event.pull_request.base.sha }}"
+        echo "Head Ref: ${{ github.event.pull_request.head.ref }}"
         echo "Head SHA: ${{ github.event.pull_request.head.sha }}"
-        diff=`git diff -U0 --no-color ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | clang-format-diff-10 -p1`
+        diff=`git diff -U0 --no-color ${{ github.event.pull_request.base.ref }}..${{ github.event.pull_request.head.ref }} -- '*.cpp' '*.h' | clang-format-diff -p1`
 
         if [ -z "$diff" ]
         then
             echo "Diff formatting looks good!"
         else
             echo "Problem with formatting!"
-            echo "To fix this locally, run: git diff -U0 --no-color base..HEAD | clang-format-diff-10 -p1 -i"
-            echo "Where replacing base with whatever branch your PR is targetting, ie. release"
+            echo "To fix this locally, run: git diff -U0 --no-color ${{ github.event.pull_request.base.ref }}..${{ github.event.pull_request.head.ref }} -- '*.cpp' '*.h' | clang-format-diff -p1 -i"
 
-            cat "$diff"
+            echo "$diff" 
 
             exit -1
         fi
@@ -167,6 +168,13 @@ jobs:
           echo -e "Importing $f into the database..."
           mysql tpzdb -h 127.0.0.1 -uroot -proot < $f
         done
+    - name: Create account
+      run: |
+        mysql tpzdb -h 127.0.0.1 -uroot -proot -f -e "INSERT INTO accounts (`id`, `login`, `password`) VALUES (1, 'test', PASSWORD('test'));"
+        mysql tpzdb -h 127.0.0.1 -uroot -proot -f -e "INSERT INTO chars(charid, accid, charname, pos_zone, nation, gmlevel) VALUES(1, 1, 'Test', 139, 0, 5);"
+        mysql tpzdb -h 127.0.0.1 -uroot -proot -f -e "INSERT INTO char_look(charid, face, race, size) VALUES(1, 1, 1, 1);"
+        mysql tpzdb -h 127.0.0.1 -uroot -proot -f -e "INSERT INTO char_stats(charid, mjob, mlvl, sjob, slvl) VALUES(1, 4, 75, 3, 37);"
+        mysql tpzdb -h 127.0.0.1 -uroot -proot -f -e "UPDATE char_jobs SET blm = 75, whm = 37 WHERE charid = 1;"
     - name: Copy confs
       run: |
         cp conf/default/* conf/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,14 +120,14 @@ jobs:
         echo "Base SHA: ${{ github.event.pull_request.base.sha }}"
         echo "Head Ref: ${{ github.event.pull_request.head.ref }}"
         echo "Head SHA: ${{ github.event.pull_request.head.sha }}"
-        diff=`git diff -U0 --no-color ${{ github.event.pull_request.base.ref }}..${{ github.event.pull_request.head.ref }} -- '*.cpp' '*.h' | clang-format-diff -p1`
+        diff=`git diff -U0 --no-color ${{ github.event.pull_request.base.ref }}..HEAD -- '*.cpp' '*.h' | clang-format-diff -p1`
 
         if [ -z "$diff" ]
         then
             echo "Diff formatting looks good!"
         else
             echo "Problem with formatting!"
-            echo "To fix this locally, run: git diff -U0 --no-color ${{ github.event.pull_request.base.ref }}..${{ github.event.pull_request.head.ref }} -- '*.cpp' '*.h' | clang-format-diff -p1 -i"
+            echo "To fix this locally, run: git diff -U0 --no-color ${{ github.event.pull_request.base.ref }}..HEAD -- '*.cpp' '*.h' | clang-format-diff -p1 -i"
 
             echo "$diff" 
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -4277,7 +4277,7 @@ namespace luautils
     {
         TPZ_DEBUG_BREAK_IF(lua_isnil(L, -1) || !lua_isnumber(L, -1));
 
-        uint32 id = lua_tointeger(L, 1);
+        uint32 id = static_cast<uint32>(lua_tointeger(L, 1));
         CItem* PItem = itemutils::GetItemPointer(id);
         if (PItem)
         {


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

I flipped the switch and swapped out travis and appveyeor for github actions and a couple of things have needed to be fixed:
- Make sure there are no stray bad-casts existing in `release`
- Make sure clang-format only looks at changes in cpp/h files