### PR TITLE
Trust: HP/MP nerfs, SJ tweaks & Trust: Prishe

### DIFF
--- a/scripts/globals/spells/trust/prishe.lua
+++ b/scripts/globals/spells/trust/prishe.lua
@@ -1,6 +1,8 @@
 -----------------------------------------
 -- Trust: Prishe
 -----------------------------------------
+require("scripts/globals/gambits")
+require("scripts/globals/magic")
 require("scripts/globals/trust")
 -----------------------------------------
 
@@ -10,4 +12,24 @@ end
 
 function onSpellCast(caster, target, spell)
     return tpz.trust.spawn(caster, spell)
+end
+
+function onMobSpawn(mob)
+    tpz.trust.teamworkMessage(mob, {
+        [tpz.magic.spell.ULMIA] = tpz.trust.message_offset.TEAMWORK_1,
+        [tpz.magic.spell.CHERUKIKI] = tpz.trust.message_offset.TEAMWORK_2,
+        [tpz.magic.spell.KUKKI_CHEBUKKI] = tpz.trust.message_offset.TEAMWORK_3,
+        [tpz.magic.spell.MAKKI_CHEBUKKI] = tpz.trust.message_offset.TEAMWORK_4,
+        [tpz.magic.spell.MILDAURION] = tpz.trust.message_offset.TEAMWORK_5,
+    })
+
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.HPP_LT, 25, ai.r.MA, ai.s.HIGHEST, tpz.magic.spellFamily.CURE)
+end
+
+function onMobDespawn(mob)
+    tpz.trust.message(mob, tpz.trust.message_offset.DESPAWN)
+end
+
+function onMobDeath(mob)
+    tpz.trust.message(mob, tpz.trust.message_offset.DEATH)
 end

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -3500,7 +3500,9 @@ INSERT INTO `mob_skill_lists` VALUES ('TRUST_Trion',1020,3194); -- Royal Saviour
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Valaineral',1025,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Joachim',1026,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Naja_Salaheem',1026,0);
--- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Prishe',1028,0);
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Prishe',1028,3234); -- Nullifying Dropkick
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Prishe',1028,3235); -- Auroral Uppercut
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Prishe',1028,3236); -- Knuckle Sandwich
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Ulmia',1029,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Shikaree_Z',1030,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Cherukiki',1031,0);

--- a/src/map/spell.cpp
+++ b/src/map/spell.cpp
@@ -605,14 +605,17 @@ namespace spell
                 {
                     return false;
                 }
+
                 // ensure trust level is appropriate+
-                if (PCaster->objtype == TYPE_TRUST && PCaster->GetMLevel() < JobMLVL)
+                if (PCaster->objtype == TYPE_TRUST && PCaster->GetMLevel() < JobMLVL && PCaster->GetSLevel() < JobSLVL)
                 {
                     return false;
                 }
+
                 // Mobs can cast any non-given char spell
                 return true;
             }
+
             if (PCaster->objtype == TYPE_PC && spell->getSpellGroup() == SPELLGROUP_TRUST)
             {
                 return true; // every PC can use trusts

--- a/src/map/utils/trustutils.cpp
+++ b/src/map/utils/trustutils.cpp
@@ -343,11 +343,23 @@ void LoadTrustStatsAndSkills(CTrustEntity* PTrust)
     uint8 jobHPGrade = grade::GetJobGrade(mJob, 0);
     uint8 jobMPGrade = grade::GetJobGrade(mJob, 1);
 
+    uint8 sjobHPGrade = grade::GetJobGrade(sJob, 0);
+    uint8 sjobMPGrade = grade::GetJobGrade(sJob, 1);
+
     float hpGrowth = 1.0f + ((7.0f - (float)jobHPGrade) / 100.0f);
     float mpGrowth = 1.0f + ((7.0f - (float)jobMPGrade) / 100.0f);
-    float base = 16.0f;
+
+    float subHPGrowth = 1.0f + ((7.0f - (float)jobHPGrade) / 100.0f);
+    float subMPGrowth = 1.0f + ((7.0f - (float)jobMPGrade) / 100.0f);
+
+    float base = 15.0f;
 
     PTrust->health.maxhp = static_cast<uint16>(base * pow(mLvl, hpGrowth) * PTrust->HPscale * map_config.alter_ego_hp_multiplier);
+
+    if (sjobMPGrade)
+    {
+        PTrust->health.maxmp = static_cast<uint16>(base * pow(sLvl, subMPGrowth) * PTrust->MPscale * map_config.alter_ego_mp_multiplier);
+    }
 
     if (jobMPGrade)
     {

--- a/src/map/utils/trustutils.cpp
+++ b/src/map/utils/trustutils.cpp
@@ -343,13 +343,13 @@ void LoadTrustStatsAndSkills(CTrustEntity* PTrust)
     uint8 jobHPGrade = grade::GetJobGrade(mJob, 0);
     uint8 jobMPGrade = grade::GetJobGrade(mJob, 1);
 
-    uint8 sjobHPGrade = grade::GetJobGrade(sJob, 0);
+    //uint8 sjobHPGrade = grade::GetJobGrade(sJob, 0);
     uint8 sjobMPGrade = grade::GetJobGrade(sJob, 1);
 
     float hpGrowth = 1.0f + ((7.0f - (float)jobHPGrade) / 100.0f);
     float mpGrowth = 1.0f + ((7.0f - (float)jobMPGrade) / 100.0f);
 
-    float subHPGrowth = 1.0f + ((7.0f - (float)jobHPGrade) / 100.0f);
+    //float subHPGrowth = 1.0f + ((7.0f - (float)jobHPGrade) / 100.0f);
     float subMPGrowth = 1.0f + ((7.0f - (float)jobMPGrade) / 100.0f);
 
     float base = 15.0f;


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**Done**
- Dropped the HP/MP base for growth for Trusts, allowed trusts to get MP based off their subjobs.
- Take Trust SJs into account when seeing if they can cast a spell
- Add Trust: Prishe. Luckily, her moves are already programmed as they are used at the end of COP, so just has to assign them.

...she'd not very good.. Oof.

**Not in this PR**
- Getting the cipher
- The cutscenes and associated TrustMemory arguments for when you receive Prishe's cipher.