### PR TITLE
Fixes A Sentry's Peril and npc_utils Glenne's script

### DIFF
--- a/scripts/zones/Southern_San_dOria/npcs/Glenne.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Glenne.lua
@@ -7,6 +7,7 @@
 local ID = require("scripts/zones/Southern_San_dOria/IDs")
 require("scripts/globals/quests")
 require("scripts/globals/titles")
+require("scripts/globals/npc_util")
 -------------------------------------
 
 require("scripts/globals/pathfind")
@@ -38,69 +39,37 @@ function onPath(npc)
 end
 
 function onTrade(player, npc, trade)
-    if (player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.A_SENTRY_S_PERIL) == QUEST_ACCEPTED and
-        trade:hasItemQty(601, 1) and count == 1) then
-            player:startEvent(513)
-            npc:wait()
+    if npcUtil.tradeHas(trade, 601) then -- Ointment Case
+        player:startEvent(513) -- Complete "A Sentry's Peril"
+        npc:wait()
     end
-
 end
 
 function onTrigger(player, npc)
-
-    local aSentrysPeril = player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.A_SENTRY_S_PERIL)
+    local sentrysPerilStatus = player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.A_SENTRY_S_PERIL)
 
     npc:wait()
-
-    if (aSentrysPeril == QUEST_AVAILABLE) then
-        player:startEvent(510)
-    elseif (aSentrysPeril == QUEST_ACCEPTED) then
-        if (player:hasItem(600) == true or player:hasItem(601) == true) then
-            player:startEvent(520)
-        else
-            player:startEvent(644)
-        end
-    elseif (aSentrysPeril == QUEST_COMPLETED) then
-        player:startEvent(521)
+    if sentrysPerilStatus == QUEST_AVAILABLE then
+        player:startEvent(510) -- Starts "A Sentry's Peril"
+    elseif sentrysPerilStatus == QUEST_ACCEPTED and (player:hasItem(600) or player:getCharVar("SentrysPerilTraded") == 1) then
+        player:startEvent(520) -- Reminder to deliver the ointment to her husband.
+    elseif sentrysPerilStatus == QUEST_ACCEPTED then
+        player:startEvent(644) -- "So you lost the ointment! I suppose I can give you another."
     else
-        npc:wait(0)
+        player:startEvent(521) -- "Thank you again for your help!"
     end
-
 end
 
 function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option, npc)
-
     npc:wait(5000)
-
-    if (csid == 510 and option == 0) then
-        if (player:getFreeSlotsCount() > 0) then
-            player:addQuest(SANDORIA, tpz.quest.id.sandoria.A_SENTRY_S_PERIL)
-            player:addItem(600)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, 600)
-        else
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 600) -- Dose of ointment
-        end
-    elseif (csid == 644) then
-        if (player:getFreeSlotsCount() > 0) then
-            player:addItem(600)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, 600)
-        else
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 600) -- Dose of ointment
-        end
-    elseif (csid == 513) then
-        if (player:getFreeSlotsCount() == 0) then
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 12832) -- Bronze Subligar
-        else
-            player:tradeComplete()
-            player:addTitle(tpz.title.RONFAURIAN_RESCUER)
-            player:addItem(12832)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, 12832) -- Bronze Subligar
-            player:addFame(SANDORIA, 30)
-            player:completeQuest(SANDORIA, tpz.quest.id.sandoria.A_SENTRY_S_PERIL)
-        end
+    if csid == 510 and option == 0 and npcUtil.giveItem(player, 600) then
+        player:addQuest(SANDORIA, tpz.quest.id.sandoria.A_SENTRY_S_PERIL)
+    elseif csid == 644 then
+        npcUtil.giveItem(player, 600)
+    elseif csid == 513 and npcUtil.completeQuest(player, SANDORIA, tpz.quest.id.sandoria.A_SENTRY_S_PERIL, {item = 12832, fame = 30, title = tpz.title.RONFAURIAN_RESCUER, var = "SentrysPerilTraded"}) then
+        player:confirmTrade()
     end
-
 end

--- a/scripts/zones/West_Ronfaure/IDs.lua
+++ b/scripts/zones/West_Ronfaure/IDs.lua
@@ -26,6 +26,7 @@ zones[tpz.zone.WEST_RONFAURE] =
         LAILLERA_DIALOG          = 7333,  -- I mustn't chat while on duty. Sorry.
         PICKPOCKET_GACHEMAGE     = 7334,  -- A pickpocket? Now that you mention it, I did see a woman flee the city. She ran west.
         PICKPOCKET_ADALEFONT     = 7335,  -- What, someone picked your pocket? And you call yourself an adventurer!
+        AAVELEON_HEALED          = 7339,  -- My wounds are healed, thanks to you!
         PALCOMONDAU_REPORT       = 7377,  -- Scout reporting! All is quiet on the road to Ghelsba!
         PALCOMONDAU_DIALOG       = 7378,  -- Let me be! I must patrol the road to Ghelsba.
         ZOVRIACE_REPORT          = 7380,  -- Scout reporting! All is quiet on the roads to La Theine!

--- a/scripts/zones/West_Ronfaure/npcs/Aaveleon.lua
+++ b/scripts/zones/West_Ronfaure/npcs/Aaveleon.lua
@@ -4,22 +4,30 @@
 -- Involved in Quest: A Sentry's Peril
 -- !pos -431 -45 343 100
 -----------------------------------
+local ID = require("scripts/zones/West_Ronfaure/IDs")
 require("scripts/globals/npc_util")
 require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.A_SENTRY_S_PERIL) == QUEST_ACCEPTED then
-        if npcUtil.tradeHas(trade, 600) then
-            player:startEvent(100)
-        else
-            player:startEvent(118)
-        end
+    if npcUtil.tradeHas(trade, 600) then -- Ointment
+        player:startEvent(100) -- He accepts the ointment and gives the player the empty case to return to his wife.
+    elseif player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.A_SENTRY_S_PERIL) < QUEST_COMPLETED then
+        player:startEvent(106) -- "What's this? I can't accept gifts from strangers."  He stops saying this after quest complete.
     end
 end
 
 function onTrigger(player, npc)
-    player:startEvent(101)
+    local sentrysPerilStatus = player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.A_SENTRY_S_PERIL)
+    local tradeFinished = player:getCharVar("SentrysPerilTraded")
+
+    if sentrysPerilStatus < QUEST_COMPLETED and tradeFinished ~= 1 then
+        player:startEvent(101) -- "Ow! Ouch! Gah... If only I'd remembered that ointment!"
+    elseif tradeFinished == 1 and not player:hasItem(601) then
+        player:startEvent(126, 601) -- "Did you lose it?"
+    else
+        player:messageSpecial(ID.text.AAVELEON_HEALED) -- "My wounds are healed, thanks to you!"
+    end
 end
 
 function onEventUpdate(player, csid, option)
@@ -28,5 +36,8 @@ end
 function onEventFinish(player, csid, option)
     if csid == 100 and npcUtil.giveItem(player, 601) then
         player:confirmTrade()
+        player:setCharVar("SentrysPerilTraded", 1)
+    elseif csid == 126 and option == 1 then
+        npcUtil.giveItem(player, 601)
     end
 end


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Fixes #1099 