### PR TITLE
Sends two Windurst 8-2 NPCs to NPC boot camp

### DIFF
--- a/scripts/zones/Davoi/npcs/Sedal-Godjal.lua
+++ b/scripts/zones/Davoi/npcs/Sedal-Godjal.lua
@@ -1,58 +1,67 @@
 -----------------------------------
 -- Area: Davoi
 --  NPC: Sedal-Godjal
--- Mini Quest used in : Whence Blows the Wind
+-- Involved in Quests: Whence the Wind Blows
+-- Involved in Missions: Windurst 8-1/8-2
 -- !pos 185 -3 -116 149
 -----------------------------------
-require("scripts/globals/missions")
 require("scripts/globals/settings")
 require("scripts/globals/keyitems")
-local ID = require("scripts/zones/Davoi/IDs")
+require("scripts/globals/npc_util")
+require("scripts/globals/missions")
+-----------------------------------
 
 function onTrade(player, npc, trade)
-
-    local CurrentMission = player:getCurrentMission(WINDURST)
-    local MissionStatus = player:getCharVar("MissionStatus")
-
-    if (trade:hasItemQty(17437, 1)) then
-        if (CurrentMission == tpz.mission.id.windurst.VAIN and MissionStatus == 3 and player:hasKeyItem(tpz.ki.MAGIC_DRAINED_STAR_SEEKER) == true) then
-            player:startEvent(120)
-        end
+    -- Vain (Windurst 8-1)
+    if
+        npcUtil.tradeHas(trade, 17437) and -- Curse Wand
+        player:getCurrentMission(WINDURST) == tpz.mission.id.windurst.VAIN and
+        player:getCharVar("MissionStatus") == 3 and
+        player:hasKeyItem(tpz.ki.MAGIC_DRAINED_STAR_SEEKER)
+    then
+        player:startEvent(120)
     end
 end
 
 function onTrigger(player, npc)
+    local currentMission = player:getCurrentMission(WINDURST)
+    local missionStatus = player:getCharVar("MissionStatus")
 
-    local CurrentMission = player:getCurrentMission(WINDURST)
-    local MissionStatus = player:getCharVar("MissionStatus")
+    -- The Jester Who'd Be King (Windurst 8-2)
+    if 
+        currentMission == tpz.mission.id.windurst.THE_JESTER_WHO_D_BE_KING and
+        player:getCharVar("MissionStatus") == 1 and not
+        player:hasKeyItem(tpz.ki.AURASTERY_RING)
+    then
+        player:startEvent(122, 0, tpz.ki.AURASTERY_RING)
 
-    if (player:getCurrentMission(WINDURST) == tpz.mission.id.windurst.THE_JESTER_WHO_D_BE_KING and player:getCharVar("MissionStatus") == 1) then
-        player:startEvent(122, 0, 276)
-    elseif (CurrentMission == tpz.mission.id.windurst.VAIN and MissionStatus >= 2) then -- wiki says it doesnt matter whether you get cs or kill first
-        if (player:hasKeyItem(tpz.ki.STAR_SEEKER) == true) then
+    -- Vain (Windurst 8-1)
+    elseif currentMission == tpz.mission.id.windurst.VAIN and missionStatus >= 2 then -- wiki says it doesnt matter whether you get cs or kill first
+        if player:hasKeyItem(tpz.ki.STAR_SEEKER) == true then
             player:startEvent(118, 0, 17437, tpz.ki.STAR_SEEKER)
-        elseif (player:hasKeyItem(tpz.ki.MAGIC_DRAINED_STAR_SEEKER) and MissionStatus == 4) then
+        elseif player:hasKeyItem(tpz.ki.MAGIC_DRAINED_STAR_SEEKER) and missionStatus == 4 then
             player:startEvent(121)
         else
             player:startEvent(119, 0, 17437)
         end
 
-    elseif (player:hasKeyItem(tpz.ki.CRIMSON_ORB) == false) then
-
+    -- Whence Blows the Wind
+    elseif player:hasKeyItem(tpz.ki.CRIMSON_ORB) == false then
         local miniQuestForORB_CS = player:getCharVar("miniQuestForORB_CS")
-        local countRedPoolForORB = player:getCharVar("countRedPoolForORB")
 
