### PR TITLE
Basic Aura Plumbing

### DIFF
--- a/scripts/globals/effects/geo_regen.lua
+++ b/scripts/globals/effects/geo_regen.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- Effect: Geo-Regen
+-----------------------------------
+require("scripts/globals/status")
+-----------------------------------
+
+function onEffectGain(target, effect)
+    target:addMod(tpz.mod.REGEN, effect:getPower())
+end
+
+function onEffectTick(target, effect)
+end
+
+function onEffectLose(target, effect)
+    target:delMod(tpz.mod.REGEN, effect:getPower())
+end

--- a/scripts/globals/spells/colure_active.lua
+++ b/scripts/globals/spells/colure_active.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+--
+--   tpz.effect.COLURE_ACTIVE
+--
+-----------------------------------
+require("scripts/globals/status")
+-----------------------------------
+
+function onEffectGain(target, effect)
+end
+
+function onEffectTick(target, effect)
+end
+
+function onEffectLose(target, effect)
+end

--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -267,6 +267,44 @@ void CTargetFind::addAllInEnmityList()
     }
 }
 
+void CTargetFind::addAllInRange(CBattleEntity* PTarget, float radius, uint8 allegiance)
+{
+    m_radius = radius;
+    m_PRadiusAround = &(m_PBattleEntity->loc.p);
+
+    if (allegiance == ALLEGIANCE_PLAYER)
+    {
+        if (PTarget && PTarget->objtype == TYPE_PC)
+        {
+            CCharEntity* PChar = static_cast<CCharEntity*>(PTarget);
+            for (auto& list : { PChar->SpawnPCList, PChar->SpawnPETList })
+            {
+                for (auto& pair : list)
+                {
+                    CBattleEntity* PBattleEntity = static_cast<CBattleEntity*>(pair.second);
+                    if (PBattleEntity &&
+                        isWithinArea(&(PBattleEntity->loc.p)) &&
+                        !PBattleEntity->isDead() &&
+                        PBattleEntity->allegiance == ALLEGIANCE_PLAYER)
+                    {
+                        m_targets.push_back(PBattleEntity);
+                    }
+                }
+            }
+        }
+        else
+        {
+            zoneutils::GetZone(PTarget->getZone())->ForEachCharInstance(PTarget, [&](CCharEntity* PChar)
+            {
+                if (PChar && isWithinArea(&(PChar->loc.p)) && !PChar->isDead())
+                {
+                    m_targets.push_back(PChar);
+                }
+            });
+        }
+    }
+}
+
 void CTargetFind::addEntity(CBattleEntity* PTarget, bool withPet)
 {
     if (validEntity(PTarget)){

--- a/src/map/ai/helpers/targetfind.h
+++ b/src/map/ai/helpers/targetfind.h
@@ -99,7 +99,8 @@ public:
 	void addAllInParty(CBattleEntity* PTarget, bool withPet);
 	void addAllInMobList(CBattleEntity* PTarget, bool withPet);
     void addAllInEnmityList();
-	void addEntity(CBattleEntity* PTarget, bool withPet);
+    void addAllInRange(CBattleEntity* PTarget, float radius, uint8 allegiance);
+    void addEntity(CBattleEntity* PTarget, bool withPet);
 
     // helpers
     bool isMobOwner(CBattleEntity* PTarget);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -10669,14 +10669,15 @@ inline int32 CLuaBaseEntity::addStatusEffectEx(lua_State *L)
     }
 
     CStatusEffect * PEffect = new CStatusEffect(
-        (EFFECT)lua_tointeger(L, 1),
-        (uint16)lua_tointeger(L, 2),
-        (uint16)lua_tointeger(L, 3),
-        (uint16)lua_tointeger(L, 4),
-        (uint16)lua_tointeger(L, 5),
-        (n >= 6 ? (uint16)lua_tointeger(L, 6) : 0),
-        (n >= 7 ? (uint16)lua_tointeger(L, 7) : 0),
-        (n >= 8 ? (uint16)lua_tointeger(L, 8) : 0));
+        (EFFECT)lua_tointeger(L, 1), // Effect ID
+        (uint16)lua_tointeger(L, 2), // Effect Icon ID
+        (uint16)lua_tointeger(L, 3), // Power
+        (uint16)lua_tointeger(L, 4), // Tick
+        (uint16)lua_tointeger(L, 5), // Duration
+        (n >= 6 ? (uint16)lua_tointeger(L, 6) : 0), // Sub Effect ID
+        (n >= 7 ? (uint16)lua_tointeger(L, 7) : 0), // Sub Power
+        (n >= 8 ? (uint16)lua_tointeger(L, 8) : 0), // Tier
+        (n >= 9 ? (uint32)lua_tointeger(L, 9) : 0)); // Effect Flag (i.e in lua tpz.effectFlag.AURA will make this an aura effect)
 
     lua_pushboolean(L, ((CBattleEntity*)m_PBaseEntity)->StatusEffectContainer->AddStatusEffect(PEffect, silent));
     return 1;

--- a/src/map/packets/char_update.cpp
+++ b/src/map/packets/char_update.cpp
@@ -103,6 +103,12 @@ CCharUpdatePacket::CCharUpdatePacket(CCharEntity* PChar)
     }
     ref<uint64>(0x4C) = PChar->StatusEffectContainer->m_Flags;
 
+    // GEO bubble effects, changes bubble effect depending on what effect is activated.
+    if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_COLURE_ACTIVE))
+    {
+        ref<uint8>(0x58) = 0x50 + PChar->StatusEffectContainer->GetStatusEffect(EFFECT_COLURE_ACTIVE)->GetPower();
+    }
+
     if (PChar->animation == ANIMATION_MOUNT)
         ref<uint16>(0x5B) = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_MOUNTED)->GetPower();
 }

