### PR TITLE
Implements Subtle Blow II

### DIFF
--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1120,6 +1120,7 @@ tpz.mod =
     DUAL_WIELD                      = 259,
     DOUBLE_ATTACK                   = 288,
     SUBTLE_BLOW                     = 289,
+    SUBTLE_BLOW_II                  = 973, -- Subtle Blow II Effect (Cap 50%) Total Effect (SB + SB_II cap 75%)
     ENF_MAG_POTENCY                 = 290, -- Increases Enfeebling magic potency %
     COUNTER                         = 291,
     KICK_ATTACK_RATE                = 292,
@@ -1565,9 +1566,9 @@ tpz.mod =
 
     -- The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     -- 570 - 825 used by WS DMG mods these are not spares.
-    -- SPARE = 973, -- stuff
     -- SPARE = 974, -- stuff
     -- SPARE = 975, -- stuff
+    -- SPARE = 976, -- stuff
 }
 
 tpz.latent =

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -33827,7 +33827,7 @@ INSERT INTO `item_mods` VALUES (25785,31,86);     -- Magic Evasion+86
 INSERT INTO `item_mods` VALUES (25785,68,60);     -- Evasion+60
 INSERT INTO `item_mods` VALUES (25785,165,4);     -- Crit Hit Rate+4
 INSERT INTO `item_mods` VALUES (25785,250,90);    -- Resist Slow+90
-INSERT INTO `item_mods` VALUES (25785,289,10);    -- Subtle Blow+10
+INSERT INTO `item_mods` VALUES (25785,973,10);    -- Subtle Blow II +10
 INSERT INTO `item_mods` VALUES (25785,302,5);     -- Triple Attack+5
 INSERT INTO `item_mods` VALUES (25785,384,100);    -- Haste +1%
 INSERT INTO `item_mods` VALUES (25786,1,148);     -- ashera_harness DEF:148
@@ -34841,7 +34841,7 @@ INSERT INTO `item_mods` VALUES (26084,8,5);       -- sherida_earring STR+5
 INSERT INTO `item_mods` VALUES (26084,9,5);       -- DEX+5
 INSERT INTO `item_mods` VALUES (26084,73,5);      -- Store TP+5
 INSERT INTO `item_mods` VALUES (26084,288,5);     -- Double Attack+5
-INSERT INTO `item_mods` VALUES (26084,289,5);     -- Subtle Blow+5
+INSERT INTO `item_mods` VALUES (26084,973,5);     -- Subtle Blow II +5
 INSERT INTO `item_mods` VALUES (26160,116,10);    -- Evanescence Ring: Dark magic skill +10
 INSERT INTO `item_mods` VALUES (26160,168,5);     -- Spell interruption rate down 5%
 INSERT INTO `item_mods` VALUES (26160,315,10);    -- Drain and Aspir potency +10%
@@ -34890,7 +34890,7 @@ INSERT INTO `item_mods` VALUES (26184,369,1);     -- Refresh+1
 INSERT INTO `item_mods` VALUES (26185,8,10);      -- niqmaddu_ring STR+10
 INSERT INTO `item_mods` VALUES (26185,9,10);      -- DEX+10
 INSERT INTO `item_mods` VALUES (26185,10,10);     -- VIT+10
-INSERT INTO `item_mods` VALUES (26185,289,5);     -- Subtle Blow+5
+INSERT INTO `item_mods` VALUES (26185,973,5);     -- Subtle Blow II +5
 INSERT INTO `item_mods` VALUES (26185,430,3);     -- Quad Attack+3
 INSERT INTO `item_mods` VALUES (26186,1,10);      -- ilabrat_ring DEF:10
 INSERT INTO `item_mods` VALUES (26186,2,60);      -- HP+60
@@ -34983,11 +34983,13 @@ INSERT INTO `item_mods` VALUES (26340,8,15);      -- STR+15
 INSERT INTO `item_mods` VALUES (26340,9,15);      -- DEX+15
 INSERT INTO `item_mods` VALUES (26340,160,-5);    -- Damage Taken-5
 INSERT INTO `item_mods` VALUES (26340,302,6);     -- Triple Attack+6
+INSERT INTO `item_mods` VALUES (26340,973,10);    -- Subtle Blow II +10
 INSERT INTO `item_mods` VALUES (26341,1,25);      -- moonbow_belt_+1 DEF:25
 INSERT INTO `item_mods` VALUES (26341,8,20);      -- STR+20
 INSERT INTO `item_mods` VALUES (26341,9,20);      -- DEX+20
 INSERT INTO `item_mods` VALUES (26341,160,-6);    -- Damage Taken-6
 INSERT INTO `item_mods` VALUES (26341,302,8);     -- Triple Attack+8
+INSERT INTO `item_mods` VALUES (26341,973,15);    -- Subtle Blow II +15
 INSERT INTO `item_mods` VALUES (26400,1,60); -- Culminus: DEF+60
 INSERT INTO `item_mods` VALUES (26400,2,57); -- HP+57
 INSERT INTO `item_mods` VALUES (26400,5,64); -- MP+64

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -804,11 +804,13 @@ enum class Mod
     CONQUEST_REGION_BONUS     = 934, // Increases the influence points awarded to the player's nation when receiving conquest points
     CAMPAIGN_BONUS            = 935, // Increases the evaluation for allied forces by percentage
 
+    SUBTLE_BLOW_II            = 973, // Subtle Blow II Effect (Cap 50%) Total Effect (SB + SB_II cap 75%)
+
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     // 570 through 825 used by WS DMG mods these are not spares.
-    // SPARE = 973, // stuff
     // SPARE = 974, // stuff
     // SPARE = 975, // stuff
