### PR TITLE
Trust TP Skill object cleanup

### DIFF
--- a/scripts/globals/spells/trust/ayame.lua
+++ b/scripts/globals/spells/trust/ayame.lua
@@ -28,7 +28,7 @@ function onMobSpawn(mob)
 
     mob:addSimpleGambit(ai.t.SELF, ai.c.HAS_TOP_ENMITY, 0,
         ai.r.JA, ai.s.SPECIFIC, tpz.ja.THIRD_EYE)
-        
+
     mob:addFullGambit({
         ['predicates'] =
         {
@@ -39,7 +39,7 @@ function onMobSpawn(mob)
                 ['target'] = ai.t.MASTER, ['condition'] = ai.c.TP_GTE, ['argument'] = 1000,
             },
         },
-        ['actions'] = 
+        ['actions'] =
         {
             {
                 ['reaction'] = ai.r.JA, ['select'] = ai.s.SPECIFIC, ['argument'] = tpz.ja.MEDITATE,
@@ -47,20 +47,7 @@ function onMobSpawn(mob)
         },
     })
 
-    mob:setTPSkills({
-        ['skills'] = {
-            { ai.r.WS, tpz.ws.TACHI_ENPI, 0 },
-            { ai.r.WS, tpz.ws.TACHI_HOBAKU, 0 },
-            { ai.r.WS, tpz.ws.TACHI_GOTEN, 0 },
-            { ai.r.WS, tpz.ws.TACHI_KAGERO, 0 },
-            { ai.r.WS, tpz.ws.TACHI_JINPU, 0 },
-            { ai.r.WS, tpz.ws.TACHI_YUKIKAZE, 0 },
-            { ai.r.WS, tpz.ws.TACHI_GEKKO, 60 },
-            { ai.r.WS, tpz.ws.TACHI_KASHA, 60 },
-        },
-        ['mode'] = ai.tp.CLOSER,
-        ['skill_select'] = ai.s.HIGHEST,
-    })
+    mob:setTrustTPSkillSettings(ai.tp.CLOSER, ai.s.HIGHEST)
 end
 
 function onMobDespawn(mob)

--- a/scripts/globals/spells/trust/curilla.lua
+++ b/scripts/globals/spells/trust/curilla.lua
@@ -33,16 +33,6 @@ function onMobSpawn(mob)
 
     mob:addSimpleGambit(ai.t.PARTY, ai.c.HPP_LT, 75,
                         ai.r.MA, ai.s.HIGHEST, tpz.magic.spellFamily.CURE)
-
-    mob:setTPSkills({
-        ['skills'] = {
-            { ai.r.WS, tpz.ws.RED_LOTUS_BLADE, 0 },
-            { ai.r.WS, tpz.ws.SERAPH_BLADE, 0 },
-            { ai.r.WS, tpz.ws.SWIFT_BLADE, 60 },
-        },
-        ['mode'] = ai.tp.ASAP,
-        ['skill_select'] = ai.s.RANDOM,
-    })
 end
 
 function onMobDespawn(mob)

--- a/scripts/globals/spells/trust/excenmille.lua
+++ b/scripts/globals/spells/trust/excenmille.lua
@@ -39,16 +39,6 @@ function onMobSpawn(mob)
     mob:addSimpleGambit(ai.t.PARTY, ai.c.HPP_LT, 75,
                         ai.r.MA, ai.s.HIGHEST, tpz.magic.spellFamily.CURE)
 
-    mob:setTPSkills({
-        ['skills'] = {
-            { ai.r.WS, tpz.ws.DOUBLE_THRUST, 0 },
-            { ai.r.WS, tpz.ws.LEG_SWEEP, 0 },
-            { ai.r.WS, tpz.ws.PENTA_THRUST, 30 },
-        },
-        ['mode'] = ai.tp.ASAP,
-        ['skill_select'] = ai.s.RANDOM,
-    })
-
     mob:addMod(tpz.mod.STORETP, 25)
 end
 

--- a/scripts/globals/spells/trust/iron_eater.lua
+++ b/scripts/globals/spells/trust/iron_eater.lua
@@ -24,16 +24,6 @@ function onMobSpawn(mob)
 
     mob:addSimpleGambit(ai.t.MASTER, ai.c.HPP_LT, 50,
                         ai.r.JA, ai.s.SPECIFIC, tpz.ja.PROVOKE)
