### PR TITLE
mount speed conf

### DIFF
--- a/conf/default/map.conf
+++ b/conf/default/map.conf
@@ -102,6 +102,9 @@ all_jobs_widescan: 1
 #Modifier to apply to player speed. 0 means default speed of 50, where 20 would mean speed 70 or -10 would mean speed 40.
 speed_mod: 0
 
+#Modifier to apply to mount speed. 0 means default speed of 80, where 20 would mean speed 100 or -20 would mean speed 60.
+mount_speed_mod: 0
+
 #Modifier to apply to agro'd monster speed. 0 means default speed, where 20 would mean default speed + 20 or -10 would mean default speed - 10.
 mob_speed_mod: 0
 

--- a/scripts/commands/speed.lua
+++ b/scripts/commands/speed.lua
@@ -2,6 +2,7 @@
 -- func: speed
 -- desc: Sets the players movement speed.
 ---------------------------------------------------------------------------------------------------
+require("scripts/globals/status");
 
 cmdprops =
 {
@@ -15,14 +16,20 @@ function error(player, msg)
 end
 
 function onTrigger(player, speed)
+    if not speed then
+        player:PrintToPlayer(string.format("Current Speed: %u", player:speed()))
+        player:PrintToPlayer(string.format("Current tpz.mod.MOVE: %u", player:getMod(tpz.mod.MOVE)))
+        return
+    end
 
-    -- validate speed amount
-    if (speed == nil or speed < 0 or speed > 255) then
+    -- Validate speed amount
+    if speed < 0 or speed > 255 then
         error(player, "Invalid speed amount.")
         return
     end
 
-    -- set speed
-    player:speed( speed )
-
+    -- Inform player and set speed
+    player:PrintToPlayer(string.format("Old Speed: %u", player:speed()))
+    player:PrintToPlayer(string.format("New Speed: %u", speed))
+    player:speed(speed)
 end

--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -410,19 +410,25 @@ float CPathFind::GetRealSpeed()
 {
     uint8 baseSpeed = m_PTarget->speed;
 
-    if (m_PTarget->objtype != TYPE_NPC)
+    // Lets not factor in player map conf or mod's to non players. 
+    // (Mobs should just have speed set directly instead, and NPC's don't have mods)
+    if (m_PTarget->objtype == TYPE_PC)
     {
         baseSpeed = ((CBattleEntity*)m_PTarget)->GetSpeed();
     }
 
-    if (baseSpeed == 0 && (m_roamFlags & ROAMFLAG_WORM))
+    // Lets not check mob things on non mobs
+    if (m_PTarget->objtype == TYPE_MOB)
     {
-        baseSpeed = 20;
-    }
-
-    if (m_PTarget->animation == ANIMATION_ATTACK)
-    {
-        baseSpeed = baseSpeed + map_config.mob_speed_mod;
+        if (baseSpeed == 0 && (m_roamFlags & ROAMFLAG_WORM))
+        {
+            baseSpeed = 20;
+        }
+        // using 'else if' so we don't mess with worm speed.
+        else if (m_PTarget->animation == ANIMATION_ATTACK)
+        {
+            baseSpeed = baseSpeed + map_config.mob_speed_mod;
+        }
     }
 
     return baseSpeed;

--- a/src/map/entities/baseentity.cpp
+++ b/src/map/entities/baseentity.cpp
@@ -33,7 +33,7 @@ CBaseEntity::CBaseEntity()
     targid = 0;
     objtype = ENTITYTYPE::TYPE_NONE;
     status = STATUS_DISAPPEAR;
-	m_TargID = 0;
+    m_TargID = 0;
     memset(&look, 0, sizeof(look));
     memset(&mainlook, 0, sizeof(mainlook));
     memset(&loc, 0, sizeof(loc));
@@ -41,12 +41,12 @@ CBaseEntity::CBaseEntity()
     animationsub = 0;
     speed = 50 + map_config.speed_mod;
     speedsub = 50 + map_config.speed_mod;
-	namevis = 1;
+    namevis = 1;
     allegiance = 0;
     updatemask = 0;
     PAI = nullptr;
-	PBattlefield = nullptr;
-	PInstance = nullptr;
+    PBattlefield = nullptr;
+    PInstance = nullptr;
 }
 
 CBaseEntity::~CBaseEntity()

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -208,13 +208,15 @@ int32 CBattleEntity::GetMaxMP()
 
 /************************************************************************
 *                                                                       *
-*  Скорость перемещения с учетом модификаторов                          *
+*  Movement speed, taking into account modifiers                        *
+*  Note: retail speeds show as a float in the client,                   *
+*        yet in the packet it seems to be just one byte 0-255..         *
 *                                                                       *
 ************************************************************************/
 
 uint8 CBattleEntity::GetSpeed()
 {
-    return (isMounted() ? 50 + map_config.speed_mod : std::clamp<uint16>(speed * (100 + getMod(Mod::MOVE)) / 100, std::numeric_limits<uint8>::min(), std::numeric_limits<uint8>::max()));
+    return (isMounted() ? 40 + map_config.mount_speed_mod : std::clamp<uint16>(speed * (100 + getMod(Mod::MOVE)) / 100, std::numeric_limits<uint8>::min(), std::numeric_limits<uint8>::max()));
 }
 
 bool CBattleEntity::CanRest()

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -965,6 +965,7 @@ int32 map_config_default()
     map_config.disable_gear_scaling = 0;
     map_config.all_jobs_widescan = 1;
     map_config.speed_mod = 0;
+    map_config.mount_speed_mod = 0;
     map_config.mob_speed_mod = 0;
     map_config.skillup_chance_multiplier = 2.5f;
     map_config.craft_chance_multiplier = 2.6f;
@@ -1231,6 +1232,10 @@ int32 map_config_read(const int8* cfgName)
         else if (strcmp(w1, "speed_mod") == 0)
         {
             map_config.speed_mod = atoi(w2);
+        }
+        else if (strcmp(w1, "mount_speed_mod") == 0)
+        {
+            map_config.mount_speed_mod = atoi(w2);
         }
         else if (strcmp(w1, "mob_speed_mod") == 0)
         {

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -89,6 +89,7 @@ struct map_config_t
     bool   disable_gear_scaling;      // Disables ability to equip higher level gear when level cap/sync effect is on player.
     bool   all_jobs_widescan;         // Enable/disable jobs other than BST and RNG having widescan.
     int8   speed_mod;                 // Modifier to add to player speed
+    int8   mount_speed_mod;           // Modifier to add to mount speed
     int8   mob_speed_mod;             // Modifier to add to monster speed
     float  skillup_chance_multiplier; // Constant used in the skillup formula that has a strong effect on skill-up rates
     float  craft_chance_multiplier;   // Constant used in the crafting skill-up formula that has a strong effect on skill-up rates

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -801,7 +801,7 @@ void SetupBattlefieldMob(CMobEntity* PMob)
     PMob->SetDespawnTime(0s);
     // Limbus mobs
     uint16 zoneID = PMob->getZone();
-    if(zoneID == 37 || zoneID == 38) 
+    if (zoneID == 37 || zoneID == 38)
     {
         PMob->setMobMod(MOBMOD_ALLI_HATE, 200);
     }
@@ -1223,15 +1223,8 @@ CMobEntity* InstantiateAlly(uint32 groupid, uint16 zoneID, CInstance* instance)
             PMob->m_EcoSystem = (ECOSYSTEM)Sql_GetIntData(SqlHandle, 19);
             PMob->m_ModelSize = (uint8)Sql_GetIntData(SqlHandle, 20);
 
-            PMob->speed = (uint8)Sql_GetIntData(SqlHandle, 21);
-            PMob->speedsub = (uint8)Sql_GetIntData(SqlHandle, 21);
-
-            /*if(PMob->speed != 0)
-            {
-            PMob->speed += map_config.speed_mod;
-            // whats this for?
-            PMob->speedsub += map_config.speed_mod;
-            }*/
+            PMob->speed = (uint8)Sql_GetIntData(SqlHandle, 21);    // Overwrites baseentity.cpp's defined speed
+            PMob->speedsub = (uint8)Sql_GetIntData(SqlHandle, 21); // Overwrites baseentity.cpp's defined speedsub
 
             PMob->strRank = (uint8)Sql_GetIntData(SqlHandle, 22);
             PMob->dexRank = (uint8)Sql_GetIntData(SqlHandle, 23);

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -302,8 +302,9 @@ void LoadNPCList()
 
                 PNpc->m_TargID = (uint32)Sql_GetUIntData(SqlHandle, 6) >> 16; // вполне вероятно
 
-                PNpc->speed = (uint8)Sql_GetIntData(SqlHandle, 7);
-                PNpc->speedsub = (uint8)Sql_GetIntData(SqlHandle, 8);
+                PNpc->speed = (uint8)Sql_GetIntData(SqlHandle, 7);    // Overwrites baseentity.cpp's defined speed
+                PNpc->speedsub = (uint8)Sql_GetIntData(SqlHandle, 8); // Overwrites baseentity.cpp's defined speedsub
+
                 PNpc->animation = (uint8)Sql_GetIntData(SqlHandle, 9);
                 PNpc->animationsub = (uint8)Sql_GetIntData(SqlHandle, 10);
 


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Also included: addition to `!speed` command to report values on use, and extra commenting of source.

**I thoroughly tested that the additions I made work, and that I did not break anything that wasn't already broken. Of things that WERE broken _before I got here(!!)_ I will be opening a detailed issue for in the near future.**

Note worthy: I verified on retail that chocobos/mounts are NOT simply double your speed. They are base 40 to the players 50, but the client doubles their "stride" effectively moving them at 80. 1 point of speed is worth 2 when mounted. Likewise flee is not "double speed" as was always thought, but I will go over that in my issue later.
