### PR TITLE
Improve Cover performance

### DIFF
--- a/src/map/attackround.cpp
+++ b/src/map/attackround.cpp
@@ -48,7 +48,14 @@ CAttackRound::CAttackRound(CBattleEntity* attacker, CBattleEntity* defender)
     m_taEntity = battleutils::getAvailableTrickAttackChar(attacker, attacker->GetBattleTarget());
 
     // Get cover partner
-    m_coverAbilityUserEntity = battleutils::GetCoverAbilityUser(attacker->GetBattleTarget(), attacker);
+    if (attacker->GetBattleTarget()->objtype == TYPE_PC)
+    {
+        m_coverAbilityUserEntity = battleutils::GetCoverAbilityUser(attacker->GetBattleTarget(), attacker);
+    }
+    else
+    {
+        m_coverAbilityUserEntity = nullptr;
+    }
 
     // Build main weapon attacks.
     CreateAttacks(dynamic_cast<CItemWeapon*>(attacker->m_Weapons[SLOT_MAIN]), RIGHTATTACK);

--- a/src/map/attackround.h
+++ b/src/map/attackround.h
@@ -59,13 +59,13 @@ public:
     void						SetSATA(bool value);		// Sets the SATA flag.
     bool						GetSATAOccured();			// Returns the SATA flag.
     CBattleEntity*				GetTAEntity();				// Returns the TA entity.
-    CBattleEntity*       GetCoverAbilityUserEntity(); // Returns the Cover ablitiy user entity.
+    CBattleEntity*              GetCoverAbilityUserEntity(); // Returns the Cover ablitiy user entity.
 
 private:
     CBattleEntity*				m_attacker;					// The attacker.
     CBattleEntity*				m_defender;					// The defender.
     CBattleEntity*				m_taEntity;					// The trick attack entity.
-    CBattleEntity*       m_coverAbilityUserEntity;  // The cover ability user.
+    CBattleEntity*              m_coverAbilityUserEntity;   // The cover ability user.
     std::vector<CAttack>		m_attackSwings;				// The list of attacks for this round.
     bool						m_sataOccured;				// Flag: Did SATA occur during the round?
     bool						m_kickAttackOccured;		// Flag: Did a kick attack occur during the round?


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Cover partners are being re-calculated and checked on every attack round, for every entity in a battle - including mobs. 
Mobs can exist in giant parties, so if they're checking for cover all the time things are gonna get bad.

This is a quick fix to limit that re-calculation to just PCs, but there is plenty of room for improvement here.

**Ideally**
- Only recalculate when: the party changes, someone's cover status changes

If anyone sees any more **quick wins** for performance here, let me know so we can ninja this into `release` and `canary`