-
-    mob:setTPSkills({
-        ['skills'] = {
-            { ai.r.WS, tpz.ws.SHIELD_BREAK, 0 },
-            { ai.r.WS, tpz.ws.ARMOR_BREAK, 0 },
-            { ai.r.WS, tpz.ws.STEEL_CYCLONE, 60 },
-        },
-        ['mode'] = ai.tp.ASAP,
-        ['skill_select'] = ai.s.RANDOM,
-    })
 end
 
 function onMobDespawn(mob)

--- a/scripts/globals/spells/trust/kupipi.lua
+++ b/scripts/globals/spells/trust/kupipi.lua
@@ -58,15 +58,6 @@ function onMobSpawn(mob)
     mob:addSimpleGambit(ai.t.TARGET, ai.c.NOT_STATUS, tpz.effect.SLOW, ai.r.MA, ai.s.HIGHEST, tpz.magic.spellFamily.SLOW, 60)
 
     mob:addSimpleGambit(ai.t.TARGET, ai.c.NOT_STATUS, tpz.effect.FLASH, ai.r.MA, ai.s.SPECIFIC, tpz.magic.spell.FLASH, 60)
-
-    mob:setTPSkills({
-        ['skills'] = {
-            { ai.r.WS, tpz.ws.STARLIGHT, 0 },
-            { ai.r.WS, tpz.ws.MOONLIGHT, 0 },
-        },
-        ['mode'] = ai.tp.ASAP,
-        ['skill_select'] = ai.s.RANDOM,
-    })
 end
 
 function onMobDespawn(mob)

--- a/scripts/globals/spells/trust/maat.lua
+++ b/scripts/globals/spells/trust/maat.lua
@@ -1,13 +1,32 @@
 -----------------------------------------
 -- Trust: Maat
 -----------------------------------------
+require("scripts/globals/ability")
+require("scripts/globals/gambits")
+require("scripts/globals/status")
 require("scripts/globals/trust")
 -----------------------------------------
 
 function onMagicCastingCheck(caster, target, spell)
-    return tpz.trust.canCast(caster, spell, 1006)
+    return tpz.trust.canCast(caster, spell)
 end
 
 function onSpellCast(caster, target, spell)
     return tpz.trust.spawn(caster, spell)
+end
+
+function onMobSpawn(mob)
+    tpz.trust.message(mob, tpz.trust.message_offset.SPAWN)
+
+    -- On cooldown
+    mob:addSimpleGambit(ai.t.SELF, ai.c.ALWAYS, 0,
+                        ai.r.JA, ai.s.SPECIFIC, tpz.ja.MANTRA)
+end
+
+function onMobDespawn(mob)
+    tpz.trust.message(mob, tpz.trust.message_offset.DESPAWN)
+end
+
+function onMobDeath(mob)
+    tpz.trust.message(mob, tpz.trust.message_offset.DEATH)
 end

--- a/scripts/globals/spells/trust/maat.lua
+++ b/scripts/globals/spells/trust/maat.lua
@@ -8,7 +8,7 @@ require("scripts/globals/trust")
 -----------------------------------------
 
 function onMagicCastingCheck(caster, target, spell)
-    return tpz.trust.canCast(caster, spell)
+    return tpz.trust.canCast(caster, spell, 1006)
 end
 
 function onSpellCast(caster, target, spell)

--- a/scripts/globals/spells/trust/naji.lua
+++ b/scripts/globals/spells/trust/naji.lua
@@ -33,15 +33,7 @@ function onMobSpawn(mob)
     mob:addSimpleGambit(ai.t.SELF, ai.c.NOT_HAS_TOP_ENMITY, 0,
                         ai.r.JA, ai.s.SPECIFIC, tpz.ja.PROVOKE)
 
-    mob:setTPSkills({
-        ['skills'] = {
-            { ai.r.WS, tpz.ws.BURNING_BLADE, 0 },
-            { ai.r.WS, tpz.ws.RED_LOTUS_BLADE, 0 },
-            { ai.r.WS, tpz.ws.VORPAL_BLADE, 60 },
-        },
-        ['mode'] = ai.tp.ASAP,
-        ['skill_select'] = ai.s.RANDOM,
-    })
+    mob:setTrustTPSkillSettings(ai.tp.ASAP, ai.s.RANDOM)
 end
 
 function onMobDespawn(mob)

--- a/scripts/globals/spells/trust/naji.lua
+++ b/scripts/globals/spells/trust/naji.lua
@@ -32,8 +32,6 @@ function onMobSpawn(mob)
 
     mob:addSimpleGambit(ai.t.SELF, ai.c.NOT_HAS_TOP_ENMITY, 0,
                         ai.r.JA, ai.s.SPECIFIC, tpz.ja.PROVOKE)