-        if (miniQuestForORB_CS == 0) then
-            player:startEvent(24); --
-        elseif (miniQuestForORB_CS == 99) then
+        if miniQuestForORB_CS == 0 then
+            player:startEvent(24)
+        elseif miniQuestForORB_CS == 99 then
             player:startEvent(22) -- Start mini quest
-        elseif (miniQuestForORB_CS == 1 and countRedPoolForORB ~= 15) then
+        elseif miniQuestForORB_CS == 1 and player:getCharVar("countRedPoolForORB") ~= 15 then
             player:startEvent(21) -- During mini quest
-        elseif (miniQuestForORB_CS == 1 and countRedPoolForORB == 15) then
+        elseif miniQuestForORB_CS == 1 then
             player:startEvent(25, 0, 0, 0, tpz.ki.CRIMSON_ORB) -- Finish mini quest
         end
+
+    -- Standard dialog
     else
-        player:startEvent(24) -- Standard dialog
+        player:startEvent(24)
     end
 
 end
@@ -61,30 +70,29 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
+    -- The Jester Who'd Be King (Windurst 8-2)
+    if csid == 122 and npcUtil.giveKeyItem(player, tpz.ki.AURASTERY_RING) then
+        if player:hasKeyItem(tpz.ki.RHINOSTERY_RING) and player:hasKeyItem(tpz.ki.OPTISTERY_RING) then
+            player:setCharVar("MissionStatus", 2)
+        end
 
-    if (csid == 22 and option == 1) then
+    -- Vain (Windurst 8-1)
+    elseif csid == 118 then
+        player:delKeyItem(tpz.ki.STAR_SEEKER)
+        npcUtil.giveKeyItem(player, tpz.ki.MAGIC_DRAINED_STAR_SEEKER)
+        player:setCharVar("MissionStatus", 3)
+    elseif csid == 120 then
+        player:tradeComplete()
+        player:setCharVar("MissionStatus", 4)
+
+    -- Whence Blows the Wind
+    elseif csid == 22 and option == 1 then
         player:setCharVar("miniQuestForORB_CS", 1)
-        player:addKeyItem(tpz.ki.WHITE_ORB)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.WHITE_ORB)
-    elseif (csid == 25) then
+        npcUtil.giveKeyItem(player, tpz.ki.WHITE_ORB)
+    elseif csid == 25 then
         player:setCharVar("miniQuestForORB_CS", 0)
         player:setCharVar("countRedPoolForORB", 0)
         player:delKeyItem(tpz.ki.CURSED_ORB)
-        player:addKeyItem(tpz.ki.CRIMSON_ORB)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.CRIMSON_ORB)
-    elseif (csid == 118) then
-        player:delKeyItem(tpz.ki.STAR_SEEKER)
-        player:addKeyItem(tpz.ki.MAGIC_DRAINED_STAR_SEEKER)
-        player:setCharVar("MissionStatus", 3)
-    elseif (csid == 120) then
-        player:tradeComplete()
-        player:setCharVar("MissionStatus", 4)
-    elseif (csid == 122) then
-        player:addKeyItem(tpz.ki.AURASTERY_RING)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.AURASTERY_RING)
-        if (player:hasKeyItem(tpz.ki.OPTISTERY_RING) and player:hasKeyItem(tpz.ki.RHINOSTERY_RING)) then
-            player:setCharVar("MissionStatus", 2)
-        end
+        npcUtil.giveKeyItem(player, tpz.ki.CRIMSON_ORB)
     end
-
 end

--- a/scripts/zones/Windurst_Waters/npcs/Tosuka-Porika.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Tosuka-Porika.lua
@@ -1,82 +1,110 @@
 -----------------------------------
 -- Area: Windurst Waters
 --  NPC: Tosuka-Porika
---  Starts Quests: Early Bird Catches the Bookworm, Chasing Tales
+-- Starts Quests: Early Bird Catches the Bookworm, Chasing Tales
 -- Involved in Quests: Hat in Hand, Past Reflections, Blessed Radiance
---  Involved in Missions: Windurst 2-1, Windurst 7-1, Windurst 8-2, CoP 3-3
+-- Involved in Missions: Windurst 2-1/7-1/8-2, CoP 3-3
 -- !pos -26 -6 103 238
 -----------------------------------
 local ID = require("scripts/zones/Windurst_Waters/IDs")
