### PR TITLE
Make finishing move checks less tall

### DIFF
--- a/scripts/globals/abilities/animated_flourish.lua
+++ b/scripts/globals/abilities/animated_flourish.lua
@@ -11,20 +11,13 @@ require("scripts/globals/msg")
 -----------------------------------
 
 function onAbilityCheck(player, target, ability)
-
-    if (player:hasStatusEffect(tpz.effect.FINISHING_MOVE_1)) then
-        return 0, 0
-
-    elseif (player:hasStatusEffect(tpz.effect.FINISHING_MOVE_2)) then
-        return 0, 0
-
-    elseif (player:hasStatusEffect(tpz.effect.FINISHING_MOVE_3)) then
-        return 0, 0
-
-    elseif (player:hasStatusEffect(tpz.effect.FINISHING_MOVE_4)) then
-        return 0, 0
-
-    elseif (player:hasStatusEffect(tpz.effect.FINISHING_MOVE_5)) then
+    if
+        player:hasStatusEffect(tpz.effect.FINISHING_MOVE_1) or
+        player:hasStatusEffect(tpz.effect.FINISHING_MOVE_2) or
+        player:hasStatusEffect(tpz.effect.FINISHING_MOVE_3) or
+        player:hasStatusEffect(tpz.effect.FINISHING_MOVE_4) or
+        player:hasStatusEffect(tpz.effect.FINISHING_MOVE_5)
+    then
         return 0, 0
     else
         return tpz.msg.basic.NO_FINISHINGMOVES, 0

--- a/scripts/globals/abilities/building_flourish.lua
+++ b/scripts/globals/abilities/building_flourish.lua
@@ -16,22 +16,14 @@ require("scripts/globals/msg")
 -----------------------------------
 
 function onAbilityCheck(player, target, ability)
-
-    if (player:hasStatusEffect(tpz.effect.FINISHING_MOVE_1)) then
+    if
+        player:hasStatusEffect(tpz.effect.FINISHING_MOVE_1) or
+        player:hasStatusEffect(tpz.effect.FINISHING_MOVE_2) or
+        player:hasStatusEffect(tpz.effect.FINISHING_MOVE_3) or
+        player:hasStatusEffect(tpz.effect.FINISHING_MOVE_4) or
+        player:hasStatusEffect(tpz.effect.FINISHING_MOVE_5)
+    then
         return 0, 0
-
-    elseif (player:hasStatusEffect(tpz.effect.FINISHING_MOVE_2)) then
-        return 0, 0
-
-    elseif (player:hasStatusEffect(tpz.effect.FINISHING_MOVE_3)) then
-        return 0, 0
-
-    elseif (player:hasStatusEffect(tpz.effect.FINISHING_MOVE_4)) then
-        return 0, 0
-
-    elseif (player:hasStatusEffect(tpz.effect.FINISHING_MOVE_5)) then
-        return 0, 0
-
     else
         return tpz.msg.basic.NO_FINISHINGMOVES, 0
     end

--- a/scripts/globals/abilities/reverse_flourish.lua
+++ b/scripts/globals/abilities/reverse_flourish.lua
@@ -11,22 +11,14 @@ require("scripts/globals/msg")
 -----------------------------------
 
 function onAbilityCheck(player, target, ability)
-
-    if (player:hasStatusEffect(tpz.effect.FINISHING_MOVE_1)) then
+    if
+        player:hasStatusEffect(tpz.effect.FINISHING_MOVE_1) or
+        player:hasStatusEffect(tpz.effect.FINISHING_MOVE_2) or
+        player:hasStatusEffect(tpz.effect.FINISHING_MOVE_3) or
+        player:hasStatusEffect(tpz.effect.FINISHING_MOVE_4) or
+        player:hasStatusEffect(tpz.effect.FINISHING_MOVE_5)
+    then
         return 0, 0
-
-    elseif (player:hasStatusEffect(tpz.effect.FINISHING_MOVE_2)) then
-        return 0, 0
-
-    elseif (player:hasStatusEffect(tpz.effect.FINISHING_MOVE_3)) then
-        return 0, 0
-
-    elseif (player:hasStatusEffect(tpz.effect.FINISHING_MOVE_4)) then
-        return 0, 0
-
-    elseif (player:hasStatusEffect(tpz.effect.FINISHING_MOVE_5)) then
-        return 0, 0
-
     else
         return tpz.msg.basic.NO_FINISHINGMOVES, 0
     end


### PR DESCRIPTION
Alternate title: Satisfy Teo OCD

Todo: helper/utils function? The other times we check this we're also modifying the number right in the ability check, which we probably shouldn't be doing.. see Violent Flourish for an example.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