-
-    mob:setTrustTPSkillSettings(ai.tp.ASAP, ai.s.RANDOM)
 end
 
 function onMobDespawn(mob)

--- a/scripts/globals/spells/trust/nanaa_mihgo.lua
+++ b/scripts/globals/spells/trust/nanaa_mihgo.lua
@@ -17,9 +17,6 @@ function onSpellCast(caster, target, spell)
 end
 
 function onMobSpawn(mob)
-    -- TODO: Table me
-    local KING_COBRA_CLAMP = 3189
-    
     tpz.trust.teamworkMessage(mob, {
         [tpz.magic.spell.ROMAA_MIHGO] = tpz.trust.message_offset.TEAMWORK_1,
     })
@@ -27,16 +24,7 @@ function onMobSpawn(mob)
     mob:addSimpleGambit(ai.t.TARGET, ai.c.ALWAYS, 0,
                         ai.r.JA, ai.s.SPECIFIC, tpz.ja.DESPOIL)
 
-    mob:setTPSkills({
-        ['skills'] = {
-            { ai.r.WS, tpz.ws.WASP_STING, 0 },
-            { ai.r.WS, tpz.ws.DANCING_EDGE, 0 },
-
-            { ai.r.MS, KING_COBRA_CLAMP, 0 },
-        },
-        ['mode'] = ai.tp.OPENER,
-        ['skill_select'] = ai.s.HIGHEST,
-    })
+    mob:setTrustTPSkillSettings(ai.tp.OPENER, ai.s.HIGHEST)
 end
 
 function onMobDespawn(mob)

--- a/scripts/globals/spells/trust/shantotto.lua
+++ b/scripts/globals/spells/trust/shantotto.lua
@@ -33,7 +33,7 @@ function onMobSpawn(mob)
                 ['target'] = ai.t.TARGET, ['condition'] = ai.c.MB_AVAILABLE, ['argument'] = 0,
             }
         },