+    // SPARE = 976, // stuff
 };
 
 //temporary workaround for using enum class as unordered_map key until compilers support it

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2000,8 +2000,8 @@ namespace battleutils
             if (giveTPtoVictim)
             {
                 //account for attacker's subtle blow which reduces the baseTP gain for the defender
-                float sBlow1 = ((100.0f - std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW), 0.0f, 50.0f)) / 100.0f);
-                float sBlow2 = ((100.0f - std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW_II), 0.0f, 50.0f)) / 100.0f);
+                float sBlow1 = (100.0f - std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW), 0.0f, 50.0f));
+                float sBlow2 = (100.0f - std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW_II), 0.0f, 50.0f));
                 float sBlowMult = ((100.0f - std::clamp((float)(sBlow1 + sBlow2), 0.0f, 75.0f)) / 100.0f);
 
                 //mobs hit get basetp+30 whereas pcs hit get basetp/3
@@ -2128,8 +2128,8 @@ namespace battleutils
             }
 
             //account for attacker's subtle blow which reduces the baseTP gain for the defender
-            float sBlow1 = ((100.0f - std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW), 0.0f, 50.0f)) / 100.0f);
-            float sBlow2 = ((100.0f - std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW_II), 0.0f, 50.0f)) / 100.0f);
+            float sBlow1 = (100.0f - std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW), 0.0f, 50.0f));
+            float sBlow2 = (100.0f - std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW_II), 0.0f, 50.0f));
             float sBlowMult = ((100.0f - std::clamp((float)(sBlow1 + sBlow2), 0.0f, 75.0f)) / 100.0f);
 
             //mobs hit get basetp+30 whereas pcs hit get basetp/3

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2000,9 +2000,9 @@ namespace battleutils
             if (giveTPtoVictim)
             {
                 //account for attacker's subtle blow which reduces the baseTP gain for the defender
-                float sBlow1 = (100.0f - std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW), 0.0f, 50.0f));
-                float sBlow2 = (100.0f - std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW_II), 0.0f, 50.0f));
-                float sBlowMult = ((100.0f - std::clamp((float)(sBlow1 + sBlow2), 0.0f, 75.0f)) / 100.0f);
+                float sBlow1 = std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW), -50.0f, 50.0f);
+                float sBlow2 = std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW_II), -50.0f, 50.0f);
+                float sBlowMult = ((100.0f - std::clamp((float)(sBlow1 + sBlow2), -75.0f, 75.0f)) / 100.0f);
 
                 //mobs hit get basetp+30 whereas pcs hit get basetp/3
                 if (PDefender->objtype == TYPE_PC || (PDefender->objtype == TYPE_PET && PDefender->PMaster && PDefender->PMaster->objtype == TYPE_PC))
@@ -2128,9 +2128,9 @@ namespace battleutils
             }
 
             //account for attacker's subtle blow which reduces the baseTP gain for the defender
-            float sBlow1 = (100.0f - std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW), 0.0f, 50.0f));
-            float sBlow2 = (100.0f - std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW_II), 0.0f, 50.0f));
-            float sBlowMult = ((100.0f - std::clamp((float)(sBlow1 + sBlow2), 0.0f, 75.0f)) / 100.0f);
+            float sBlow1 = std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW), -50.0f, 50.0f);
+            float sBlow2 = std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW_II), -50.0f, 50.0f);
+            float sBlowMult = ((100.0f - std::clamp((float)(sBlow1 + sBlow2), -75.0f, 75.0f)) / 100.0f);
 
             //mobs hit get basetp+30 whereas pcs hit get basetp/3
             if (PDefender->objtype == TYPE_PC)

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2000,7 +2000,9 @@ namespace battleutils
             if (giveTPtoVictim)
             {
                 //account for attacker's subtle blow which reduces the baseTP gain for the defender
-                float sBlowMult = ((100.0f - std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW), 0.0f, 50.0f)) / 100.0f);
+                float sBlow1 = ((100.0f - std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW), 0.0f, 50.0f)) / 100.0f);
+                float sBlow2 = ((100.0f - std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW_II), 0.0f, 50.0f)) / 100.0f);
+                float sBlowMult = ((100.0f - std::clamp((float)(sBlow1 + sBlow2), 0.0f, 75.0f)) / 100.0f);
 
                 //mobs hit get basetp+30 whereas pcs hit get basetp/3
                 if (PDefender->objtype == TYPE_PC || (PDefender->objtype == TYPE_PET && PDefender->PMaster && PDefender->PMaster->objtype == TYPE_PC))
@@ -2126,7 +2128,9 @@ namespace battleutils
             }
 
             //account for attacker's subtle blow which reduces the baseTP gain for the defender
-            float sBlowMult = ((100.0f - std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW), 0.0f, 50.0f)) / 100.0f);
+            float sBlow1 = ((100.0f - std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW), 0.0f, 50.0f)) / 100.0f);
+            float sBlow2 = ((100.0f - std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW_II), 0.0f, 50.0f)) / 100.0f);
+            float sBlowMult = ((100.0f - std::clamp((float)(sBlow1 + sBlow2), 0.0f, 75.0f)) / 100.0f);
 
             //mobs hit get basetp+30 whereas pcs hit get basetp/3
             if (PDefender->objtype == TYPE_PC)


### PR DESCRIPTION
Adds MOD and Math to implement Subtle Blow II.
Per BGWiki SB_II caps at 50%, however SB + SB_II cannot exceed (cap at) 75%.
https://www.bg-wiki.com/bg/Subtle_Blow_II

Added clamps for each individual pool and a clamp for combined pool.

Adds Subtle Blow II to Moonbow Belt/+1
Corrects Subtle Blow -> Subtle Blow II on Sherida and Niqmaddu

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

