### PR TITLE
Fix conditions for earning Nanaa Mihgo and Ayame trusts

### DIFF
--- a/scripts/zones/Metalworks/npcs/Ayame.lua
+++ b/scripts/zones/Metalworks/npcs/Ayame.lua
@@ -107,7 +107,7 @@ function onEventFinish(player, csid, option)
         player:setCharVar("FadedPromises", 2)
     elseif (csid == 804) then
         player:setCharVar("FadedPromises", 4)
-    elseif csid == 985 then
+    elseif csid == 985 and option == 2 then
         player:addSpell(900, true, true)
         player:messageSpecial(ID.text.YOU_LEARNED_TRUST, 0, 900)
     end

--- a/scripts/zones/Windurst_Woods/npcs/Nanaa_Mihgo.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Nanaa_Mihgo.lua
@@ -75,11 +75,12 @@ function onTrigger(player, npc)
     local hittingTheMarquisateNanaaCS = player:getCharVar("hittingTheMarquisateNanaaCS")
     local job = player:getMainJob()
     local lvl = player:getMainLvl()
-    local Rank3 = player:getRank() >= 3 and 1 or 0
 
     -- TRUST
-    if mihgosAmigo == QUEST_COMPLETED and player:hasKeyItem(tpz.ki.WINDURST_TRUST_PERMIT) and not player:hasSpell(901) then
-        player:startEvent(865, 0, 0, 0, TrustMemory(player), 0, 0, 0, Rank3)
+    if player:hasKeyItem(tpz.ki.WINDURST_TRUST_PERMIT) and not player:hasSpell(901) then
+        local trustFlag = (player:getRank() >=3 and 1 or 0) + (mihgosAmigo == QUEST_COMPLETED and 2 or 0)
+
+        player:startEvent(865, 0, 0, 0, TrustMemory(player), 0, 0, 0, trustFlag)
 
         -- WINDURST 2-1: LOST FOR WORDS
     elseif player:getCurrentMission(WINDURST) == tpz.mission.id.windurst.LOST_FOR_WORDS and missionStatus > 0 and
@@ -241,7 +242,7 @@ function onEventFinish(player, csid, option)
         player:addGil(GIL_RATE * 200)
         player:addFame(NORG, 30)
 
-    elseif csid == 865 then
+    elseif csid == 865 and option == 2 then
         player:addSpell(901, true, true)
         player:messageSpecial(ID.text.YOU_LEARNED_TRUST, 0, 901)
     end


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Fixes conditional logic issue pointed out and identified by zach, nyu, and residentevil.

Also makes Nanaa's dialogue make sense depending on player rank/quest completion.

If there are any more, just point them out to me and I'll PR the fix.