-        ['actions'] = 
+        ['actions'] =
         {
             {
                 ['reaction'] = ai.r.MA, ['select'] = ai.s.HIGHEST, ['argument'] = tpz.magic.spellFamily.NONE,

--- a/scripts/globals/spells/trust/shantotto_ii.lua
+++ b/scripts/globals/spells/trust/shantotto_ii.lua
@@ -20,7 +20,7 @@ function onMobSpawn(mob)
     mob:addSimpleGambit(ai.t.TARGET, ai.c.MB_AVAILABLE, 0, ai.r.MA, ai.s.MB_ELEMENT, tpz.magic.spellFamily.NONE)
     mob:addSimpleGambit(ai.t.TARGET, ai.c.NOT_SC_AVAILABLE, 0, ai.r.MA, ai.s.HIGHEST, tpz.magic.spellFamily.NONE, 30)
 
-    local power = mob:getMainLvl() 
+    local power = mob:getMainLvl()
     mob:addMod(tpz.mod.MATT, power)
     mob:addMod(tpz.mod.MACC, power)
     mob:addMod(tpz.mod.HASTE_MAGIC, 20)

--- a/scripts/globals/spells/trust/trion.lua
+++ b/scripts/globals/spells/trust/trion.lua
@@ -32,22 +32,6 @@ function onMobSpawn(mob)
 
     mob:addSimpleGambit(ai.t.PARTY, ai.c.HPP_LT, 75,
                         ai.r.MA, ai.s.HIGHEST, tpz.magic.spellFamily.CURE)
-
-    -- TODO: Table me
-    local ROYAL_BASH = 3193
-    local ROYAL_SAVIOUR = 3194
-    mob:setTPSkills({
-        ['skills'] = {
-            { ai.r.MS, ROYAL_BASH, 0 },
-            { ai.r.MS, ROYAL_SAVIOUR, 0 },
-
-            { ai.r.WS, tpz.ws.RED_LOTUS_BLADE, 0 },
-            { ai.r.WS, tpz.ws.FLAT_BLADE, 0 },
-            { ai.r.WS, tpz.ws.SAVAGE_BLADE, 60 },
-        },
-        ['mode'] = ai.tp.ASAP,
-        ['skill_select'] = ai.s.RANDOM,
-    })
 end
 
 function onMobDespawn(mob)

--- a/scripts/globals/spells/trust/volker.lua
+++ b/scripts/globals/spells/trust/volker.lua
@@ -26,17 +26,6 @@ function onMobSpawn(mob)
 
     mob:addSimpleGambit(ai.t.MASTER, ai.c.HPP_LT, 50,
                         ai.r.JA, ai.s.SPECIFIC, tpz.ja.PROVOKE)
-
-    mob:setTPSkills({
-        ['skills'] = {
-            { ai.r.WS, tpz.ws.RED_LOTUS_BLADE, 0 },
-            { ai.r.WS, tpz.ws.SPIRIT_WITHIN, 0 },
-            { ai.r.WS, tpz.ws.VORPAL_BLADE, 60 },
-            { ai.r.WS, tpz.ws.SAVAGE_BLADE, 60 },
-        },
-        ['mode'] = ai.tp.ASAP,
-        ['skill_select'] = ai.s.RANDOM,
-    })
 end
 
 function onMobDespawn(mob)

--- a/scripts/globals/spells/trust/zeid_ii.lua
+++ b/scripts/globals/spells/trust/zeid_ii.lua
@@ -40,13 +40,7 @@ function onMobSpawn(mob)
     mob:addSimpleGambit(ai.t.SELF, ai.c.ALWAYS, 0,
                         ai.r.JA, ai.s.SPECIFIC, tpz.ja.LAST_RESORT)
 
-    mob:setTPSkills({
-        ['skills'] = {
-            { ai.r.WS, tpz.ws.GROUND_STRIKE, 0 },
-        },
-        ['mode'] = ai.tp.CLOSER,
-        ['skill_select'] = ai.s.RANDOM,
-    })
+    mob:setTrustTPSkillSettings(ai.tp.CLOSER, ai.s.RANDOM)
 end
 
 function onMobDespawn(mob)

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -3444,7 +3444,9 @@ INSERT INTO `mob_skill_lists` VALUES ('Siren',1010,3514); -- Hysteric Assault
 INSERT INTO `mob_skill_lists` VALUES ('Siren',1010,3515); -- Clarsach Call
 -- Trusts
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Shantotto',1011,0);
--- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Naji',1012,0);
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Naji',1012,33); -- Burning Blade
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Naji',1012,34); -- Red Lotus Blade
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Naji',1012,40); -- Vorpal Blade
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Kupipi',1013,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Excenmille',1014,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Ayame',1015,0);

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -3447,14 +3447,35 @@ INSERT INTO `mob_skill_lists` VALUES ('Siren',1010,3515); -- Clarsach Call
 INSERT INTO `mob_skill_lists` VALUES ('TRUST_Naji',1012,33); -- Burning Blade
 INSERT INTO `mob_skill_lists` VALUES ('TRUST_Naji',1012,34); -- Red Lotus Blade
 INSERT INTO `mob_skill_lists` VALUES ('TRUST_Naji',1012,40); -- Vorpal Blade
--- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Kupipi',1013,0);
--- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Excenmille',1014,0);
--- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Ayame',1015,0);
--- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Nanaa_Mihgo',1016,0);
--- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Curilla',1017,0);
--- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Volker',1018,0);
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Kupipi',1013,163); -- Starlight
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Kupipi',1013,164); -- Moonlight
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Excenmille',1014,112); -- Double Thrust
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Excenmille',1014,115); -- Leg Sweep
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Excenmille',1014,116); -- Penta Thrust
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Ayame',1015,144); -- Tachi: Enpi
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Ayame',1015,145); -- Tachi: Hobaku
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Ayame',1015,146); -- Tachi: Goten
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Ayame',1015,147); -- Tachi: Kagero
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Ayame',1015,148); -- Tachi: Jinpu
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Ayame',1015,150); -- Tachi: Yukikaze
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Ayame',1015,151); -- Tachi: Gekko
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Ayame',1015,152); -- Tachi: Kasha
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Nanaa_Mihgo',1016,16);   -- Wasp Sting
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Nanaa_Mihgo',1016,23);   -- Dancing Edge
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Nanaa_Mihgo',1016,3189); -- King Cobra Clamp
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Curilla',1017,34); -- Red Lotus Blade
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Curilla',1017,37); -- Seraph Blade
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Curilla',1017,41); -- Swift Blade
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Volker',1018,34); -- Red Lotus Blade
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Volker',1018,39); -- Spirits Within
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Volker',1018,40); -- Vorpal Blade
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Volker',1018,42); -- Savage Blade
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Ajido-Marujido',1019,0);
--- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Trion',1020,0);
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Trion',1020,34);   -- Red Lotus Blade
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Trion',1020,35);   -- Flat Blade
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Trion',1020,42);   -- Savage Blade
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Trion',1020,3193); -- Royal Bash
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Trion',1020,3194); -- Royal Saviour
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Zeid',1021,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Lion',1022,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Tenzen',1023,0);
@@ -3466,7 +3487,9 @@ INSERT INTO `mob_skill_lists` VALUES ('TRUST_Naji',1012,40); -- Vorpal Blade
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Ulmia',1029,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Shikaree_Z',1030,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Cherukiki',1031,0);
--- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Iron_Eater',1032,0);
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Iron_Eater',1032,80); -- Shield Break
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Iron_Eater',1032,83); -- Armor Break
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Iron_Eater',1032,88); -- Steel Cyclone
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Gessho',1033,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Gadalar',1034,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Rainemard',1035,0);
@@ -3482,7 +3505,16 @@ INSERT INTO `mob_skill_lists` VALUES ('TRUST_Naji',1012,40); -- Vorpal Blade
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Aldo',1045,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Moogle',1046,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Fablinix',1047,0);
--- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,0);
+-- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,0); -- Combo (Maat)
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,1028); -- Shoulder Tackle (Maat)
+-- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,3); -- One Inch Punch (Maat)
+-- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,4); -- Backhand Blow (Maat)
+-- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,5); -- Raging Fists (Maat)
+-- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,6); -- Spinning Attack (Maat)
+-- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,7); -- Howling Fist (Maat)
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,1033); -- Dragon Kick (Maat)
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,1034); -- Asuran Fists (Maat)
+-- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,0); -- TODO: Bear Killer
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_D_Shantotto',1049,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Star_Sibyl',1050,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Karaha-Baruha',1051,0);
@@ -3559,7 +3591,7 @@ INSERT INTO `mob_skill_lists` VALUES ('TRUST_Naji',1012,40); -- Vorpal Blade
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Aldo_UC',1122,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Naja_Salaheem_UC',1123,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Lion_II',1124,0);
--- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Zied_II',1125,0);
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Zied_II',1125,56); -- Ground Strike
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Prishe_II',1126,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Nashmeira_II',1127,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Lilisette_II',1128,0);

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -3507,11 +3507,11 @@ INSERT INTO `mob_skill_lists` VALUES ('TRUST_Iron_Eater',1032,88); -- Steel Cycl
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Fablinix',1047,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,0); -- Combo (Maat)
 INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,1028); -- Shoulder Tackle (Maat)
--- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,3); -- One Inch Punch (Maat)
--- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,4); -- Backhand Blow (Maat)
--- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,5); -- Raging Fists (Maat)
--- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,6); -- Spinning Attack (Maat)
--- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,7); -- Howling Fist (Maat)
+-- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,0); -- One Inch Punch (Maat)
+-- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,0); -- Backhand Blow (Maat)
+-- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,0); -- Raging Fists (Maat)
+-- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,0); -- Spinning Attack (Maat)
+-- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,0); -- Howling Fist (Maat)
 INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,1033); -- Dragon Kick (Maat)
 INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,1034); -- Asuran Fists (Maat)
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,0); -- TODO: Bear Killer

--- a/src/map/ai/helpers/gambits_container.h
+++ b/src/map/ai/helpers/gambits_container.h
@@ -151,7 +151,6 @@ struct TrustSkill_t
 {
     G_REACTION skill_type;
     uint32 skill_id;
-    uint32 min_level;
     uint8 primary;
     uint8 secondary;
     uint8 tertiary;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -12573,6 +12573,8 @@ inline int32 CLuaBaseEntity::addFullGambit(lua_State* L)
 
     bool gambit_error = false;
 
+    uint32 stackTop = lua_gettop(L);
+
     lua_pushvalue(L, 1); // Push main table onto stack
 
     lua_getfield(L, 1, "predicates"); // Acts as push
@@ -12645,6 +12647,8 @@ inline int32 CLuaBaseEntity::addFullGambit(lua_State* L)
     {
         ShowWarning("Invalid Gambit");
     }
+
+    lua_settop(L, stackTop);
 
     // ===
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -9212,7 +9212,7 @@ inline int32 CLuaBaseEntity::getLeaderID(lua_State* L)
 *  Function: getPartyLastMemberJoinedTime()
 *  Purpose : Get the epoch time point in seconds that the last PC joined the party (if any)
 *  Example : seconds_since_last_member_joined = os.time() - player:getPartyLastMemberJoinedTime()
-*  Notes   : 
+*  Notes   :
 ************************************************************************/
 
 int32 CLuaBaseEntity::getPartyLastMemberJoinedTime(lua_State* L)
@@ -12661,114 +12661,25 @@ inline int32 CLuaBaseEntity::addFullGambit(lua_State* L)
 }
 
 /************************************************************************
-*  Function: setTPSkills()
+*  Function: setTrustTPSkillSettings(trigger, select)
 *  Purpose :
-*  Example : mob:setTPSkills(...)
+*  Example : mob:setTrustTPSkillSettings(ai.tp.ASAP, ai.s.RANDOM)
 *  Notes   :
 ************************************************************************/
 
