### PR TITLE
Add support for configuring from system environment

### DIFF
--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -515,13 +515,13 @@ void login_config_default()
 
 void login_config_read_from_env()
 {
-    login_config.mysql_login     = std::getenv("DB_USER") ? std::getenv("DB_USER") : login_config.mysql_login;
-    login_config.mysql_password  = std::getenv("DB_USER_PASSWD") ? std::getenv("DB_USER_PASSWD") : login_config.mysql_password;
-    login_config.mysql_host      = std::getenv("DB_HOST") ? std::getenv("DB_HOST") : login_config.mysql_host;
-    login_config.mysql_port      = std::getenv("DB_PORT") ? std::stoi(std::getenv("DB_PORT")) : login_config.mysql_port;
-    login_config.mysql_database  = std::getenv("DB_NAME") ? std::getenv("DB_NAME") : login_config.mysql_database;
-    login_config.msg_server_ip   = std::getenv("MSG_IP") ? std::getenv("MSG_IP") : login_config.msg_server_ip;
-    login_config.msg_server_port = std::getenv("MSG_PORT") ? std::stoi(std::getenv("MSG_PORT")) : login_config.msg_server_port;
+    login_config.mysql_login     = std::getenv("TPZ_DB_USER") ? std::getenv("TPZ_DB_USER") : login_config.mysql_login;
+    login_config.mysql_password  = std::getenv("TPZ_DB_USER_PASSWD") ? std::getenv("TPZ_DB_USER_PASSWD") : login_config.mysql_password;
+    login_config.mysql_host      = std::getenv("TPZ_DB_HOST") ? std::getenv("TPZ_DB_HOST") : login_config.mysql_host;
+    login_config.mysql_port      = std::getenv("TPZ_DB_PORT") ? std::stoi(std::getenv("TPZ_DB_PORT")) : login_config.mysql_port;
+    login_config.mysql_database  = std::getenv("TPZ_DB_NAME") ? std::getenv("TPZ_DB_NAME") : login_config.mysql_database;
+    login_config.msg_server_ip   = std::getenv("TPZ_MSG_IP") ? std::getenv("TPZ_MSG_IP") : login_config.msg_server_ip;
+    login_config.msg_server_port = std::getenv("TPZ_MSG_PORT") ? std::stoi(std::getenv("TPZ_MSG_PORT")) : login_config.msg_server_port;
 }
 
 void version_info_default()

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -33,6 +33,7 @@
 #include <thread>
 #include <iostream>
 #include <functional>
+#include <cstdlib>
 
 #ifdef WIN32
 #include <io.h>
@@ -82,6 +83,7 @@ int32 do_init(int32 argc, char** argv)
 
     login_config_default();
     config_read(LOGIN_CONF_FILENAME, "login", login_config_read);
+    login_config_read_from_env();
 
     version_info_default();
     config_read(VERSION_INFO_FILENAME, "version info", version_info_read);
@@ -509,6 +511,17 @@ void login_config_default()
 
     login_config.log_user_ip = "false";
     login_config.account_creation = "true";
+}
+
+void login_config_read_from_env()
+{
+    login_config.mysql_login     = std::getenv("DB_USER") ? std::getenv("DB_USER") : login_config.mysql_login;
+    login_config.mysql_password  = std::getenv("DB_USER_PASSWD") ? std::getenv("DB_USER_PASSWD") : login_config.mysql_password;
+    login_config.mysql_host      = std::getenv("DB_HOST") ? std::getenv("DB_HOST") : login_config.mysql_host;
+    login_config.mysql_port      = std::getenv("DB_PORT") ? std::stoi(std::getenv("DB_PORT")) : login_config.mysql_port;
+    login_config.mysql_database  = std::getenv("DB_NAME") ? std::getenv("DB_NAME") : login_config.mysql_database;
+    login_config.msg_server_ip   = std::getenv("MSG_IP") ? std::getenv("MSG_IP") : login_config.msg_server_ip;
+    login_config.msg_server_port = std::getenv("MSG_PORT") ? std::stoi(std::getenv("MSG_PORT")) : login_config.msg_server_port;
 }
 
 void version_info_default()

--- a/src/login/login.h
+++ b/src/login/login.h
@@ -93,6 +93,7 @@ void login_versionscreen(int32 flag);
 
 void login_config_read(const char *key, const char* value);
 void login_config_default();
+void login_config_read_from_env();
 
 void version_info_read(const char *key, const char* value);
 void version_info_default();

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1021,13 +1021,13 @@ int32 map_config_default()
 
 int32 map_config_from_env()
 {
-    map_config.mysql_login     = std::getenv("DB_USER") ? std::getenv("DB_USER") : map_config.mysql_login;
-    map_config.mysql_password  = std::getenv("DB_USER_PASSWD") ? std::getenv("DB_USER_PASSWD") : map_config.mysql_password;
-    map_config.mysql_host      = std::getenv("DB_HOST") ? std::getenv("DB_HOST") : map_config.mysql_host;
-    map_config.mysql_port      = std::getenv("DB_PORT") ? std::stoi(std::getenv("DB_PORT")) : map_config.mysql_port;
-    map_config.mysql_database  = std::getenv("DB_NAME") ? std::getenv("DB_NAME") : map_config.mysql_database;
-    map_config.msg_server_ip   = std::getenv("MSG_IP") ? std::getenv("MSG_IP") : map_config.msg_server_ip;
-    map_config.msg_server_port = std::getenv("MSG_PORT") ? std::stoi(std::getenv("MSG_PORT")) : map_config.msg_server_port;
+    map_config.mysql_login     = std::getenv("TPZ_DB_USER") ? std::getenv("TPZ_DB_USER") : map_config.mysql_login;
+    map_config.mysql_password  = std::getenv("TPZ_DB_USER_PASSWD") ? std::getenv("TPZ_DB_USER_PASSWD") : map_config.mysql_password;
+    map_config.mysql_host      = std::getenv("TPZ_DB_HOST") ? std::getenv("TPZ_DB_HOST") : map_config.mysql_host;
+    map_config.mysql_port      = std::getenv("TPZ_DB_PORT") ? std::stoi(std::getenv("TPZ_DB_PORT")) : map_config.mysql_port;
+    map_config.mysql_database  = std::getenv("TPZ_DB_NAME") ? std::getenv("TPZ_DB_NAME") : map_config.mysql_database;
+    map_config.msg_server_ip   = std::getenv("TPZ_MSG_IP") ? std::getenv("TPZ_MSG_IP") : map_config.msg_server_ip;
+    map_config.msg_server_port = std::getenv("TPZ_MSG_PORT") ? std::stoi(std::getenv("TPZ_MSG_PORT")) : map_config.msg_server_port;
     return 0;
 }
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -166,6 +166,7 @@ int32 do_init(int32 argc, char** argv)
 
     map_config_default();
     map_config_read((const int8*)MAP_CONF_FILENAME);
+    map_config_from_env();
     ShowMessage("\t\t - " CL_GREEN"[OK]" CL_RESET"\n");
     ShowStatus("do_init: map_config is reading");
     ShowMessage("\t\t - " CL_GREEN"[OK]" CL_RESET"\n");
@@ -1015,6 +1016,18 @@ int32 map_config_default()
     map_config.skillup_bloodpact = true;
     map_config.anticheat_enabled = false;
     map_config.anticheat_jail_disable = false;
+    return 0;
+}
+
+int32 map_config_from_env()
+{
+    map_config.mysql_login     = std::getenv("DB_USER") ? std::getenv("DB_USER") : map_config.mysql_login;
+    map_config.mysql_password  = std::getenv("DB_USER_PASSWD") ? std::getenv("DB_USER_PASSWD") : map_config.mysql_password;
+    map_config.mysql_host      = std::getenv("DB_HOST") ? std::getenv("DB_HOST") : map_config.mysql_host;
+    map_config.mysql_port      = std::getenv("DB_PORT") ? std::stoi(std::getenv("DB_PORT")) : map_config.mysql_port;
+    map_config.mysql_database  = std::getenv("DB_NAME") ? std::getenv("DB_NAME") : map_config.mysql_database;
+    map_config.msg_server_ip   = std::getenv("MSG_IP") ? std::getenv("MSG_IP") : map_config.msg_server_ip;
+    map_config.msg_server_port = std::getenv("MSG_PORT") ? std::stoi(std::getenv("MSG_PORT")) : map_config.msg_server_port;
     return 0;
 }
 

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -195,6 +195,7 @@ void  map_versionscreen(int32 flag);                                            
 
 int32 map_config_read(const int8 *cfgName);                                             // Map-Server Config [venom]
 int32 map_config_default();