-require("scripts/globals/settings")
 require("scripts/globals/titles")
-require("scripts/globals/missions")
 require("scripts/globals/quests")
+require("scripts/globals/settings")
 require("scripts/globals/keyitems")
+require("scripts/globals/npc_util")
+require("scripts/globals/missions")
 -----------------------------------
 
 function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-
-    -- cs notes
-    -- 370 (370) = You have no mission, gtfo
-    -- 379 (379) = Not sure yet (Adventurer from the other day?)
-    -- 380 (380) = About the book of gods and "some adventurer"
-    -- 160 (160) = 1st cutscene of Windurst Mission 2-1
-    -- 161 (161) = More info on 2-1, if you talk to him right after the previous cutscene again
-
     local bookwormStatus = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.EARLY_BIRD_CATCHES_THE_BOOKWORM)
-    local glyphStatus = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.GLYPH_HANGER)
     local chasingStatus = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CHASING_TALES)
+    local currentMission = player:getCurrentMission(WINDURST)
+    local missionStatus = player:getCharVar("MissionStatus")
+    local windurstFame = player:getFameLevel(WINDURST)
 
-    local Fame = player:getFameLevel(WINDURST)
+    -- The Road Forks (CoP 3-3)
+    elseif player:getCurrentMission(COP) == tpz.mission.id.cop.THE_ROAD_FORKS and player:getCharVar("MEMORIES_OF_A_MAIDEN_Status") == 10 then
+        player:startEvent(875)
 
-    if (player:getCurrentMission(WINDURST) == tpz.mission.id.windurst.THE_JESTER_WHO_D_BE_KING and player:getCharVar("MissionStatus") == 1) then
-        player:startEvent(801)
+    -- The Jester Who'd Be King (Windurst 8-2)
+    if
+        currentMission == tpz.mission.id.windurst.THE_JESTER_WHO_D_BE_KING and
+        player:getCharVar("MissionStatus") == 1 and not
+        player:hasKeyItem(tpz.ki.tpz.ki.OPTISTERY_RING)
+    then
+        player:startEvent(801, 0, tpz.ki.OPTISTERY_RING)
 
-    elseif (player:getCurrentMission(COP) == tpz.mission.id.cop.THE_ROAD_FORKS and player:getCharVar("MEMORIES_OF_A_MAIDEN_Status")==10) then
-        player:startEvent(875) -- COP event
+    -- The Sixth Ministry (Windurst 7-1)
+    elseif currentMission == tpz.mission.id.windurst.THE_SIXTH_MINISTRY then
+        if missionStatus == 0 then
+            player:startEvent(715, 0, tpz.ki.OPTISTERY_RING)
+        elseif missionStatus == 1 then
+            player:startEvent(716, 0, tpz.ki.OPTISTERY_RING)
+        elseif missionStatus == 2 then
+            player:startEvent(724)
+        end
 
-    -- Start Past Reflections in First -----------
-    elseif (player:getCurrentMission(WINDURST) == tpz.mission.id.windurst.LOST_FOR_WORDS) then
-        MissionStatus = player:getCharVar("MissionStatus")
-        if (MissionStatus == 0) then
-            player:startEvent(160) -- First CS for Mission 2-1
-        elseif (MissionStatus > 0 and MissionStatus < 6) then
-            player:startEvent(161) -- During Mission 2-1
-        elseif (MissionStatus == 6) then
+    -- Lost for Words (Windurst 2-1)
+    elseif currentMission == tpz.mission.id.windurst.LOST_FOR_WORDS then
+        if missionStatus == 0 then
+            player:startEvent(160) -- Beginning CS for Mission 2-1
+        elseif missionStatus > 0 and missionStatus < 6 then
+            player:startEvent(161) -- Additional dialogue for 2-1
+        elseif (missionStatus == 6) then
             player:startEvent(168) -- Finish Mission 2-1
         end
