### PR TITLE
Fix crimson orb mini quest bug

### DIFF
--- a/scripts/zones/Davoi/npcs/_45d.lua
+++ b/scripts/zones/Davoi/npcs/_45d.lua
@@ -21,7 +21,9 @@ function onTrigger(player, npc)
         else
             player:messageSpecial(ID.text.CAVE_HAS_BEEN_SEALED_OFF)
             player:messageSpecial(ID.text.MAY_BE_SOME_WAY_TO_BREAK)
-            player:setCharVar("miniQuestForORB_CS", 99)
+            if player:getCharVar("miniQuestForORB_CS") == 0 then -- Only set when not already active
+                player:setCharVar("miniQuestForORB_CS", 99)
+            end
         end
     end
 end


### PR DESCRIPTION
The value for `miniQuestForORB_CS` needs to be set conditionally to prevent being issued again while already on the quest. Not doing so resets the variable on characters that are already on the quest and touch the wall of banishing, ultimately messing up the NPC trigger (will trigger the quest anew and hand out a new white orb).

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

