### PR TITLE
regine: check completion before check player out of flyers

### DIFF
--- a/scripts/zones/Port_San_dOria/npcs/Regine.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Regine.lua
@@ -32,10 +32,10 @@ function onTrigger(player, npc)
     -- FLYERS FOR REGINE
     if ffr == QUEST_AVAILABLE then -- ready to accept quest
         player:startEvent(510, 2)
-    elseif ffr == QUEST_ACCEPTED and not player:hasItem(532) then -- on quest but out of flyers
-        player:startEvent(510, 3)
     elseif ffr == QUEST_ACCEPTED and player:getCharVar('[ffr]deliveryMask') == 32767 then -- all flyers delivered
         player:startEvent(603)
+    elseif ffr == QUEST_ACCEPTED and not player:hasItem(532) then -- on quest but out of flyers
+        player:startEvent(510, 3)
 
     -- DEFAULT MENU
     else


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

* When talking to Regine with FFR active, check for completion before checking whether out of flyers.  [Fixes #1106]