-    elseif (bookwormStatus == QUEST_AVAILABLE and glyphStatus == QUEST_COMPLETED and Fame >= 2 and player:needToZone() == false) then
-        player:startEvent(387) -- Start Quest "Early Bird Catches the Bookworm"
-    elseif (bookwormStatus == QUEST_ACCEPTED) then
-        player:startEvent(388) -- During Quest "Early Bird Catches the Bookworm"
-    elseif (player:getQuestStatus(WINDURST, tpz.quest.id.windurst.HAT_IN_HAND) == QUEST_ACCEPTED or player:getCharVar("QuestHatInHand_var2") == 1) then
-        function testflag(set, flag)
-            return (set % (2*flag) >= flag)
-        end
-        if (testflag(tonumber(player:getCharVar("QuestHatInHand_var")), 32) == false) then
-            player:startEvent(55) -- Show Off Hat
-        end
-    -- Book is tpz.ki.A_SONG_OF_LOVE, KeyItem ID = 126
-    elseif (chasingStatus == QUEST_AVAILABLE and bookwormStatus == QUEST_COMPLETED and WindyMission ~= tpz.mission.id.windurst.THE_JESTER_WHO_D_BE_KING and Fame >= 3 and player:needToZone() == false) then
-        player:startEvent(403) --  Add initial cutscene
-    elseif (chasingStatus == QUEST_ACCEPTED and player:getCharVar("CHASING_TALES_TRACK_BOOK") > 0) then
-        player:startEvent(412)
-    elseif (player:hasKeyItem(tpz.ki.OVERDUE_BOOK_NOTIFICATION) ==true) then
-        player:startEvent(412)
-    elseif (chasingStatus == QUEST_ACCEPTED) then
-        player:startEvent(406) --  Add follow up cutscene
-        -- Windurst Mission 7-1 --
-    elseif (player:getCurrentMission(WINDURST) == tpz.mission.id.windurst.THE_SIXTH_MINISTRY and player:getCharVar("MissionStatus") == 0) then
-        player:startEvent(715, 0, tpz.ki.OPTISTERY_RING)
-    elseif (player:getCurrentMission(WINDURST) == tpz.mission.id.windurst.THE_SIXTH_MINISTRY and player:getCharVar("MissionStatus") == 1) then
-        player:startEvent(716, 0, tpz.ki.OPTISTERY_RING)
-    elseif (player:getCurrentMission(WINDURST) == tpz.mission.id.windurst.THE_SIXTH_MINISTRY and player:getCharVar("MissionStatus") == 2) then
-        player:startEvent(724)
+
+    -- Hat in Hand
+    elseif
+        (player:getQuestStatus(WINDURST, tpz.quest.id.windurst.HAT_IN_HAND) == QUEST_ACCEPTED or
+        player:getCharVar("QuestHatInHand_var2") == 1) and
+        bit.band(player:getCharVar("QuestHatInHand_var"), bit.lshift(1, 5)) == 0
+    then
+        player:startEvent(55) -- Show Off Hat
+
+    -- Early Bird Catches the Bookworm
+    elseif
+        bookwormStatus == QUEST_AVAILABLE and
+        player:getQuestStatus(WINDURST, tpz.quest.id.windurst.GLYPH_HANGER) == QUEST_COMPLETED and
+        windurstFame >= 2 and
+        player:needToZone() == false
+    then
+        player:startEvent(387) -- Start quest "Early Bird Catches the Bookworm"
+
+    elseif bookwormStatus == QUEST_ACCEPTED then
+        player:startEvent(388) -- During quest "Early Bird Catches the Bookworm"
+
+    -- Chasing Tales
+    elseif
+        chasingStatus == QUEST_AVAILABLE and
+        bookwormStatus == QUEST_COMPLETED and
+        currentMission ~= tpz.mission.id.windurst.THE_JESTER_WHO_D_BE_KING and
+        windurstFame >= 3 and
+        player:needToZone() == false
+    then
+        player:startEvent(403) -- Start quest "Chasing Tales"
+
+    elseif chasingStatus == QUEST_ACCEPTED and player:getCharVar("CHASING_TALES_TRACK_BOOK") == 0 then
+        player:startEvent(406) -- CS immediately after accepting quest (Points player to Furakku-Norakku)
+    elseif chasingStatus == QUEST_ACCEPTED then
+        player:startEvent(412) -- CS after talking to Furakku-Norakku
+
+    -- Standard dialogues
+    elseif player:hasCompletedMission(WINDURST, tpz.mission.id.windurst.MOON_READING) then
+        player:startEvent(380) -- "Thanks to some adventurer somewhere, I was able to awaken from an inescapable nightmare."
+    elseif player:hasCompletedMission(WINDURST, tpz.mission.id.windurst.THE_SIXTH_MINISTRY) then
+        player:startEvent(379) -- "Hey, you're the adventurer from the other day!"
+    elseif player:hasCompletedMission(WINDURST, tpz.mission.id.windurst.LOST_FOR_WORDS) then
+        player:startEvent(169) -- "You must not frighten the others with rumors that the Book of the Gods has gone blank..."
+    elseif player:getLocalVar("TosukaDialogueToggle") == 1 then
+        player:startEvent(881) -- He toggles this event with 370 when player has no other mission/quest dialogue.
+        player:setLocalVar("TosukaDialogueToggle", 0)
     else
