### PR TITLE
Change Conquest update + Guild Shop resets to JST time

### DIFF
--- a/scripts/globals/common.lua
+++ b/scripts/globals/common.lua
@@ -46,29 +46,10 @@ end
 
 -----------------------------------
 --  getMidnight
---  Returns midnight for the current day in epoch format
+--  Returns the next upcoming JST midnight
 -----------------------------------
 
-function getMidnight(day)
-    -- Get time, because this is going to get ugly.  Using ! for UTC won't work where we're going.
-    local hometime = os.date("*t")
-    if day ~= nil then
-        hometime = os.date("*t", day)
-    end
-    -- Set to 24:00 to get end of the day.
-    local midnight = os.time{year=hometime.year, month=hometime.month, day=hometime.day, hour=24}
-    -- And determine the timezone in seconds, because we'll need that to get UTC and LUA doesn't make it easy.
-    local timezone = os.difftime(os.time(), os.time(os.date("!*t")))
-
-    -- Midnight adjusted for timezone, then timezone offset * 3600 to get us where we want to be.
-    local finaltime = midnight + timezone - (TIMEZONE_OFFSET * 3600)
-    -- And make sure that the offset midnight isn't already passed
-    if day ~= nil and finaltime <= day or day == nil and finaltime <= os.time() then
-        finaltime = finaltime + 86400
-    end
-
-    return finaltime
-end
+getMidnight = JstMidnight
 
 -----------------------------------
 --  getVanaMidnight(day)

--- a/scripts/globals/settings.lua
+++ b/scripts/globals/settings.lua
@@ -143,7 +143,6 @@ HOMEPOINT_HEAL = 0 --Set to 1 if you want Home Points to heal you like in single
 RIVERNE_PORTERS = 120 -- Time in seconds that Unstable Displacements in Cape Riverne stay open after trading a scale.
 LANTERNS_STAY_LIT = 1200 -- time in seconds that lanterns in the Den of Rancor stay lit.
 ENABLE_COP_ZONE_CAP = 0 -- enable or disable lvl cap
-TIMEZONE_OFFSET = 9.0 -- Offset from UTC used to determine when "JP Midnight" is for the server.  Default is JST (+9.0).
 ALLOW_MULTIPLE_EXP_RINGS = 0 -- Set to 1 to remove ownership restrictions on the Chariot/Empress/Emperor Band trio.
 BYPASS_EXP_RING_ONE_PER_WEEK = 0 -- -- Set to 1 to bypass the limit of one ring per Conquest Tally Week.
 NUMBER_OF_DM_EARRINGS = 1 -- Number of earrings players can simultaneously own from Divine Might before scripts start blocking them (Default: 1)

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -118,6 +118,7 @@ namespace luautils
         lua_register(LuaHandle, "GetPlayerByName", luautils::GetPlayerByName);
         lua_register(LuaHandle, "GetPlayerByID", luautils::GetPlayerByID);
         lua_register(LuaHandle, "GetMobAction", luautils::GetMobAction);
+        lua_register(LuaHandle, "JstMidnight", luautils::JstMidnight);
         lua_register(LuaHandle, "VanadielTime", luautils::VanadielTime);
         lua_register(LuaHandle, "VanadielTOTD", luautils::VanadielTOTD);
         lua_register(LuaHandle, "VanadielHour", luautils::VanadielHour);
@@ -446,6 +447,7 @@ namespace luautils
         return 0;
     }
 
+
     /************************************************************************
     *                                                                       *
     *  Узнаем страну, владеющую текущим регионом                            *
@@ -687,6 +689,19 @@ namespace luautils
     int32 VanadielDayElement(lua_State* L)
     {
         lua_pushinteger(L, CVanaTime::getInstance()->getWeekday());
+        return 1;
+    }
+
+
+    /************************************************************************
+    *                                                                       *
+    * JstMidnight - Returns UTC timestamp of upcoming JST midnight
+    *                                                                       *
+    ************************************************************************/
+
+    int32 JstMidnight(lua_State* L)
+    {
+        lua_pushinteger(L, CVanaTime::getInstance()->getJstMidnight());
         return 1;
     }
 

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -149,6 +149,7 @@ namespace luautils
     int32 GetPlayerByName(lua_State*);                                          // Gets Player ref from a name supplied
     int32 GetPlayerByID(lua_State*);                                            // Gets Player ref from an Id supplied
     int32 GetMobAction(lua_State*);                                             // Get Mobs current action
