### PR TITLE
Migrate Guild Trade State cvars to LocalVars

### DIFF
--- a/scripts/zones/Bastok_Markets/npcs/Reinberta.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Reinberta.lua
@@ -21,15 +21,15 @@ function onTrade(player, npc, trade)
         if signed ~=0 then
             player:setSkillRank(tpz.skill.GOLDSMITHING, newRank)
             player:startEvent(301, 0, 0, 0, 0, newRank, 1)
-            player:setCharVar("GoldsmithingExpertQuest",2)
-            player:setCharVar("GoldsmithingTraded",1)
+            player:setCharVar("GoldsmithingExpertQuest",0)
+            player:setLocalVar("GoldsmithingTraded",1)
         else
             player:startEvent(301, 0, 0, 0, 0, newRank, 0)
         end
     elseif newRank ~= 0 and newRank <=9 then
         player:setSkillRank(tpz.skill.GOLDSMITHING, newRank)
         player:startEvent(301, 0, 0, 0, 0, newRank)
-        player:setCharVar("GoldsmithingTraded",1)
+        player:setLocalVar("GoldsmithingTraded",1)
     end
 end
 
@@ -84,9 +84,9 @@ function onEventFinish(player, csid, option)
             signupGuild(player, guild.goldsmithing)
         end
     else
-        if player:getCharVar("GoldsmithingTraded") == 1 then
+        if player:getLocalVar("GoldsmithingTraded") == 1 then
             player:tradeComplete()
-            player:setCharVar("GoldsmithingTraded",0)
+            player:setLocalVar("GoldsmithingTraded",0)
         end
     end
 end

--- a/scripts/zones/Bastok_Mines/npcs/Abd-al-Raziq.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Abd-al-Raziq.lua
@@ -22,15 +22,15 @@ function onTrade(player, npc, trade)
         if signed ~=0 then
             player:setSkillRank(tpz.skill.ALCHEMY, newRank)
             player:startEvent(121, 0, 0, 0, 0, newRank, 1)
-            player:setCharVar("AlchemyExpertQuest",2)
-            player:setCharVar("AlchemyTraded",1)
+            player:setCharVar("AlchemyExpertQuest",0)
+            player:setLocalVar("AlchemyTraded",1)
         else
             player:startEvent(121, 0, 0, 0, 0, newRank, 0)
         end
     elseif newRank ~= 0 and newRank <=9 then
         player:setSkillRank(tpz.skill.ALCHEMY, newRank)
         player:startEvent(121, 0, 0, 0, 0, newRank)
-        player:setCharVar("AlchemyTraded",1)
+        player:setLocalVar("AlchemyTraded",1)
     end
 end
 
@@ -99,9 +99,9 @@ function onEventFinish(player, csid, option)
             signupGuild(player, guild.alchemy)
         end
     else
-        if player:getCharVar("AlchemyTraded") == 1 then
+        if player:getLocalVar("AlchemyTraded") == 1 then
             player:tradeComplete()
-            player:setCharVar("AlchemyTraded",0)
+            player:setLocalVar("AlchemyTraded",0)
         end
     end
 end

--- a/scripts/zones/Metalworks/npcs/Ghemp.lua
+++ b/scripts/zones/Metalworks/npcs/Ghemp.lua
@@ -21,15 +21,15 @@ function onTrade(player, npc, trade)
         if signed ~=0 then
             player:setSkillRank(tpz.skill.SMITHING, newRank)
             player:startEvent(102, 0, 0, 0, 0, newRank, 1)
-            player:setCharVar("SmithingExpertQuest",2)
-            player:setCharVar("SmithingTraded",1)
+            player:setCharVar("SmithingExpertQuest",0)
+            player:setLocalVar("SmithingTraded",1)
         else
             player:startEvent(102, 0, 0, 0, 0, newRank, 0)
         end
     elseif newRank ~= 0 and newRank <=9 then
         player:setSkillRank(tpz.skill.SMITHING, newRank)
         player:startEvent(102, 0, 0, 0, 0, newRank)
-        player:setCharVar("SmithingTraded",1)
+        player:setLocalVar("SmithingTraded",1)
     end
 end
 
@@ -84,9 +84,9 @@ function onEventFinish(player, csid, option)
             signupGuild(player, guild.smithing)
         end
     else
-        if player:getCharVar("SmithingTraded") == 1 then
+        if player:getLocalVar("SmithingTraded") == 1 then
             player:tradeComplete()
-            player:setCharVar("SmithingTraded",0)
+            player:setLocalVar("SmithingTraded",0)
         end
     end
 end

--- a/scripts/zones/Northern_San_dOria/npcs/Cheupirudaux.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Cheupirudaux.lua
@@ -22,15 +22,15 @@ function onTrade(player, npc, trade)
         if signed ~=0 then
             player:setSkillRank(tpz.skill.WOODWORKING, newRank)
             player:startEvent(622, 0, 0, 0, 0, newRank, 1)
