### PR TITLE
CI: Swap mysql:5.6 image for mariadb:10.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,7 @@ jobs:
     runs-on: ubuntu-18.04
     services:
       mysql:
-        image: mysql:5.6
+        image: mariadb:10.1
         env:
           MYSQL_DATABASE: tpzdb
           MYSQL_ROOT_PASSWORD: root


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Didn't know MariaDB was _this much_ of a drop-in replacement for MySQL. We think Maria is much fussier around comment formatting and maybe a few other things, so this will hopefully catch future strangeness.

I picked 10.1 because that's what I've used in the rest of the CI, I'm open to suggestions to changing it to other versions