-int32 CLuaBaseEntity::setTPSkills(lua_State* L)
+int32 CLuaBaseEntity::setTrustTPSkillSettings(lua_State* L)
 {
     TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
     TPZ_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_TRUST);
-    TPZ_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_istable(L, 1));
-
-    auto trust = static_cast<CTrustEntity*>(m_PBaseEntity);
-    auto controller = static_cast<CTrustController*>(trust->PAI->GetController());
-    auto mLvl = trust->GetMLevel();
+    TPZ_DEBUG_BREAK_IF(!lua_isnumber(L, 1) || !lua_isnumber(L, 2));
 
     using namespace gambits;
 
-    // TODO: This is all garbage and arcane, can be done better!
+    auto trust = static_cast<CTrustEntity*>(m_PBaseEntity);
+    auto controller = static_cast<CTrustController*>(trust->PAI->GetController());
 
-    std::vector<uint32> skills_data;
-
-    // skills
-    lua_getfield(L, 1, "skills");
-    if (lua_istable(L, -1))
-    {
-        auto table = lua_gettop(L);
-        lua_pushnil(L);
-        while (lua_next(L, table) != 0)
-        {
-            auto sub_table = lua_gettop(L);
-            lua_pushnil(L);
-            while (lua_next(L, sub_table) != 0)
-            {
-                auto value = static_cast<uint32>(lua_tonumber(L, -1));
-                skills_data.emplace_back(value);
-                lua_pop(L, 1);
-            }
-            lua_pop(L, 1);
-        }
-    }
-    else
-    {
-        // No skills, fatal!
-    }
-    lua_pop(L, 1);
-
-    // Handle skills_data
-    for (size_t i = 0; i < skills_data.size(); i += 3)
-    {
-        auto skill_type = skills_data[i];
-        auto skill_id = skills_data[i + 1];
-        auto min_level = skills_data[i + 2];
-
-        TrustSkill_t skill{ static_cast<G_REACTION>(skill_type), skill_id, min_level };
-        if (skill.skill_type == G_REACTION::WS)
-        {
-            CWeaponSkill* PWeaponSkill = battleutils::GetWeaponSkill(skill_id);
-            if (!PWeaponSkill)
-            {
-                ShowWarning("CLuaBaseEntity::setTPSkills: Error loading WeaponSkill id %d for trust %s\n", skill_id, trust->name);
-                break;
-            }
-            skill.primary = PWeaponSkill->getPrimarySkillchain();
-            skill.secondary = PWeaponSkill->getSecondarySkillchain();
-            skill.tertiary = PWeaponSkill->getTertiarySkillchain();
-        }
-        else // MS
-        {
-            CMobSkill* PMobSkill = battleutils::GetMobSkill(skill_id);
-            if (!PMobSkill)
-            {
-                ShowWarning("CLuaBaseEntity::setTPSkills: Error loading MobSkill id %d for trust %s\n", skill_id, trust->name);
-                break;
-            }
-            skill.primary = PMobSkill->getPrimarySkillchain();
-            skill.secondary = PMobSkill->getSecondarySkillchain();
-            skill.tertiary = PMobSkill->getTertiarySkillchain();
-        }
-        
-        if (mLvl >= min_level)
-        {
-            controller->m_GambitsContainer->tp_skills.emplace_back(skill);
-        }
-     }
-
-    // mode
-    uint32 mode = 0;
-    lua_getfield(L, 1, "mode");
-    if (lua_isnumber(L, -1))
-    {
-        mode = static_cast<uint32>(lua_tonumber(L, -1));
-    }
-    lua_pop(L, 1);
-
-    // skill_select
-    uint32 skill_select = 0;
-    lua_getfield(L, 1, "skill_select");
-    if (lua_isnumber(L, -1))
-    {
-        skill_select = static_cast<uint32>(lua_tonumber(L, -1));
-    }
-    lua_pop(L, 1);
-
-    lua_pop(L, 1); // Init state
-
-    controller->m_GambitsContainer->tp_trigger = static_cast<G_TP_TRIGGER>(mode);
-    controller->m_GambitsContainer->tp_select = static_cast<G_SELECT>(skill_select);
+    controller->m_GambitsContainer->tp_trigger = static_cast<G_TP_TRIGGER>(lua_tonumber(L, 1));
+    controller->m_GambitsContainer->tp_select = static_cast<G_SELECT>(lua_tonumber(L, 2));
 
     return 0;
 }
