### PR TITLE
Fix RoE Records called through Lua without supplied params

### DIFF
--- a/scripts/globals/roe.lua
+++ b/scripts/globals/roe.lua
@@ -134,7 +134,7 @@ end
 function tpz.roe.onRecordTrigger(player, recordID, params)
     local entry = tpz.roe.records[recordID]
     if entry and entry:check(player, params) then
-        local progress = params.progress + entry.increment
+        local progress = (params and params.progress or player:getEminenceProgress(recordID)) + entry.increment
         if progress >= entry.goal then
             completeRecord(player, recordID, entry.reward)
         else


### PR DESCRIPTION
Thanks to cocosolos for the spot on this one.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits
