### PR TITLE
Reduce lockdown level on NPC trades

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -4064,7 +4064,7 @@ inline int32 CLuaBaseEntity::getFreeSlotsCount(lua_State *L)
 *  Notes   : Must use trade:confirmItem(slotID) first
 ************************************************************************/
 
-inline int32 CLuaBaseEntity::confirmTrade(lua_State *L)
+inline int32 CLuaBaseEntity::confirmTrade(lua_State* L)
 {
     TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
     TPZ_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
@@ -4073,11 +4073,21 @@ inline int32 CLuaBaseEntity::confirmTrade(lua_State *L)
 
     for (uint8 slotID = 0; slotID < TRADE_CONTAINER_SIZE; ++slotID)
     {
-        if (PChar->TradeContainer->getInvSlotID(slotID) != 0xFF && PChar->TradeContainer->getConfirmedStatus(slotID))
+        if (PChar->TradeContainer->getInvSlotID(slotID) != 0xFF)
         {
-            uint8 invSlotID = PChar->TradeContainer->getInvSlotID(slotID);
-            auto quantity = (int32)std::min<uint32>(PChar->TradeContainer->getQuantity(slotID), PChar->TradeContainer->getConfirmedStatus(slotID));
-            charutils::UpdateItem(PChar, LOC_INVENTORY, invSlotID, -quantity);
+            CItem* PItem = PChar->TradeContainer->getItem(slotID);
+            if (PItem)
+            {
+                uint8 confirmedItems = PChar->TradeContainer->getConfirmedStatus(slotID);
+                auto quantity = (int32)std::min<uint32>(PChar->TradeContainer->getQuantity(slotID), confirmedItems);
+
+                PItem->setReserve(PItem->getReserve() - quantity);
+                if (confirmedItems > 0)
+                {
+                    uint8 invSlotID = PChar->TradeContainer->getInvSlotID(slotID);
+                    charutils::UpdateItem(PChar, LOC_INVENTORY, invSlotID, -quantity);
+                }
+            }
         }
     }
     PChar->TradeContainer->Clean();
@@ -4092,7 +4102,7 @@ inline int32 CLuaBaseEntity::confirmTrade(lua_State *L)
 *  Notes   :
 ************************************************************************/
 
-inline int32 CLuaBaseEntity::tradeComplete(lua_State *L)
+inline int32 CLuaBaseEntity::tradeComplete(lua_State* L)
 {
     TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
     TPZ_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
@@ -4105,8 +4115,12 @@ inline int32 CLuaBaseEntity::tradeComplete(lua_State *L)
         {
             uint8 invSlotID = PChar->TradeContainer->getInvSlotID(slotID);
             int32 quantity = PChar->TradeContainer->getQuantity(slotID);
-
-            charutils::UpdateItem(PChar, LOC_INVENTORY, invSlotID, -quantity);
+            CItem* PItem = PChar->TradeContainer->getItem(slotID);
+            if (PItem)
+            {
+                PItem->setReserve(0);
+                charutils::UpdateItem(PChar, LOC_INVENTORY, invSlotID, -quantity);
+            }
         }
     }
     PChar->TradeContainer->Clean();

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -1347,22 +1347,25 @@ void SmallPacket0x036(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
             CItem* PItem = PChar->getStorage(LOC_INVENTORY)->GetItem(invSlotID);
 
-            if ((PItem == nullptr) || (PItem->isSubType(ITEM_LOCKED)) || (PItem->getQuantity() < Quantity))
+            if (PItem == nullptr || PItem->getQuantity() < Quantity)
             {
                 ShowError(CL_RED "SmallPacket0x036: Player %s trying to trade invalid item [to NPC]! \n" CL_RESET, PChar->GetName());
-
-                // Leave the items locked so people can't use invalid trade attempts to unlock arbitrary inventory slots
                 return;
             }
-            else
+
+            if (PItem->getReserve() > 0)
             {
-                PChar->TradeContainer->setItem(slotID, PItem->getID(), invSlotID, Quantity, PItem);
-                PItem->setSubType(ITEM_LOCKED);
+                ShowError(CL_RED "SmallPacket0x036: Player %s trying to trade a RESERVED item [to NPC]! \n" CL_RESET, PChar->GetName());
+                return;
             }
+
+            PItem->setReserve(Quantity);
+            PChar->TradeContainer->setItem(slotID, PItem->getID(), invSlotID, Quantity, PItem);
         }
 
         PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DETECTABLE);
         luautils::OnTrade(PChar, PNpc);
+        PChar->TradeContainer->unreserveUnconfirmed();
     }
     return;
 }

--- a/src/map/trade_container.cpp
+++ b/src/map/trade_container.cpp
@@ -21,9 +21,8 @@
 
 #include <string.h>
 
-#include "utils/itemutils.h"
 #include "trade_container.h"
-
+#include "utils/itemutils.h"
 
 CTradeContainer::CTradeContainer()
 {
@@ -80,7 +79,7 @@ uint32 CTradeContainer::getItemQuantity(uint16 itemID)
     uint32 quantity = 0;
     for (uint8 slotID = 0; slotID < m_PItem.size(); ++slotID)
     {
-        if( m_itemID[slotID] == itemID)
+        if (m_itemID[slotID] == itemID)
         {
             quantity += m_quantity[slotID];
         }
@@ -223,6 +222,28 @@ uint8 CTradeContainer::getCraftType()
 void CTradeContainer::setCraftType(uint8 craftType)
 {
     m_craftType = craftType;
+}
+
+void CTradeContainer::unreserveUnconfirmed()
+{
+    for (uint8 slotID = 0; slotID < CONTAINER_SIZE; ++slotID)
+    {
+        CItem* PItem = m_PItem[slotID];
+
+        if (PItem)
+        {
+            uint8 confirmedStatus = getConfirmedStatus(slotID);
+            if (confirmedStatus && confirmedStatus > 0)
+            {
+
+                PItem->setReserve(confirmedStatus);
+            }
+            else
+            {
+                PItem->setReserve(0);
+            }
+        }
+    }
 }
 
 void CTradeContainer::Clean()

--- a/src/map/trade_container.h
+++ b/src/map/trade_container.h
@@ -73,6 +73,7 @@ public:
     void    setItem(uint8 slotID, uint16 itemID, uint8 invSlotID, uint32 quantity, CItem* item = nullptr);
     void    setSize(uint8 size);
     void    setExSize(uint8 size);                          // Set "extra" size information; purpose changes depending on container's goal
+    void    unreserveUnconfirmed();
 
     void    Clean();                                        // отчищаем контейнер
 


### PR DESCRIPTION
Previous resolution to the NPC trade replication exploit may be overzealous in locking down trade items, preventing players from exchanging items when they legitimately should be able to.

So here is an updated version which resolves some reported issues, while offering the same level of protection!

I'll be posting the specifics of the exploits in #1146 on Monday (2020/09/28), so make sure you're patched!

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