-        player:startEvent(370) -- Standard Conversation
+        player:startEvent(370) -- "It doesn't seem like you'd have any business with our distinguished Library of Magic..."
+        player:setLocalVar("TosukaDialogueToggle", 1)
     end
 end
 
@@ -84,31 +112,39 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-
-    if (csid == 55) then  -- Show Off Hat
-        player:addCharVar("QuestHatInHand_var", 32)
-        player:addCharVar("QuestHatInHand_count", 1)
-    elseif (csid == 160) then
-        player:setCharVar("MissionStatus", 1)
-    elseif (csid == 168) then
-        finishMissionTimeline(player, 1, csid, option)
-    elseif (csid == 387 and option == 0) then -- Early Bird Catches the Bookworm
-        player:addQuest(WINDURST, tpz.quest.id.windurst.EARLY_BIRD_CATCHES_THE_BOOKWORM)
-    elseif (csid == 403 and option == 0) then
-        player:addQuest(WINDURST, tpz.quest.id.windurst.CHASING_TALES)
-    elseif (csid ==875) then
+    -- The Road Forks (CoP 3-3)
+    if csid == 875 then
         player:setCharVar("MEMORIES_OF_A_MAIDEN_Status", 11)
-    elseif (csid == 715) then
-        player:addKeyItem(tpz.ki.OPTISTERY_RING)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.OPTISTERY_RING)
-        player:setCharVar("MissionStatus", 1)
-    elseif (csid == 724) then
-        finishMissionTimeline(player, 3, csid, option)
-    elseif (csid == 801) then
-        player:addKeyItem(tpz.ki.OPTISTERY_RING)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.OPTISTERY_RING)
-        if (player:hasKeyItem(tpz.ki.AURASTERY_RING) and player:hasKeyItem(tpz.ki.RHINOSTERY_RING)) then
+
+    -- The Jester Who'd Be King (Windurst 8-2)
+    elseif csid == 801 and npcUtil.giveKeyItem(player, tpz.ki.OPTISTERY_RING) then
+        if player:hasKeyItem(tpz.ki.RHINOSTERY_RING) and player:hasKeyItem(tpz.ki.AURASTERY_RING) then
             player:setCharVar("MissionStatus", 2)
         end
+
+    -- The Sixth Ministry (Windurst 7-1)
+    elseif csid == 715 and npcUtil.giveKeyItem(player, tpz.ki.OPTISTERY_RING) then
+        player:setCharVar("MissionStatus", 1)
+    elseif csid == 724 then
+        finishMissionTimeline(player, 3, csid, option)
+
+    -- Lost for Words (Windurst 2-1)
+    elseif csid == 160 then
+        player:setCharVar("MissionStatus", 1)
+    elseif csid == 168 then
+        finishMissionTimeline(player, 1, csid, option)
+
+    -- Hat in Hand
+    elseif csid == 55 then  -- Show Off Hat
+        player:addCharVar("QuestHatInHand_var", 32)
+        player:addCharVar("QuestHatInHand_count", 1)
+
+    -- Early Bird Catches the Bookworm
+    elseif csid == 387 and option == 0 then
+        player:addQuest(WINDURST, tpz.quest.id.windurst.EARLY_BIRD_CATCHES_THE_BOOKWORM)
+
+    -- Chasing Tales
+    elseif csid == 403 and option == 0 then
+        player:addQuest(WINDURST, tpz.quest.id.windurst.CHASING_TALES)
     end
 end


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Fixes several errors and missing content from these NPCs, adds some npc.util functions, slimmed down and optimized scripts in a friendly-to-read manner.

![image](https://user-images.githubusercontent.com/37684138/92809562-95e6b400-f371-11ea-86d0-d6892777c823.png)