+int32 map_config_from_env();
 
 int32 map_cleanup(time_point tick,CTaskMgr::CTask *PTask);                              // Clean up timed out players
 int32 map_close_session(time_point tick, map_session_data_t* map_session_data);

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -404,11 +404,11 @@ void search_config_read(const int8* file)
 
 void search_config_read_from_env()
 {
-    search_config.mysql_login   = std::getenv("DB_USER") ? std::getenv("DB_USER") : search_config.mysql_login;
-    search_config.mysql_password = std::getenv("DB_USER_PASSWD") ? std::getenv("DB_USER_PASSWD") : search_config.mysql_password;
-    search_config.mysql_host     = std::getenv("DB_HOST") ? std::getenv("DB_HOST") : search_config.mysql_host;
-    search_config.mysql_port     = std::getenv("DB_PORT") ? std::stoi(std::getenv("DB_PORT")) : search_config.mysql_port;
-    search_config.mysql_database = std::getenv("DB_NAME") ? std::getenv("DB_NAME") : search_config.mysql_database;
+    search_config.mysql_login    = std::getenv("TPZ_DB_USER") ? std::getenv("TPZ_DB_USER") : search_config.mysql_login;
+    search_config.mysql_password = std::getenv("TPZ_DB_USER_PASSWD") ? std::getenv("TPZ_DB_USER_PASSWD") : search_config.mysql_password;
+    search_config.mysql_host     = std::getenv("TPZ_DB_HOST") ? std::getenv("TPZ_DB_HOST") : search_config.mysql_host;
+    search_config.mysql_port     = std::getenv("TPZ_DB_PORT") ? std::stoi(std::getenv("TPZ_DB_PORT")) : search_config.mysql_port;
+    search_config.mysql_database = std::getenv("TPZ_DB_NAME") ? std::getenv("TPZ_DB_NAME") : search_config.mysql_database;
 }
 
 /************************************************************************
@@ -466,7 +466,7 @@ void login_config_read(const int8* file)
 
 void login_config_read_from_env()
 {
-    login_config.search_server_port = std::getenv("SEARCH_PORT") ? std::getenv("SEARCH_PORT") : login_config.search_server_port;
+    login_config.search_server_port = std::getenv("TPZ_SEARCH_PORT") ? std::getenv("TPZ_SEARCH_PORT") : login_config.search_server_port;
 }
 
 void TCPComm(SOCKET socket)

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -98,9 +98,11 @@ login_config_t login_config;
 
 void search_config_default();
 void search_config_read(const int8* file);
+void search_config_read_from_env();
 
 void login_config_default();
 void login_config_read(const int8* file);       // We only need the search server port defined here
+void login_config_read_from_env();
 
 /************************************************************************
 *                                                                       *
@@ -169,7 +171,9 @@ int32 main(int32 argc, char **argv)
 
     search_config_default();
     search_config_read((const int8*)SEARCH_CONF_FILENAME);
+    search_config_read_from_env();
     login_config_read((const int8*)LOGIN_CONF_FILENAME);
+    login_config_read_from_env();
 
 #ifdef WIN32
     // Initialize Winsock
@@ -398,6 +402,15 @@ void search_config_read(const int8* file)
     fclose(fp);
 }
 
+void search_config_read_from_env()
+{
+    search_config.mysql_login   = std::getenv("DB_USER") ? std::getenv("DB_USER") : search_config.mysql_login;
+    search_config.mysql_password = std::getenv("DB_USER_PASSWD") ? std::getenv("DB_USER_PASSWD") : search_config.mysql_password;
+    search_config.mysql_host     = std::getenv("DB_HOST") ? std::getenv("DB_HOST") : search_config.mysql_host;
+    search_config.mysql_port     = std::getenv("DB_PORT") ? std::stoi(std::getenv("DB_PORT")) : search_config.mysql_port;
+    search_config.mysql_database = std::getenv("DB_NAME") ? std::getenv("DB_NAME") : search_config.mysql_database;
+}
+
 /************************************************************************
 *                                                                       *
 *  login_topaz                                                          *
@@ -449,6 +462,11 @@ void login_config_read(const int8* file)
         }
     }
     fclose(fp);
+}
+
+void login_config_read_from_env()
+{
+    login_config.search_server_port = std::getenv("SEARCH_PORT") ? std::getenv("SEARCH_PORT") : login_config.search_server_port;
 }
 
 void TCPComm(SOCKET socket)


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Salvaged from Dan's PR: `Beginning support for Ansible, Docker, and Jenkins #867`

This will aid in letting people automate the different processes inside containers, otherwise, it won't affect anyone at all (That is of course, unless you have these things defined on your regular system for _something else_, then things will get weird.)



**TODO**
Test it