### PR TITLE
Must zone before obntaining additional sunsand

### DIFF
--- a/scripts/zones/Valkurm_Dunes/npcs/qm1.lua
+++ b/scripts/zones/Valkurm_Dunes/npcs/qm1.lua
@@ -11,14 +11,13 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-
-    if (player:getFreeSlotsCount() > 0 and player:hasItem(503) == false) then
+    if player:getFreeSlotsCount() > 0 and player:getLocalVar("gotSunSand") == 0 and not player:hasItem(503) then
         player:addItem(503)
         player:messageSpecial(ID.text.ITEM_OBTAINED, 503)
+        player:setLocalVar("gotSunSand", 1)
     else
         player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 503)
     end
-
 end
 
 function onEventUpdate(player, csid, option)

--- a/scripts/zones/Valkurm_Dunes/npcs/qm1.lua
+++ b/scripts/zones/Valkurm_Dunes/npcs/qm1.lua
@@ -11,18 +11,25 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-    if player:getFreeSlotsCount() > 0 and player:getLocalVar("gotSunSand") == 0 and not player:hasItem(503) then
+    -- NOTE: the NPC is despawned when weather is not up, we do NOT need to check weather.
+
+    -- Already got sunsand
+    if player:getLocalVar("gotSunSand") > 0 then
+        player:messageSpecial(NOTHING_OUT_OF_ORDINARY)
+
+    -- its go time
+    elseif player:getFreeSlotsCount() > 0 and not player:hasItem(503) then
         player:addItem(503)
         player:messageSpecial(ID.text.ITEM_OBTAINED, 503)
         player:setLocalVar("gotSunSand", 1)
+
+    -- no room!
     else
         player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 503)
     end
 end
 
 function onEventUpdate(player, csid, option)
-    -- printf("CSID2: %u", csid)
-    -- printf("RESULT2: %u", option)
 end
 
 function onEventFinish(player, csid, option)


### PR DESCRIPTION
No more infinity sunsands without zonage: this behavior is retail accurate.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [:thinking:] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

