### PR TITLE
Add latent for target being specified mob family to of with mob ecosystem latent

### DIFF
--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1627,7 +1627,10 @@ tpz.latent =
     ZONE_HOME_NATION         = 54, -- in zone and citizen of nation (aketons)
     MP_OVER                  = 55, -- mp greater than # - PARAM: MP #
     WEAPON_DRAWN_MP_OVER     = 56, -- while weapon is drawn and mp greater than # - PARAM: MP #
-    ELEVEN_ROLL_ACTIVE       = 57  -- corsair roll of 11 active
+    ELEVEN_ROLL_ACTIVE       = 57, -- corsair roll of 11 active
+    IN_ASSAULT               = 58, -- is in an Instance battle in a TOAU zone
+    VS_ECOSYSTEM             = 59, -- Vs. Specific Ecosystem ID (e.g. Vs. Birds: Accuracy+3)
+    VS_FAMILY                = 60, -- Vs. Specific Family ID (e.g. Vs. Apkallu: Accuracy+3)
 }
 
 ------------------------------------

--- a/sql/mob_family_system.sql
+++ b/sql/mob_family_system.sql
@@ -26,7 +26,7 @@ CREATE TABLE `mob_family_system` (
   `familyid` smallint(4) unsigned NOT NULL,
   `family` tinytext,
   `systemid` tinyint(2) unsigned NOT NULL DEFAULT '0',
-  `system` tinytext,
+  `ecosystem` tinytext,
   `mobsize` tinyint(2) unsigned NOT NULL DEFAULT '0',
   `speed` tinyint(3) unsigned NOT NULL DEFAULT '40',
   `HP` tinyint(3) unsigned NOT NULL DEFAULT '100',

--- a/src/map/latent_effect.h
+++ b/src/map/latent_effect.h
@@ -86,10 +86,11 @@ enum LATENT
     LATENT_WEAPON_DRAWN_MP_OVER     = 56, //while weapon is drawn and mp greater than # - PARAM: MP #
     LATENT_ELEVEN_ROLL_ACTIVE       = 57, //corsair roll of 11 active
     LATENT_IN_ASSAULT               = 58, // is in an Instance battle in a TOAU zone
-    LATENT_VS_ECOSYSTEM             = 59  // Vs. Ecosystem (e.g. Vs. Birds: Accuracy+3)
+    LATENT_VS_ECOSYSTEM             = 59, // Vs. Specific Ecosystem ID (e.g. Vs. Birds: Accuracy+3)
+    LATENT_VS_FAMILY                = 60, // Vs. Specific Family ID (e.g. Vs. Apkallu: Accuracy+3)
 };
 
-#define MAX_LATENTEFFECTID    58
+#define MAX_LATENTEFFECTID    61
 
 /************************************************************************
 *																		*

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -654,6 +654,7 @@ void CLatentEffectContainer::CheckLatentsTargetChange()
         {
         case LATENT_SIGNET_BONUS:
         case LATENT_VS_ECOSYSTEM:
+        case LATENT_VS_FAMILY:
             return ProcessLatentEffect(latentEffect);
         default:
             break;
@@ -1111,6 +1112,16 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
         if (CBattleEntity* PTarget = m_POwner->GetBattleTarget())
         {
             expression = PTarget->m_EcoSystem == latentEffect.GetConditionsValue();
+        }
+        break;
+    case LATENT_VS_FAMILY:
+        if (CBattleEntity* PTarget = m_POwner->GetBattleTarget())
+        {
+            auto PMob = dynamic_cast<CMobEntity*>(PTarget);
+            if (PMob)
+            {
+                expression = PMob->m_Family == latentEffect.GetConditionsValue();
+            }
         }
         break;
     default:

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -1117,7 +1117,7 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
     case LATENT_VS_FAMILY:
         if (CBattleEntity* PTarget = m_POwner->GetBattleTarget())
         {
-            auto PMob = dynamic_cast<CMobEntity*>(PTarget);
+            CMobEntity* PMob = dynamic_cast<CMobEntity*>(PTarget);
             if (PMob)
             {
                 expression = PMob->m_Family == latentEffect.GetConditionsValue();


### PR DESCRIPTION
Adds latent for target being specified mob family to of with mob ecosystem latent
- Also fixed max latent ID
- Also fixed missing latent ID in status.lua
- Also renamed plain text field currently unused anywhere, this is purely for human readability


<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits


This was needed for my add effect rework to handled some items that only prov vs a single mob family instead of their ecosystem (which we already have a latent for. As soon as this makes its way to release, please update the effect-rework branch by pulling release into it) thank you.