### PR TITLE
More Trust Checks

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4113,7 +4113,7 @@ namespace battleutils
                                 return;
                             }
                             CBattleEntity* highestClaim = mob->PEnmityContainer->GetHighestEnmity();
-                            if (highestClaim->objtype == TYPE_TRUST)
+                            if (highestClaim && highestClaim->objtype == TYPE_TRUST)
                             {
                                 highestClaim = static_cast<CTrustEntity*>(highestClaim)->PMaster;
                             }

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -579,8 +579,6 @@ void CZoneEntities::SpawnTRUSTs(CCharEntity* PChar)
                 }
             }
         }
-
-
     }
 }
 

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -556,28 +556,31 @@ void CZoneEntities::SpawnTRUSTs(CCharEntity* PChar)
 {
     for (EntityList_t::const_iterator it = m_trustList.begin(); it != m_trustList.end(); ++it)
     {
-        CTrustEntity* PCurrentTrust = (CTrustEntity*)it->second;
-        CCharEntity* master = (CCharEntity*)PCurrentTrust->PMaster;
-        SpawnIDList_t::iterator TRUST = PChar->SpawnTRUSTList.lower_bound(PCurrentTrust->id);
-
-        if (PCurrentTrust->status == STATUS_NORMAL &&
-            distance(PChar->loc.p, PCurrentTrust->loc.p) < 50)
+        if (CTrustEntity* PCurrentTrust = dynamic_cast<CTrustEntity*>(it->second))
         {
-            if (TRUST == PChar->SpawnTRUSTList.end() || PChar->SpawnTRUSTList.key_comp()(PCurrentTrust->id, TRUST->first))
+            CCharEntity* master = static_cast<CCharEntity*>(PCurrentTrust->PMaster);
+            SpawnIDList_t::iterator TRUST = PChar->SpawnTRUSTList.lower_bound(PCurrentTrust->id);
+
+            if (PCurrentTrust->status == STATUS_NORMAL && distance(PChar->loc.p, PCurrentTrust->loc.p) < 50)
             {
-                PChar->SpawnTRUSTList.insert(TRUST, SpawnIDList_t::value_type(PCurrentTrust->id, PCurrentTrust));
-                PChar->pushPacket(new CEntityUpdatePacket(PCurrentTrust, ENTITY_SPAWN, UPDATE_ALL_MOB));
-                PChar->pushPacket(new CTrustSyncPacket(master, PCurrentTrust));
+                if (TRUST == PChar->SpawnTRUSTList.end() || PChar->SpawnTRUSTList.key_comp()(PCurrentTrust->id, TRUST->first))
+                {
+                    PChar->SpawnTRUSTList.insert(TRUST, SpawnIDList_t::value_type(PCurrentTrust->id, PCurrentTrust));
+                    PChar->pushPacket(new CEntityUpdatePacket(PCurrentTrust, ENTITY_SPAWN, UPDATE_ALL_MOB));
+                    PChar->pushPacket(new CTrustSyncPacket(master, PCurrentTrust));
+                }
+            }
+            else
+            {
+                if (TRUST != PChar->SpawnTRUSTList.end() && !(PChar->SpawnTRUSTList.key_comp()(PCurrentTrust->id, TRUST->first)))
+                {
+                    PChar->SpawnTRUSTList.erase(TRUST);
+                    PChar->pushPacket(new CEntityUpdatePacket(PCurrentTrust, ENTITY_DESPAWN, UPDATE_NONE));
+                }
             }
         }
-        else {
-            if (TRUST != PChar->SpawnTRUSTList.end() &&
-                !(PChar->SpawnTRUSTList.key_comp()(PCurrentTrust->id, TRUST->first)))
-            {
-                PChar->SpawnTRUSTList.erase(TRUST);
-                PChar->pushPacket(new CEntityUpdatePacket(PCurrentTrust, ENTITY_DESPAWN, UPDATE_NONE));
-            }
-        }
+
+
     }
 }
 
@@ -1086,35 +1089,41 @@ void CZoneEntities::ZoneServer(time_point tick, bool check_regions)
     EntityList_t::const_iterator trustit = m_trustList.begin();
     while (trustit != m_trustList.end())
     {
-        CTrustEntity* PTrust = (CTrustEntity*)trustit->second;
-        PTrust->PRecastContainer->Check();
-        PTrust->StatusEffectContainer->CheckEffectsExpiry(tick);
-        if (tick > m_EffectCheckTime)
+        if (CTrustEntity* PTrust = dynamic_cast<CTrustEntity*>(trustit->second))
         {
-            PTrust->StatusEffectContainer->TickRegen(tick);
-            PTrust->StatusEffectContainer->TickEffects(tick);
-        }
-        PTrust->PAI->Tick(tick);
-        if (PTrust->status == STATUS_DISAPPEAR)
-        {
-            for (auto PMobIt : m_mobList)
+            PTrust->PRecastContainer->Check();
+            PTrust->StatusEffectContainer->CheckEffectsExpiry(tick);
+            if (tick > m_EffectCheckTime)
             {
-                CMobEntity* PCurrentMob = (CMobEntity*)PMobIt.second;
-                PCurrentMob->PEnmityContainer->Clear(PTrust->id);
+                PTrust->StatusEffectContainer->TickRegen(tick);
+                PTrust->StatusEffectContainer->TickEffects(tick);
             }
-
-            for (EntityList_t::const_iterator it = m_charList.begin(); it != m_charList.end(); ++it)
+            PTrust->PAI->Tick(tick);
+            if (PTrust->status == STATUS_DISAPPEAR)
             {
-                CCharEntity* PChar = (CCharEntity*)it->second;
-                if (distance(PChar->loc.p, PTrust->loc.p) < 50)
+                for (auto PMobIt : m_mobList)
                 {
-                    PChar->SpawnTRUSTList.erase(PTrust->id);
-                    PChar->ReloadPartyInc();
+                    CMobEntity* PCurrentMob = (CMobEntity*)PMobIt.second;
+                    PCurrentMob->PEnmityContainer->Clear(PTrust->id);
                 }
-            }
 
-            delete trustit->second;
-            m_trustList.erase(trustit++);
+                for (EntityList_t::const_iterator it = m_charList.begin(); it != m_charList.end(); ++it)
+                {
+                    CCharEntity* PChar = (CCharEntity*)it->second;
+                    if (distance(PChar->loc.p, PTrust->loc.p) < 50)
+                    {
+                        PChar->SpawnTRUSTList.erase(PTrust->id);
+                        PChar->ReloadPartyInc();
+                    }
+                }
+
+                delete trustit->second;
+                m_trustList.erase(trustit++);
+            }
+            else
+            {
+                ++trustit;
+            }
         }
         else
         {


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Fixes https://github.com/project-topaz/topaz/issues/1062
Hah, I wish. The crashes never end.

Death to C-style casts and static casts. Long live dynamic_cast, so we know if all or part of the target pointer's pointee has been deleted, so it'll be unsafe to dereference.

Honestly, I _still_ can't reproduce any of these crashes, on Windows, on Linux, taking off trust limits and zoning, killing, warping, refa-all-ing etc.

Like all the previous "fixes" this doesn't introduce any new crashes for me, but it might move the crash to somewhere else 🤷 