+    int32 JstMidnight(lua_State* L);
     int32 VanadielTime(lua_State*);                                             // Gets the current Vanadiel Time in timestamp format (SE epoch in earth seconds)
     int32 VanadielTOTD(lua_State*);                                             // текущее игровое время суток
     int32 VanadielHour(lua_State*);                                             // текущие Vanadiel часы

--- a/src/map/time_server.cpp
+++ b/src/map/time_server.cpp
@@ -40,27 +40,31 @@ int32 time_server(time_point tick,CTaskMgr::CTask* PTask)
     // uint8 WeekDay = (uint8)CVanaTime::getInstance()->getWeekday();
 
     // weekly update for conquest (sunday at midnight)
+    static time_point lastConquestTally = tick - 1h;
+    static time_point lastConquestUpdate = tick - 1h;
     if (CVanaTime::getInstance()->getSysWeekDay() == 1  && CVanaTime::getInstance()->getSysHour() == 0 && CVanaTime::getInstance()->getSysMinute() == 0)
     {
-        if (tick > (CVanaTime::getInstance()->lastConquestTally + 1h))
+        if (tick > (lastConquestTally + 1h))
         {
             conquest::UpdateWeekConquest();
-            CVanaTime::getInstance()->lastConquestTally = tick;
+            lastConquestTally = tick;
         }
     }
     // hourly conquest update
     else if (CVanaTime::getInstance()->getSysMinute() == 0)
     {
-        if (tick > (CVanaTime::getInstance()->lastConquestUpdate + 1h))
+        if (tick > (lastConquestUpdate + 1h))
         {
             conquest::UpdateConquestSystem();
-            CVanaTime::getInstance()->lastConquestUpdate = tick;
+            lastConquestUpdate = tick;
         }
     }
 
+    // Vanadiel Hour
+    static time_point lastVHourlyUpdate = tick - 4800ms;
     if (CVanaTime::getInstance()->getMinute() == 0)
     {
-        if (tick > (CVanaTime::getInstance()->lastVHourlyUpdate + 4800ms))
+        if (tick > (lastVHourlyUpdate + 4800ms))
         {
 			zoneutils::ForEachZone([](CZone* PZone)
             {
@@ -72,34 +76,25 @@ int32 time_server(time_point tick,CTaskMgr::CTask* PTask)
 				});
 			});
 
-            CVanaTime::getInstance()->lastVHourlyUpdate = tick;
+            lastVHourlyUpdate = tick;
         }
 
-    }
-
-    //Midnight
-    if (CVanaTime::getInstance()->getSysHour() == 0 && CVanaTime::getInstance()->getSysMinute() == 0)
-    {
-        if (tick > (CVanaTime::getInstance()->lastMidnight + 1h))
-        {
-            guildutils::UpdateGuildPointsPattern();
-            CVanaTime::getInstance()->lastMidnight = tick;
-        }
     }
 
     //JST Midnight
-    static time_point lastTickedJstMidnight = tick - 1s;
+    static time_point lastTickedJstMidnight = tick - 1h;
     if (CVanaTime::getInstance()->getJstHour() == 0 && CVanaTime::getInstance()->getJstMinute() == 0)
     {
         if (tick > (lastTickedJstMidnight + 1h))
         {
             // roeutils::CycleDailyRecords();
+            guildutils::UpdateGuildPointsPattern();
             lastTickedJstMidnight = tick;
         }
     }
 
     //4-hour RoE Timed blocks
-    static time_point lastTickedRoeBlock = tick - 1s;
+    static time_point lastTickedRoeBlock = tick - 1h;
     if (CVanaTime::getInstance()->getJstHour() % 4 == 0 && CVanaTime::getInstance()->getJstMinute() == 0)
     {
         if (tick > (lastTickedRoeBlock + 1h))
@@ -109,9 +104,11 @@ int32 time_server(time_point tick,CTaskMgr::CTask* PTask)
         }
     }
 