--- a/src/map/spell.h
+++ b/src/map/spell.h
@@ -899,6 +899,8 @@ enum class SpellID : uint16
     Bilgestorm              = 742,
     Bloodrake               = 743,
 
+    Indi_Regen              = 768,
+
     Distract                = 841,
     Distract_II             = 842,
     Frazzle                 = 843,

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -51,7 +51,9 @@ When a status effect is gained twice on a player. It can do one or more of the f
 #include "entities/battleentity.h"
 #include "entities/charentity.h"
 #include "entities/automatonentity.h"
+#include "entities/mobentity.h"
 #include "utils/itemutils.h"
+#include "enmity_container.h"
 #include "map.h"
 #include "latent_effect_container.h"
 #include "status_effect_container.h"
@@ -546,7 +548,7 @@ void CStatusEffectContainer::RemoveStatusEffect(CStatusEffect* PStatusEffect, bo
 
             if (PStatusEffect->GetIcon() != 0)
             {
-                if (!silent)
+                if (!silent && (PStatusEffect->GetFlag() & EFFECTFLAG_NO_LOSS_MESSAGE) == 0)
                 {
                     PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, PStatusEffect->GetIcon(), 0, 206));
                 }
@@ -1500,6 +1502,47 @@ void CStatusEffectContainer::CheckEffectsExpiry(time_point tick)
 
 /************************************************************************
 *                                                                       *
+*                                                                       *
+*                                                                       *
+************************************************************************/
+
+
+void CStatusEffectContainer::HandleAura(CStatusEffect* PStatusEffect)
+{
+    CBattleEntity* PEntity = static_cast<CBattleEntity*>(m_POwner);
+    uint16 targetType = (uint16)PStatusEffect->GetTier();
+
+    switch (targetType)
+    {
+    case ALLEGIANCE_PLAYER:
+    {
+        if (PEntity->objtype == TYPE_PET || PEntity->objtype == TYPE_TRUST)
+        {
+            PEntity = PEntity->PMaster;
+        }
+        PEntity->ForParty([&](CBattleEntity* PMember)
+        {
+            if (PMember != nullptr && PEntity->loc.zone->GetID() == PMember->loc.zone->GetID() && distance(m_POwner->loc.p, PMember->loc.p) <= 6.25 && !PMember->isDead())
+            {
+                CStatusEffect* PEffect = new CStatusEffect(
+                    (EFFECT)PStatusEffect->GetSubID(), // Effect ID
+                    (uint16)PStatusEffect->GetSubID(), // Effect Icon (Associated with ID)
+                    (uint16)PStatusEffect->GetSubPower(), // Power
+                    3, // Tick
+                    4); // Duration
+                PEffect->SetFlag(EFFECTFLAG_NO_LOSS_MESSAGE);
+                PMember->StatusEffectContainer->AddStatusEffect(PEffect, true);
+            }
+        });
+    }
+    break;
+    default:
+        break;
+    }
+}
+
+/************************************************************************
+*                                                                       *
 *  Runs OnEffectTick for all status effects                             *
 *                                                                       *
 ************************************************************************/
@@ -1515,6 +1558,10 @@ void CStatusEffectContainer::TickEffects(time_point tick)
             if (PStatusEffect->GetTickTime() != 0 &&
                 PStatusEffect->GetElapsedTickCount() <= std::chrono::duration_cast<std::chrono::milliseconds>(tick - PStatusEffect->GetStartTime()).count() / PStatusEffect->GetTickTime())
             {
+                if (PStatusEffect->GetFlag() & EFFECTFLAG_AURA)
+                {
+                    HandleAura(PStatusEffect);
+                }
                 PStatusEffect->IncrementElapsedTickCount();
                 luautils::OnEffectTick(m_POwner, PStatusEffect);
             }

--- a/src/map/status_effect_container.h
+++ b/src/map/status_effect_container.h
@@ -120,6 +120,7 @@ private:
     void RemoveStatusEffect(CStatusEffect* PEffect, bool silent = false);	// удаляем эффект по его номеру в контейнере
     void DeleteStatusEffects();
     void SetEffectParams(CStatusEffect* StatusEffect);			// устанавливаем имя эффекта
+    void HandleAura(CStatusEffect* PStatusEffect);
 
     void OverwriteStatusEffect(CStatusEffect* StatusEffect);
 


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Way back when I wrote some messy core code to allow the use of GEO Auras. I handed this off to MrSent who then wrote _all_ of GEO. Super impressive stuff, but functionally impossible to review. 

**So I'd like to:**
- Get the core plumbing into `release`, where it will sit unused by anything. 
- Use it in my `feature/trust` branch for Sakura - the passive regen trust.
- Ship those two off into canary for general testing.
- Once we see that the aura code doesn't ruin servers, and maybe iterate on it a bit, we can start dripping in geo content.

**TODO:**
- ~~Make effects fall off silently~~
- ~~Address that TODO about using spawnlists, or something that isn't _everyone in the zone_~~

**Testing**
Make a gm command:
```lua
cmdprops =
{
    permission = 1,
    parameters = ""
}

function onTrigger(player)
    local bubbleEffect = 14
    local tick_effect = tpz.effect.GEO_REGEN
    local potency = 10
    local target_type = tpz.allegiance.PLAYER

    player:addStatusEffectEx(tpz.effect.COLURE_ACTIVE, tpz.effect.COLURE_ACTIVE, bubbleEffect, 3, 15, tick_effect,
        potency, target_type, tpz.effectFlag.AURA + tpz.effectFlag.NO_LOSS_MESSAGE)
end
```