@@ -15431,8 +15342,8 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,trustPartyMessage),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,addSimpleGambit),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,addFullGambit),
-    LUNAR_DECLARE_METHOD(CLuaBaseEntity,setTPSkills),
-  
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,setTrustTPSkillSettings),
+
     // Mob Entity-Specific
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,setMobLevel),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getSystem),

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -598,7 +598,7 @@ public:
     int32 trustPartyMessage(lua_State*);
     int32 addSimpleGambit(lua_State*);
     int32 addFullGambit(lua_State*);
-    int32 setTPSkills(lua_State*);
+    int32 setTrustTPSkillSettings(lua_State*);
 
     int32 isJugPet(lua_State*);              // If the entity has a pet, test if it is a jug pet.
     int32 hasValidJugPetItem(lua_State*);

--- a/src/map/utils/trustutils.cpp
+++ b/src/map/utils/trustutils.cpp
@@ -534,7 +534,11 @@ void LoadTrustStatsAndSkills(CTrustEntity* PTrust)
 
         // Only get access to skills that produce Lv3 SCs after Lv60
         bool canFormLv3Skillchain = skill.primary >= SC_GRAVITATION || skill.secondary >= SC_GRAVITATION || skill.tertiary >= SC_GRAVITATION;
-        if (!canFormLv3Skillchain || PTrust->GetMLevel() >= 60)
+
+        // Special case for Zeid II and others who only have Lv3+ skills
+        bool onlyHasLc3Skillchains = canFormLv3Skillchain && controller->m_GambitsContainer->tp_skills.empty();
+
+        if (!canFormLv3Skillchain || PTrust->GetMLevel() >= 60 || onlyHasLc3Skillchains)
         {
             controller->m_GambitsContainer->tp_skills.emplace_back(skill);
         }

--- a/src/map/utils/trustutils.cpp
+++ b/src/map/utils/trustutils.cpp
@@ -19,6 +19,7 @@
 
 #include "../ai/ai_container.h"
 #include "../ai/controllers/trust_controller.h"
+#include "../ai/helpers/gambits_container.h"
 #include "../entities/mobentity.h"
 #include "../entities/trustentity.h"
 #include "../items/item_weapon.h"
@@ -26,7 +27,9 @@
 #include "../packets/entity_update.h"
 #include "../packets/message_standard.h"
 #include "../packets/trust_sync.h"
+#include "../mobskill.h"
 #include "../status_effect_container.h"
+#include "../weapon_skill.h"
 #include "../zone_instance.h"
 
 struct TrustSpell_ID
@@ -213,7 +216,7 @@ void BuildTrust(uint32 TrustID)
             trust->pierceres = (uint16)(Sql_GetFloatData(SqlHandle, 31) * 1000);
             trust->hthres    = (uint16)(Sql_GetFloatData(SqlHandle, 32) * 1000);
             trust->impactres = (uint16)(Sql_GetFloatData(SqlHandle, 33) * 1000);
-        
+
             trust->firedef    = 0;
             trust->icedef     = 0;
             trust->winddef    = 0;
@@ -252,7 +255,7 @@ void SpawnTrust(CCharEntity* PMaster, uint32 TrustID)
     CTrustEntity* PTrust = LoadTrust(PMaster, TrustID);
     PMaster->PTrusts.insert(PMaster->PTrusts.end(), PTrust);
     PMaster->StatusEffectContainer->CopyConfrontationEffect(PTrust);
