### PR TITLE
Add JST timekeeping functions to vanatime

### DIFF
--- a/src/map/time_server.cpp
+++ b/src/map/time_server.cpp
@@ -87,6 +87,28 @@ int32 time_server(time_point tick,CTaskMgr::CTask* PTask)
         }
     }
 
+    //JST Midnight
+    static time_point lastTickedJstMidnight = tick - 1s;
+    if (CVanaTime::getInstance()->getJstHour() == 0 && CVanaTime::getInstance()->getJstMinute() == 0)
+    {
+        if (tick > (lastTickedJstMidnight + 1h))
+        {
+            // roeutils::CycleDailyRecords();
+            lastTickedJstMidnight = tick;
+        }
+    }
+
+    //4-hour RoE Timed blocks
+    static time_point lastTickedRoeBlock = tick - 1s;
+    if (CVanaTime::getInstance()->getJstHour() % 4 == 0 && CVanaTime::getInstance()->getJstMinute() == 0)
+    {
+        if (tick > (lastTickedRoeBlock + 1h))
+        {
+            // roeutils::CycleTimedRecords();
+            lastTickedRoeBlock = tick;
+        }
+    }
+
     if (CVanaTime::getInstance()->getHour() == 0 && CVanaTime::getInstance()->getMinute() == 0)
     {
         if (tick > (CVanaTime::getInstance()->lastVDailyUpdate + 4800ms))

--- a/src/map/vana_time.cpp
+++ b/src/map/vana_time.cpp
@@ -19,6 +19,10 @@
 ===========================================================================
 */
 
+#ifdef WIN32
+#define timegm _mkgmtime
+#endif
+
 #include "../common/showmsg.h"
 
 #include <time.h>
@@ -124,6 +128,64 @@ uint32 CVanaTime::getSysYearDay()
     tm *ltm = localtime(&now);
 
     return ltm->tm_yday;
+}
+
+uint32 CVanaTime::getJstHour()
+{
+    auto now = time(nullptr) + JST_OFFSET;
+    tm *jtm = gmtime(&now);
+
+    return jtm->tm_hour;
+}
+
+uint32 CVanaTime::getJstMinute()
+{
+    auto now = time(nullptr) + JST_OFFSET;
+    tm *jtm = gmtime(&now);
+
+    return jtm->tm_min;
+}
+
+uint32 CVanaTime::getJstSecond()
+{
+    auto now = time(nullptr) + JST_OFFSET;
+    tm *jtm = gmtime(&now);
+
+    return jtm->tm_sec;
+}
+
+uint32 CVanaTime::getJstWeekDay()
+{
+    auto now = time(nullptr) + JST_OFFSET;
+    tm *jtm = gmtime(&now);
+
+    return jtm->tm_wday;
+}
+
+uint32 CVanaTime::getJstDayOfMonth()
+{
+    auto now = time(nullptr) + JST_OFFSET;
+    tm *jtm = gmtime(&now);
+
+    return jtm->tm_mday;
+}
+
+uint32 CVanaTime::getJstYearDay()
+{
+    auto now = time(nullptr) + JST_OFFSET;
+    tm *jtm = gmtime(&now);
+
+    return jtm->tm_yday;
+}
+
+uint32 CVanaTime::getJstMidnight()
+{
+    auto now = time(nullptr) + JST_OFFSET;
+    tm* jst = gmtime(&now);
+    jst->tm_hour = 0;
+    jst->tm_min = 0;
+    jst->tm_sec = 0;
+    return static_cast<uint32>(timegm(jst) - JST_OFFSET + (60 * 60 * 24));     // Unix timestamp of the upcoming JST midnight
 }
 
 uint32 CVanaTime::getVanaTime()

--- a/src/map/vana_time.h
+++ b/src/map/vana_time.h
@@ -29,6 +29,8 @@
 #define VTIME_DAY			1440			// 24 hours * GameHour
 #define VTIME_HOUR			60				// 60 minutes
 
+#define JST_OFFSET 32400                    // JST +offset from UTC
+
 #include "../common/cbasetypes.h"
 
 enum DAYTYPE
@@ -81,6 +83,13 @@ public:
 	uint32	 getSysSecond();
 	uint32	 getSysWeekDay();						// Number of day since sunday
 	uint32	 getSysYearDay();						// Number of day since 1st january
+    uint32   getJstHour();
+    uint32   getJstMinute();
+    uint32   getJstSecond();
+    uint32   getJstWeekDay();                       // Number of day since sunday
+    uint32   getJstDayOfMonth();
+    uint32   getJstYearDay();                       // Number of day since 1st january
+    uint32   getJstMidnight();                      // Upcoming JST midnight in unix timestamp
 
     uint32   getVanaTime();
 	int32	 getCustomEpoch();


### PR DESCRIPTION
This adds functions to retrieve JST-based time. It is agnostic to the local timezone setting, only expecting the clock be set correctly for their own local timezone.

Should greatly help PR #914 

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

