### PR TITLE
Ensure no Lua stack mis-management can occur in RoE.

### DIFF
--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -129,6 +129,7 @@ bool event(ROE_EVENT eventID, CCharEntity* PChar, RoeDatagramList payload)
         return 0;
 
     lua_State* L = luautils::LuaHandle;
+    uint32 stackTop = lua_gettop(L);
     lua_getglobal(L, "tpz");
     lua_getfield(L, -1, "roe");
 
@@ -183,6 +184,7 @@ bool event(ROE_EVENT eventID, CCharEntity* PChar, RoeDatagramList payload)
             }
         }
     }
+    lua_settop(L, stackTop);
     return true;
 }
 


### PR DESCRIPTION
I've seen no issues in testing, but just so nobody can say it's RoE blowing the Lua stack (ala Canaria reports).

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