+    // Vanadiel Day
+    static time_point lastVDailyUpdate = tick - 4800ms;
     if (CVanaTime::getInstance()->getHour() == 0 && CVanaTime::getInstance()->getMinute() == 0)
     {
-        if (tick > (CVanaTime::getInstance()->lastVDailyUpdate + 4800ms))
+        if (tick > (lastVDailyUpdate + 4800ms))
         {
 			zoneutils::ForEachZone([](CZone* PZone)
 			{
@@ -125,7 +122,7 @@ int32 time_server(time_point tick,CTaskMgr::CTask* PTask)
             guildutils::UpdateGuildsStock();
             zoneutils::SavePlayTime();
 
-            CVanaTime::getInstance()->lastVDailyUpdate = tick;
+            lastVDailyUpdate = tick;
         }
     }
 

--- a/src/map/time_server.cpp
+++ b/src/map/time_server.cpp
@@ -42,7 +42,7 @@ int32 time_server(time_point tick,CTaskMgr::CTask* PTask)
     // weekly update for conquest (sunday at midnight)
     static time_point lastConquestTally = tick - 1h;
     static time_point lastConquestUpdate = tick - 1h;
-    if (CVanaTime::getInstance()->getSysWeekDay() == 1  && CVanaTime::getInstance()->getSysHour() == 0 && CVanaTime::getInstance()->getSysMinute() == 0)
+    if (CVanaTime::getInstance()->getJstWeekDay() == 1  && CVanaTime::getInstance()->getJstHour() == 0 && CVanaTime::getInstance()->getJstMinute() == 0)
     {
         if (tick > (lastConquestTally + 1h))
         {
@@ -51,7 +51,7 @@ int32 time_server(time_point tick,CTaskMgr::CTask* PTask)
         }
     }
     // hourly conquest update
-    else if (CVanaTime::getInstance()->getSysMinute() == 0)
+    else if (CVanaTime::getInstance()->getJstMinute() == 0)
     {
         if (tick > (lastConquestUpdate + 1h))
         {

--- a/src/map/utils/guildutils.cpp
+++ b/src/map/utils/guildutils.cpp
@@ -153,7 +153,7 @@ void UpdateGuildPointsPattern()
 
     if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) == 1 && Sql_NextRow(SqlHandle) == SQL_SUCCESS)
     {
-        if (Sql_GetUIntData(SqlHandle, 0) != CVanaTime::getInstance()->getSysYearDay())
+        if (Sql_GetUIntData(SqlHandle, 0) != CVanaTime::getInstance()->getJstYearDay())
         {
             update = true;
         }
@@ -166,7 +166,7 @@ void UpdateGuildPointsPattern()
     {
         //write the new pattern and update time to prevent other servers from updating the pattern
         Sql_Query(SqlHandle, "REPLACE INTO server_variables (name,value) VALUES('[GUILD]pattern_update', %u), ('[GUILD]pattern', %u);",
-            CVanaTime::getInstance()->getSysYearDay(), pattern);
+            CVanaTime::getInstance()->getJstYearDay(), pattern);
         Sql_Query(SqlHandle, "DELETE FROM char_vars WHERE varname = '[GUILD]daily_points';");
     }
 

--- a/src/map/vana_time.h
+++ b/src/map/vana_time.h
@@ -96,11 +96,6 @@ public:
 
 	void	 setCustomEpoch(int32 epoch);
 
-	time_point   lastConquestUpdate;
-    time_point   lastVHourlyUpdate;
-    time_point   lastVDailyUpdate;
-    time_point   lastConquestTally;
-    time_point   lastMidnight;
 
 private:
 


### PR DESCRIPTION
+ Move Guild Reset over to JST midnight instead of local.
+ fix + remove single-purpose vars from global Vanatime class.
+ Move Conquest over to JST instead of local time.
+ Migrate Lua over to new JST function for getMidnight.

Fixes #750
Fixes #875
Fixes #22 
Closes #552 

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