-            player:setCharVar("WoodworkingExpertQuest",2)
-            player:setCharVar("WoodworkingTraded",1)
+            player:setCharVar("WoodworkingExpertQuest",0)
+            player:setLocalVar("WoodworkingTraded",1)
         else
             player:startEvent(622, 0, 0, 0, 0, newRank, 0)
         end
     elseif newRank ~= 0 and newRank <=9 then
         player:setSkillRank(tpz.skill.WOODWORKING, newRank)
         player:startEvent(622, 0, 0, 0, 0, newRank)
-        player:setCharVar("WoodworkingTraded",1)
+        player:setLocalVar("WoodworkingTraded",1)
     end
 end
 
@@ -84,9 +84,9 @@ function onEventFinish(player, csid, option)
             signupGuild(player, guild.woodworking)
         end
     else
-        if player:getCharVar("WoodworkingTraded") == 1 then
+        if player:getLocalVar("WoodworkingTraded") == 1 then
             player:tradeComplete()
-            player:setCharVar("WoodworkingTraded",0)
+            player:setLocalVar("WoodworkingTraded",0)
         end
     end
 end

--- a/scripts/zones/Northern_San_dOria/npcs/Mevreauche.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Mevreauche.lua
@@ -21,15 +21,15 @@ function onTrade(player, npc, trade)
         if signed ~=0 then
             player:setSkillRank(tpz.skill.SMITHING, newRank)
             player:startEvent(627, 0, 0, 0, 0, newRank, 1)
-            player:setCharVar("SmithingExpertQuest",2)
-            player:setCharVar("SmithingTraded",1)
+            player:setCharVar("SmithingExpertQuest",0)
+            player:setLocalVar("SmithingTraded",1)
         else
             player:startEvent(627, 0, 0, 0, 0, newRank, 0)
         end
     elseif newRank ~= 0 and newRank <=9 then
         player:setSkillRank(tpz.skill.SMITHING, newRank)
         player:startEvent(627, 0, 0, 0, 0, newRank)
-        player:setCharVar("SmithingTraded",1)
+        player:setLocalVar("SmithingTraded",1)
     end
 end
 
@@ -84,9 +84,9 @@ function onEventFinish(player, csid, option)
             signupGuild(player, guild.smithing)
         end
     else
-        if player:getCharVar("SmithingTraded") == 1 then
+        if player:getLocalVar("SmithingTraded") == 1 then
             player:tradeComplete()
-            player:setCharVar("SmithingTraded",0)
+            player:setLocalVar("SmithingTraded",0)
         end
     end
 end

--- a/scripts/zones/Port_Windurst/npcs/Thubu_Parohren.lua
+++ b/scripts/zones/Port_Windurst/npcs/Thubu_Parohren.lua
@@ -19,12 +19,12 @@ function onTrade(player, npc, trade)
     then
         player:setSkillRank(tpz.skill.FISHING, newRank)
         player:startEvent(10010, 0, 0, 0, 0, newRank)
-        player:setCharVar("FishingExpertQuest",2)
-        player:setCharVar("FishingTraded",1)
+        player:setCharVar("FishingExpertQuest",0)
+        player:setLocalVar("FishingTraded",1)
     elseif newRank ~= 0 and newRank <=9 then
         player:setSkillRank(tpz.skill.FISHING, newRank)
         player:startEvent(10010, 0, 0, 0, 0, newRank)
-        player:setCharVar("FishingTraded",1)
+        player:setLocalVar("FishingTraded",1)
     end
 end
 
@@ -82,9 +82,9 @@ function onEventFinish(player, csid, option)
             signupGuild(player, guild.fishing)
         end
     else
-        if player:getCharVar("FishingTraded") == 1 then
+        if player:getLocalVar("FishingTraded") == 1 then
             player:tradeComplete()
-            player:setCharVar("FishingTraded",0)
+            player:setLocalVar("FishingTraded",0)
         end
     end
 end

--- a/scripts/zones/Southern_San_dOria/npcs/Faulpie.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Faulpie.lua
@@ -22,15 +22,15 @@ function onTrade(player, npc, trade)
         if signed ~=0 then
             player:setSkillRank(tpz.skill.LEATHERCRAFT, newRank)
             player:startEvent(649, 0, 0, 0, 0, newRank, 1)
-            player:setCharVar("LeathercraftExpertQuest",2)
-            player:setCharVar("LeathercraftTraded",1)
+            player:setCharVar("LeathercraftExpertQuest",0)
+            player:setLocalVar("LeathercraftTraded",1)
         else
             player:startEvent(649, 0, 0, 0, 0, newRank, 0)
         end
     elseif newRank ~= 0 and newRank <=9 then
         player:setSkillRank(tpz.skill.LEATHERCRAFT, newRank)
         player:startEvent(649, 0, 0, 0, 0, newRank)
-        player:setCharVar("LeathercraftTraded",1)
+        player:setLocalVar("LeathercraftTraded",1)
     end
 end
 
@@ -100,9 +100,9 @@ function onEventFinish(player, csid, option)
             signupGuild(player, guild.leathercraft)
         end
     else
