### PR TITLE
Add new message type for possible exploit attempts 

### DIFF
--- a/conf/default/login.conf
+++ b/conf/default/login.conf
@@ -29,6 +29,7 @@ stdout_with_ansisequence: no
 #Lua          = 512
 #Navmesh      = 1024
 #Action       = 2048
+#Exploit      = 4096
 #Example: "console_silent: 7" Hides standard, status and information messages (1+2+4)
 console_silent: 0
 

--- a/conf/default/map.conf
+++ b/conf/default/map.conf
@@ -32,6 +32,7 @@ stdout_with_ansisequence: no
 #Lua          = 512
 #Navmesh      = 1024
 #Action       = 2048
+#Exploit      = 4096
 #Example: "console_silent: 7" Hides standard, status and information messages (1+2+4)
 console_silent: 0
 

--- a/src/common/showmsg.cpp
+++ b/src/common/showmsg.cpp
@@ -646,6 +646,9 @@ int _vShowMessage(MSGTYPE flag, const std::string& string)
         case MSG_ACTION: // Bright White  (mostly useless "player did this" info)
             strcat(prefix, CL_WHITE"[Action Info]" CL_RESET);
             break;
+        case MSG_EXPLOIT: // Bright Red (Detected a likely exploit)
+            strcat(prefix, CL_RED"[Error]" CL_RESET);
+            break;
         default:
             ShowError("In function _vShowMessage() -> Invalid flag passed.\n");
             return 1;

--- a/src/common/showmsg.cpp
+++ b/src/common/showmsg.cpp
@@ -647,7 +647,7 @@ int _vShowMessage(MSGTYPE flag, const std::string& string)
             strcat(prefix, CL_WHITE"[Action Info]" CL_RESET);
             break;
         case MSG_EXPLOIT: // Bright Red (Detected a likely exploit)
-            strcat(prefix, CL_RED"[Error]" CL_RESET);
+            strcat(prefix, CL_RED"[Possible Exploit]" CL_RESET);
             break;
         default:
             ShowError("In function _vShowMessage() -> Invalid flag passed.\n");

--- a/src/common/showmsg.h
+++ b/src/common/showmsg.h
@@ -104,7 +104,8 @@ enum MSGTYPE
     MSG_SQL         = 0x0100,
     MSG_LUASCRIPT   = 0x0200,
     MSG_NAVMESH     = 0x0400,
-    MSG_ACTION      = 0x0800
+    MSG_ACTION      = 0x0800,
+    MSG_EXPLOIT     = 0x1000
 };
 
 void ClearScreen(void);
@@ -194,6 +195,13 @@ int32 ShowAction(const std::string& fmt_string, Args... args)
 {
     std::string fmt_string_v = fmt::sprintf(fmt_string, args...);
     return _vShowMessage(MSG_ACTION, fmt_string_v);
+}
+
+template<typename... Args>
+int32 ShowExploit(const std::string& fmt_string, Args... args)
+{
+    std::string fmt_string_v = fmt::sprintf(fmt_string, args...);
+    return _vShowMessage(MSG_EXPLOIT, fmt_string_v);
 }
 
 #endif /* _SHOWMSG_H_ */

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -2874,7 +2874,7 @@ void SmallPacket0x05D(map_session_data_t* session, CCharEntity* PChar, CBasicPac
     {
         return;
     }
-    
+
     PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CCharEmotionPacket(PChar, TargetID, TargetIndex, EmoteID, emoteMode, extra));
 
     luautils::OnPlayerEmote(PChar, EmoteID);
@@ -3822,13 +3822,13 @@ void SmallPacket0x085(map_session_data_t* session, CCharEntity* PChar, CBasicPac
     {
         if (quantity < 1 || quantity > PItem->getStackSize()) // Possible exploit
         {
-            ShowError(CL_RED"SmallPacket0x085: Player %s trying to sell invalid quantity %u of itemID %u [to VENDOR] \n" CL_RESET, PChar->GetName(), quantity);
+            ShowExploit(CL_RED"SmallPacket0x085: Player %s trying to sell invalid quantity %u of itemID %u [to VENDOR] \n" CL_RESET, PChar->GetName(), quantity);
             return;
         }
 
         if (PItem->isSubType(ITEM_LOCKED)) // Possible exploit
         {
-            ShowError(CL_RED"SmallPacket0x085: Player %s trying to sell %u of a LOCKED item! ID %i [to VENDOR] \n" CL_RESET, PChar->GetName(), quantity, PItem->getID());
+            ShowExploit(CL_RED"SmallPacket0x085: Player %s trying to sell %u of a LOCKED item! ID %i [to VENDOR] \n" CL_RESET, PChar->GetName(), quantity, PItem->getID());
             return;
         }
 
@@ -5868,7 +5868,7 @@ void SmallPacket0x106(map_session_data_t* session, CCharEntity* PChar, CBasicPac
     if (Quantity < 1)
     {
         // Exploit attempt..
-        ShowError(
+        ShowExploit(
             CL_RED "Player %s purchasing invalid quantity %u from Player %s bazaar! \n" CL_RESET,
             PChar->GetName(), Quantity, PTarget->GetName());
         return;
@@ -5905,7 +5905,7 @@ void SmallPacket0x106(map_session_data_t* session, CCharEntity* PChar, CBasicPac
         if (PCharGil->getQuantity() < PriceWithTax)
         {
             // Exploit attempt
-            ShowError(CL_RED "Bazaar purchase exploit attempt by: %s\n" CL_RESET, PChar->GetName());
+            ShowExploit(CL_RED "Bazaar purchase exploit attempt by: %s\n" CL_RESET, PChar->GetName());
             PChar->pushPacket(new CBazaarPurchasePacket(PTarget, false));
             return;
         }

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1636,7 +1636,7 @@ namespace charutils
                 case SLOT_SUB:
                 {
                     PChar->look.sub = 0;
-                    PChar->m_Weapons[SLOT_SUB] = itemutils::GetUnarmedItem();           // << equips "nothing" in the sub slot to prevent multi attack exploit
+                    PChar->m_Weapons[SLOT_SUB] = itemutils::GetUnarmedItem(); // << equips "nothing" in the sub slot to prevent multi attack exploit
                     PChar->health.tp = 0;
                     PChar->StatusEffectContainer->DelStatusEffect(EFFECT_AFTERMATH);
                     BuildingCharWeaponSkills(PChar);

--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -128,7 +128,7 @@ bool isRightRecipe(CCharEntity* PChar)
                 #ifdef _TPZ_SYNTH_DEBUG_MESSAGES_
                 ShowDebug(CL_CYAN"Current skill = %u, Recipe skill = %u\n" CL_RESET, currentSkill, skillValue*10);
                 #endif
-                if (currentSkill < (skillValue*10 - 150)) // Check player skill against recipe level. Range must be 14 or less. 
+                if (currentSkill < (skillValue*10 - 150)) // Check player skill against recipe level. Range must be 14 or less.
                 {
                     PChar->pushPacket(new CSynthMessagePacket(PChar, SYNTH_NOSKILL));
                     #ifdef _TPZ_SYNTH_DEBUG_MESSAGES_
@@ -418,7 +418,7 @@ int32 doSynthSkillUp(CCharEntity* PChar)
         }
 
         uint8  skillRank = PChar->RealSkills.rank[skillID]; // Check character rank
-        uint16 maxSkill  = (skillRank+1)*100;               // Skill cap, depending on rank        
+        uint16 maxSkill  = (skillRank+1)*100;               // Skill cap, depending on rank
 
         int32  charSkill = PChar->RealSkills.skill[skillID]; // Compare against real character skill, without image support, gear or moghancements
         int32  baseDiff   = PChar->CraftContainer->getQuantity(skillID-40) - charSkill/10; //the 5 lvl difference rule for breaks does NOT consider the effects of image support/gear
@@ -791,7 +791,7 @@ int32 doSynthResult(CCharEntity* PChar)
         {
             // Attempted cheating - Did not spend enough time doing the synth animation.
             #ifdef _TPZ_SYNTH_DEBUG_MESSAGES_
-            ShowDebug(CL_CYAN"Caught player cheating by injecting synth done packet.\n");
+            ShowExploit(CL_CYAN"Caught player cheating by injecting synth done packet.\n");
             #endif
             // Check whether the cheat type action requires us to actively block the cheating attempt
             // Note: Due to technical reasons jail action also forces us to break the synth


### PR DESCRIPTION
Note: seeing this in your log doesn't guarantee an exploit was being performed.

*Someday* all of these message functions should be changed into just one function with an additional parameter at the beginning telling us which type it is, rather than identical code repeated for each message type. I didn't have time for that right now though.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

