### PR TITLE
fix key item for eco-warrior sandy turn-in

### DIFF
--- a/scripts/zones/Southern_San_dOria/npcs/Norejaie.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Norejaie.lua
@@ -21,7 +21,7 @@ function onTrigger(player, npc)
         player:startEvent(677) -- Offer Eco-Warrior quest
     elseif ecoStatus == 1 then
         player:startEvent(679) -- Reminder dialogue to talk to Rojaireaut
-    elseif ecoStatus == 3 and player:hasKeyItem(tpz.ki.INDIGESTED_ORE) then
+    elseif ecoStatus == 3 and player:hasKeyItem(tpz.ki.INDIGESTED_STALAGMITE) then
         player:startEvent(681) -- Complete quest
     elseif ecoStatus > 100 then
         player:startEvent(682) -- Already on a different nation's Eco-Warrior
@@ -46,7 +46,7 @@ function onEventFinish(player, csid, option)
         fame = 80,
         var = "EcoStatus"
     }) then
-        player:delKeyItem(tpz.ki.INDIGESTED_ORE)
+        player:delKeyItem(tpz.ki.INDIGESTED_STALAGMITE)
         player:setCharVar("EcoReset", getConquestTally())
     end
 end


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

* Fixes checked key item when completing [Eco-Warrior (San d'Oria)](https://ffxiclopedia.fandom.com/wiki/Eco-Warrior_(San_d%27Oria)) [Fixes #1104]