-        if player:getCharVar("LeathercraftTraded") == 1 then
+        if player:getLocalVar("LeathercraftTraded") == 1 then
             player:tradeComplete()
-            player:setCharVar("LeathercraftTraded",0)
+            player:setLocalVar("LeathercraftTraded",0)
         end
     end
 end

--- a/scripts/zones/Windurst_Waters/npcs/Piketo-Puketo.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Piketo-Puketo.lua
@@ -21,15 +21,15 @@ function onTrade(player, npc, trade)
         if signed ~=0 then
             player:setSkillRank(tpz.skill.COOKING, newRank)
             player:startEvent(10014, 0, 0, 0, 0, newRank, 1)
-            player:setCharVar("CookingExpertQuest",2)
-            player:setCharVar("CookingTraded",1)
+            player:setCharVar("CookingExpertQuest",0)
+            player:setLocalVar("CookingTraded",1)
         else
             player:startEvent(10014, 0, 0, 0, 0, newRank, 0)
         end
     elseif newRank ~= 0 and newRank <=9 then
         player:setSkillRank(tpz.skill.COOKING, newRank)
         player:startEvent(10014, 0, 0, 0, 0, newRank)
-        player:setCharVar("CookingTraded",1)
+        player:setLocalVar("CookingTraded",1)
     end
 end
 
@@ -84,9 +84,9 @@ function onEventFinish(player, csid, option)
             signupGuild(player, guild.cooking)
         end
     else
-        if player:getCharVar("CookingTraded") == 1 then
+        if player:getLocalVar("CookingTraded") == 1 then
             player:tradeComplete()
-            player:setCharVar("CookingTraded",0)
+            player:setLocalVar("CookingTraded",0)
         end
     end
 end

--- a/scripts/zones/Windurst_Woods/npcs/Peshi_Yohnts.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Peshi_Yohnts.lua
@@ -21,15 +21,15 @@ function onTrade(player, npc, trade)
         if signed ~=0 then
             player:setSkillRank(tpz.skill.BONECRAFT, newRank)
             player:startEvent(10017, 0, 0, 0, 0, newRank, 1)
-            player:setCharVar("BonecraftExpertQuest",2)
-            player:setCharVar("BonecraftTraded",1)
+            player:setCharVar("BonecraftExpertQuest",0)
+            player:setLocalVar("BonecraftTraded",1)
         else
             player:startEvent(10017, 0, 0, 0, 0, newRank, 0)
         end
     elseif newRank ~= 0 and newRank <=9 then
         player:setSkillRank(tpz.skill.BONECRAFT, newRank)
         player:startEvent(10017, 0, 0, 0, 0, newRank)
-        player:setCharVar("BonecraftTraded",1)
+        player:setLocalVar("BonecraftTraded",1)
     end
 end
 
@@ -86,9 +86,9 @@ function onEventFinish(player, csid, option)
             signupGuild(player, guild.bonecraft)
         end
     else
-        if player:getCharVar("BonecraftTraded") == 1 then
+        if player:getLocalVar("BonecraftTraded") == 1 then
             player:tradeComplete()
-            player:setCharVar("BonecraftTraded",0)
+            player:setLocalVar("BonecraftTraded",0)
         end
     end
 end

--- a/scripts/zones/Windurst_Woods/npcs/Ponono.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Ponono.lua
@@ -21,15 +21,15 @@ function onTrade(player, npc, trade)
         if signed ~=0 then
             player:setSkillRank(tpz.skill.CLOTHCRAFT, newRank)
             player:startEvent(10012, 0, 0, 0, 0, newRank, 1)
-            player:setCharVar("ClothcraftExpertQuest",2)
-            player:setCharVar("ClothcraftTraded",1)
+            player:setCharVar("ClothcraftExpertQuest",0)
+            player:setLocalVar("ClothcraftTraded",1)
         else
             player:startEvent(10012, 0, 0, 0, 0, newRank, 0)
         end
     elseif newRank ~= 0 and newRank <=9 then
         player:setSkillRank(tpz.skill.CLOTHCRAFT, newRank)
         player:startEvent(10012, 0, 0, 0, 0, newRank)
-        player:setCharVar("ClothcraftTraded",1)
+        player:setLocalVar("ClothcraftTraded",1)
     end
 end
 
@@ -83,9 +83,9 @@ function onEventFinish(player, csid, option)
             signupGuild(player, guild.clothcraft)
         end
     else
-        if player:getCharVar("ClothcraftTraded") == 1 then
+        if player:getLocalVar("ClothcraftTraded") == 1 then
             player:tradeComplete()
-            player:setCharVar("ClothcraftTraded",0)
+            player:setLocalVar("ClothcraftTraded",0)
         end
     end
 end


### PR DESCRIPTION
Migrates cvar sets and checks from char to local.
Changes ExpertQuest flag at completion from 2 to 0 so it doesn't stick around like Craft Glitter.
ExpertQuest flag is needed to persist the "Quest" status once it's accepted (otherwise you'll constantly get the menu prompt when the CS fires.) To the best of my knowledge, no actual quest exists that can be started/completed in the quest log.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

