### PR TITLE
Fix unhandled condition in GM command

### DIFF
--- a/scripts/commands/setmod.lua
+++ b/scripts/commands/setmod.lua
@@ -17,6 +17,11 @@ function error(player, msg)
 end
 
 function onTrigger(player, modifier, amount, target)
+    if not modifier then
+        error(player, "Must specify modifier and amount. ")
+        return
+    end
+
     local modID = tonumber(modifier) or tpz.mod[string.upper(modifier)]
     if not modID then
         error(player, "No valid modifier found. ")

--- a/scripts/commands/setmod.lua
+++ b/scripts/commands/setmod.lua
@@ -17,7 +17,7 @@ function error(player, msg)
 end
 
 function onTrigger(player, modifier, amount, target)
-    if not modifier then
+    if not modifier or not amount then
         error(player, "Must specify modifier and amount. ")
         return
     end
@@ -25,11 +25,6 @@ function onTrigger(player, modifier, amount, target)
     local modID = tonumber(modifier) or tpz.mod[string.upper(modifier)]
     if not modID then
         error(player, "No valid modifier found. ")
-        return
-    end
-
-    if not tonumber(amount) then
-        error(player, "Need an amount to set the modifier to! ")
         return
     end
 


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

I missed a condition in testing which can prevent the help text from showing. I forgot to check "no input at all". Scritp now checks for that before trying to validate the ID exists.