-    
+
     if (PMaster->PBattlefield)
     {
         PTrust->PBattlefield = PMaster->PBattlefield;
@@ -480,5 +483,61 @@ void LoadTrustStatsAndSkills(CTrustEntity* PTrust)
     battleutils::AddTraits(PTrust, traits::GetTraits(sJob), sLvl);
 
     mobutils::SetupJob(PTrust);
+
+    // Skills
+    using namespace gambits;
+    auto controller = static_cast<CTrustController*>(PTrust->PAI->GetController());
+
+    // Default TP selectors
+    controller->m_GambitsContainer->tp_trigger = G_TP_TRIGGER::ASAP;
+    controller->m_GambitsContainer->tp_select = G_SELECT::RANDOM;
+
+    auto skillList = battleutils::GetMobSkillList(PTrust->m_MobSkillList);
+    for (uint16 skill_id : skillList)
+    {
+        TrustSkill_t skill;
+        if (skill_id <= 240) // Player WSs
+        {
+            CWeaponSkill* PWeaponSkill = battleutils::GetWeaponSkill(skill_id);
+            if (!PWeaponSkill)
+            {
+                ShowWarning("LoadTrustStatsAndSkills: Error loading WeaponSkill id %d for trust %s\n", skill_id, PTrust->name);
+                break;
+            }
+
+            skill = TrustSkill_t {
+                G_REACTION::WS,
+                skill_id,
+                PWeaponSkill->getPrimarySkillchain(),
+                PWeaponSkill->getSecondarySkillchain(),
+                PWeaponSkill->getTertiarySkillchain(),
+            };
+        }
+        else // MobSkills
+        {
+            CMobSkill* PMobSkill = battleutils::GetMobSkill(skill_id);
+            if (!PMobSkill)
+            {
+                ShowWarning("LoadTrustStatsAndSkills: Error loading MobSkill id %d for trust %s\n", skill_id, PTrust->name);
+                break;
+            }
+            skill = {
+                G_REACTION::MS,
+                skill_id,
+                skill.primary = PMobSkill->getPrimarySkillchain(),
+                skill.secondary = PMobSkill->getSecondarySkillchain(),
+                skill.tertiary = PMobSkill->getTertiarySkillchain(),
+            };
+
+            controller->m_GambitsContainer->tp_skills.emplace_back(skill);
+        }
+
+        // Only get access to skills that produce Lv3 SCs after Lv60
+        bool canFormLv3Skillchain = skill.primary >= SC_GRAVITATION || skill.secondary >= SC_GRAVITATION || skill.tertiary >= SC_GRAVITATION;
+        if (!canFormLv3Skillchain || PTrust->GetMLevel() >= 60)
+        {
+            controller->m_GambitsContainer->tp_skills.emplace_back(skill);
+        }
+    }
 }
 }; // namespace trustutils

--- a/src/map/utils/trustutils.cpp
+++ b/src/map/utils/trustutils.cpp
@@ -340,8 +340,8 @@ void LoadTrustStatsAndSkills(CTrustEntity* PTrust)
 
     // TODO: HP/MP should take into account family, job, etc.
 
-    float growth = 1.06f;
-    float base   = 18.0f;
+    float growth = 1.04f;
+    float base   = 16.0f;
 
     PTrust->health.maxhp = static_cast<uint16>(base * pow(mLvl, growth) * PTrust->HPscale * map_config.alter_ego_hp_multiplier);
 


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Remove this horrible broken object:
```lua
mob:setTPSkills({
        ['skills'] = {
            { ai.r.WS, tpz.ws.BURNING_BLADE, 0 },
            { ai.r.WS, tpz.ws.RED_LOTUS_BLADE, 0 },
            { ai.r.WS, tpz.ws.VORPAL_BLADE, 60 },
        },
        ['mode'] = ai.tp.ASAP,
        ['skill_select'] = ai.s.RANDOM,
    })
```

Replace with a db-based mob skill list and this simple binding:
```sql
INSERT INTO `mob_skill_lists` VALUES ('TRUST_Naji',1012,33); -- Burning Blade
INSERT INTO `mob_skill_lists` VALUES ('TRUST_Naji',1012,34); -- Red Lotus Blade
INSERT INTO `mob_skill_lists` VALUES ('TRUST_Naji',1012,40); -- Vorpal Blade
```
```lua
mob:setTrustTPSkillSettings(ai.tp.ASAP, ai.s.RANDOM)
```
The binding will default to `ai.tp.ASAP, ai.s.RANDOM` behaviour if not provided, so it isn't present in simple trusts.

Added bonus: All the trust skill list numbers are reserved in `release`, so no conflicts!

Also removes a good amount of wacky Lua stack and table shenanigans, so if the stack overflows were from me... this should fix it. But we still don't know the cause for sure 🤷 

This update sponsored by Maat - who has his own animations, so can't have all of his WSs yet.
