### PR TITLE
Whats with all the howling? (fixing howl sql fields)

### DIFF
--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -582,11 +582,11 @@ INSERT INTO `mob_skills` VALUES (755,909,'fission',0,7.0,2000,1500,4,0,0,0,0,0,0
 -- INSERT INTO `mob_skills` VALUES (759,503,'howl',0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (760,504,'howl',0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (761,505,'howl',0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (762,354,'howl',0,7.0,2000,1500,1,0,0,0,0,0,0); -- Quadav
+INSERT INTO `mob_skills` VALUES (762,354,'howl',1,20.0,2000,1500,1,0,0,0,0,0,0);-- Quadav
 -- INSERT INTO `mob_skills` VALUES (763,507,'howl',0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (764,354,'howl',0,7.0,2000,1500,1,0,0,0,0,0,0); -- Yagudo
+INSERT INTO `mob_skills` VALUES (764,354,'howl',1,20.0,2000,1500,1,0,0,0,0,0,0); -- Yagudo
 -- INSERT INTO `mob_skills` VALUES (765,509,'howl',0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (766,510,'howl',0,7.0,2000,1500,1,0,0,0,0,0,0); -- Orc
+INSERT INTO `mob_skills` VALUES (766,354,'howl',1,20.0,2000,1500,1,0,0,0,0,0,0); -- Orc
 -- INSERT INTO `mob_skills` VALUES (767,511,'bow',0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (768,512,'jumping_strike',0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (769,513,'flying_punch',0,7.0,2000,1500,4,0,0,0,0,0,0);


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [-] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Compared with the previously posted retail caps, and with the previously working howls.

Set:
aoe = 1
range = 20 yalm
target = self
anim time and prep time = as they were, [which is probably still wrong like 99% of every mobskill in the entire list and has been for years](https://github.com/project-topaz/topaz/issues/309)