### PR TITLE
Styleguide fixes for Windurst Woods and usage of npcUtils

### DIFF
--- a/scripts/zones/Windurst_Woods/npcs/Anillah.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Anillah.lua
@@ -32,7 +32,10 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-    if csid == 10015 and option == 1 then
+    if
+        csid == 10015 and
+        option == 1
+    then
         player:messageSpecial(ID.text.IMAGE_SUPPORT, 0, 4, 2)
         player:addStatusEffect(tpz.effect.CLOTHCRAFT_IMAGERY, 1, 0, 120)
     end

--- a/scripts/zones/Windurst_Woods/npcs/Apururu.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Apururu.lua
@@ -14,11 +14,17 @@ require("scripts/globals/titles")
 
 function onTrade(player, npc, trade)
     -- THE KIND CARDIAN
-    if player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.THE_KIND_CARDIAN) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 969) then
+    if
+        player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.THE_KIND_CARDIAN) == QUEST_ACCEPTED and
+        npcUtil.tradeHas(trade, 969)
+    then
         player:startEvent(397)
 
     -- CAN CARDIANS CRY?
-    elseif player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CAN_CARDIANS_CRY) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 551) then
+    elseif
+        player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CAN_CARDIANS_CRY) == QUEST_ACCEPTED
+        and npcUtil.tradeHas(trade, 551)
+    then
         player:startEvent(325, 0, 20000, 5000)
     end
 end
@@ -79,7 +85,11 @@ function onTrigger(player, npc)
         end
 
     -- CAN CARDIANS CRY?
-    elseif allNewC3000 == QUEST_COMPLETED and canCardiansCry == QUEST_AVAILABLE and player:getFameLevel(WINDURST) >= 5 then
+    elseif
+        allNewC3000 == QUEST_COMPLETED and
+        canCardiansCry == QUEST_AVAILABLE and
+        player:getFameLevel(WINDURST) >= 5
+    then
         player:startEvent(319, 0, 20000) -- start quest
     elseif canCardiansCry == QUEST_ACCEPTED then
         player:startEvent(320, 0, 20000) -- reminder
@@ -96,22 +106,17 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-
     -- WINDURST 1-2: THE HEART OF THE MATTER
     if csid == 137 then
         player:setCharVar("MissionStatus", 1)
-
-        npcUtil.giveKeyItem(player,
-            {
-                tpz.ki.FIRST_DARK_MANA_ORB,
-                tpz.ki.SECOND_DARK_MANA_ORB,
-                tpz.ki.THIRD_DARK_MANA_ORB,
-                tpz.ki.FOURTH_DARK_MANA_ORB,
-                tpz.ki.FIFTH_DARK_MANA_ORB,
-                tpz.ki.SIXTH_DARK_MANA_ORB
-            }
-        )
-
+        npcUtil.giveKeyItem(player, {
+            tpz.ki.FIRST_DARK_MANA_ORB,
+            tpz.ki.SECOND_DARK_MANA_ORB,
+            tpz.ki.THIRD_DARK_MANA_ORB,
+            tpz.ki.FOURTH_DARK_MANA_ORB,
+            tpz.ki.FIFTH_DARK_MANA_ORB,
+            tpz.ki.SIXTH_DARK_MANA_ORB
+        })
         player:setCharVar("MissionStatus_orb1", 1) -- Set the orb variables: 1 = not handled, 2 = handled
         player:setCharVar("MissionStatus_orb2", 1)
         player:setCharVar("MissionStatus_orb3", 1)
@@ -120,14 +125,12 @@ function onEventFinish(player, csid, option)
         player:setCharVar("MissionStatus_orb6", 1)
     elseif csid == 143 or csid == 145 then
         finishMissionTimeline(player, 1, csid, option)
-
         player:setCharVar("MissionStatus_orb1", 0)
         player:setCharVar("MissionStatus_orb2", 0)
         player:setCharVar("MissionStatus_orb3", 0)
         player:setCharVar("MissionStatus_orb4", 0)
         player:setCharVar("MissionStatus_orb5", 0)
         player:setCharVar("MissionStatus_orb6", 0)
-
         player:delKeyItem(tpz.ki.FIRST_GLOWING_MANA_ORB) -- Remove the glowing orb key items
         player:delKeyItem(tpz.ki.SECOND_GLOWING_MANA_ORB)
         player:delKeyItem(tpz.ki.THIRD_GLOWING_MANA_ORB)
@@ -160,7 +163,10 @@ function onEventFinish(player, csid, option)
         player:delKeyItem(tpz.ki.LETTER_FROM_ZONPAZIPPA)
 
     -- THE KIND CARDIAN
-    elseif csid == 392 and option == 1 then
+    elseif
+        csid == 392 and
+        option == 1
+    then
         player:setCharVar("theKindCardianVar", 1)
     elseif csid == 397 then
         player:delKeyItem(tpz.ki.TWO_OF_SWORDS)
@@ -171,7 +177,8 @@ function onEventFinish(player, csid, option)
     -- CAN CARDIANS CRY?
     elseif csid == 319 then
         player:addQuest(WINDURST, tpz.quest.id.windurst.CAN_CARDIANS_CRY)
-    elseif csid == 325 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.CAN_CARDIANS_CRY, {gil=5000}) then
+    elseif csid == 325 then
         player:confirmTrade()
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.CAN_CARDIANS_CRY, {gil=5000})
     end
 end

--- a/scripts/zones/Windurst_Woods/npcs/Apururu.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Apururu.lua
@@ -22,8 +22,8 @@ function onTrade(player, npc, trade)
 
     -- CAN CARDIANS CRY?
     elseif
-        player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CAN_CARDIANS_CRY) == QUEST_ACCEPTED
-        and npcUtil.tradeHas(trade, 551)
+        player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CAN_CARDIANS_CRY) == QUEST_ACCEPTED and
+        npcUtil.tradeHas(trade, 551)
     then
         player:startEvent(325, 0, 20000, 5000)
     end

--- a/scripts/zones/Windurst_Woods/npcs/Bin_Stejihna.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Bin_Stejihna.lua
@@ -14,28 +14,25 @@ end
 
 function onTrigger(player, npc)
     local RegionOwner = GetRegionOwner(tpz.region.ZULKHEIM)
+    local rank = getNationRank(tpz.nation.WINDURST)
+    local stock =
+    {
+        622,     44,  -- Dried Marjoram
+        4372,    44,  -- Giant Sheep Meat
+        4366,    22,  -- La Theine Cabbage
+        611,     36,  -- Rye Flour
+        610,     55,  -- San d'Orian Flour
+        4378,    55   -- Selbina Milk
+    }
+
     if RegionOwner ~= tpz.nation.WINDURST then
         player:showText(npc, ID.text.BIN_STEJIHNA_CLOSED_DIALOG)
     else
-        player:showText(npc, ID.text.BIN_STEJIHNA_OPEN_DIALOG)
-
-        local rank = getNationRank(tpz.nation.WINDURST)
         if rank ~= 3 then
             table.insert(stock, 1840) --Semolina
             table.insert(stock, 1840)
         end
-
-        local stock =
-        {
-            1840,  1840,  -- Semolina
-            4372,    44,  -- Giant Sheep Meat
-            622,     44,  -- Dried Marjoram
-            610,     55,  -- San d'Orian Flour
-            611,     36,  -- Rye Flour
-            4366,    22,  -- La Theine Cabbage
-            4378,    55   -- Selbina Milk
-        }
-
+        player:showText(npc, ID.text.BIN_STEJIHNA_OPEN_DIALOG)
         tpz.shop.general(player, stock, WINDURST)
     end
 end

--- a/scripts/zones/Windurst_Woods/npcs/Boizo-Naizo.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Boizo-Naizo.lua
@@ -10,7 +10,9 @@ require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.RIDING_ON_THE_CLOUDS) == QUEST_ACCEPTED and player:getCharVar("ridingOnTheClouds_4") == 6 and npcUtil.tradeHas(trade, 1127) then
+    if player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.RIDING_ON_THE_CLOUDS) == QUEST_ACCEPTED
+        and player:getCharVar("ridingOnTheClouds_4") == 6 and npcUtil.tradeHas(trade, 1127)
+    then
         player:setCharVar("ridingOnTheClouds_4", 0)
         player:confirmTrade()
         npcUtil.giveKeyItem(player, tpz.ki.SPIRITED_STONE)

--- a/scripts/zones/Windurst_Woods/npcs/Boizo-Naizo.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Boizo-Naizo.lua
@@ -10,8 +10,10 @@ require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.RIDING_ON_THE_CLOUDS) == QUEST_ACCEPTED
-        and player:getCharVar("ridingOnTheClouds_4") == 6 and npcUtil.tradeHas(trade, 1127)
+    if
+        player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.RIDING_ON_THE_CLOUDS) == QUEST_ACCEPTED and
+        player:getCharVar("ridingOnTheClouds_4") == 6 and
+        npcUtil.tradeHas(trade, 1127)
     then
         player:setCharVar("ridingOnTheClouds_4", 0)
         player:confirmTrade()

--- a/scripts/zones/Windurst_Woods/npcs/Cayu_Pensharhumi.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Cayu_Pensharhumi.lua
@@ -13,7 +13,9 @@ end
 function onTrigger(player, npc)
     local WildcatWindurst = player:getCharVar("WildcatWindurst")
 
-    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not player:getMaskBit(WildcatWindurst, 2) then
+    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED
+        and not player:getMaskBit(WildcatWindurst, 2)
+    then
         player:startEvent(733)
     else
         player:startEvent(259)

--- a/scripts/zones/Windurst_Woods/npcs/Cayu_Pensharhumi.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Cayu_Pensharhumi.lua
@@ -11,10 +11,9 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-    local WildcatWindurst = player:getCharVar("WildcatWindurst")
-
-    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED
-        and not player:getMaskBit(WildcatWindurst, 2)
+    if
+        player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
+        not player:getMaskBit(player:getCharVar("WildcatWindurst"), 2)
     then
         player:startEvent(733)
     else

--- a/scripts/zones/Windurst_Woods/npcs/Etsa_Rhuyuli.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Etsa_Rhuyuli.lua
@@ -11,10 +11,9 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-    local WildcatWindurst = player:getCharVar("WildcatWindurst")
-
-    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED
-        and not player:getMaskBit(WildcatWindurst, 1)
+    if
+        player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
+        not player:getMaskBit(player:getCharVar("WildcatWindurst"), 1)
     then
         player:startEvent(734)
     else

--- a/scripts/zones/Windurst_Woods/npcs/Etsa_Rhuyuli.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Etsa_Rhuyuli.lua
@@ -13,7 +13,9 @@ end
 function onTrigger(player, npc)
     local WildcatWindurst = player:getCharVar("WildcatWindurst")
 
-    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not player:getMaskBit(WildcatWindurst, 1) then
+    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED
+        and not player:getMaskBit(WildcatWindurst, 1)
+    then
         player:startEvent(734)
     else
         player:startEvent(422)

--- a/scripts/zones/Windurst_Woods/npcs/Gioh_Ajihri.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Gioh_Ajihri.lua
@@ -11,7 +11,11 @@ require("scripts/globals/titles")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getCharVar("GiohAijhriSpokenTo") == 1 and not player:needToZone() and npcUtil.tradeHas(trade, 13360) then
+    if
+        player:getCharVar("GiohAijhriSpokenTo") == 1 and
+        not player:needToZone() and
+        npcUtil.tradeHas(trade, 13360)
+    then
         player:startEvent(490)
     end
 end
@@ -27,7 +31,10 @@ function onTrigger(player, npc)
         end
     elseif twinstoneBonding == QUEST_ACCEPTED then
         player:startEvent(488, 0, 13360)
-    elseif twinstoneBonding == QUEST_AVAILABLE and player:getFameLevel(WINDURST) >= 2 then
+    elseif
+        twinstoneBonding == QUEST_AVAILABLE and
+        player:getFameLevel(WINDURST) >= 2
+    then
         player:startEvent(487, 0, 13360)
     else
         player:startEvent(424)
@@ -45,7 +52,6 @@ function onEventFinish(player, csid, option)
         player:confirmTrade()
         player:needToZone(true)
         player:setCharVar("GiohAijhriSpokenTo", 0)
-
         if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.TWINSTONE_BONDING) == QUEST_ACCEPTED then
             npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.TWINSTONE_BONDING, {
                 item = 17154,

--- a/scripts/zones/Windurst_Woods/npcs/Gioh_Ajihri.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Gioh_Ajihri.lua
@@ -47,7 +47,11 @@ function onEventFinish(player, csid, option)
         player:setCharVar("GiohAijhriSpokenTo", 0)
 
         if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.TWINSTONE_BONDING) == QUEST_ACCEPTED then
-            npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.TWINSTONE_BONDING, {item=17154, fame=80, title=tpz.title.BOND_FIXER})
+            npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.TWINSTONE_BONDING, {
+                item = 17154,
+                fame = 80,
+                title = tpz.title.BOND_FIXER
+            })
         else
             player:addFame(WINDURST, 10)
             player:addGil(GIL_RATE*900)

--- a/scripts/zones/Windurst_Woods/npcs/Gottah_Maporushanoh.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Gottah_Maporushanoh.lua
@@ -10,11 +10,11 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-    local AmazinScorpio = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.THE_AMAZIN_SCORPIO)
+    local amazinScorpio = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.THE_AMAZIN_SCORPIO)
 
-    if AmazinScorpio == QUEST_COMPLETED then
+    if amazinScorpio == QUEST_COMPLETED then
         player:startEvent(486)
-    elseif AmazinScorpio == QUEST_ACCEPTED then
+    elseif amazinScorpio == QUEST_ACCEPTED then
         player:startEvent(483)
     else
         player:startEvent(420)

--- a/scripts/zones/Windurst_Woods/npcs/Ibwam.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Ibwam.lua
@@ -45,9 +45,10 @@ Port Windurst (West to East)
 ]]--
 
 function onTrade(player, npc, trade)
-    if npcUtil.tradeHas(trade, {{"gil", 300}})
-        and player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_COMPLETED
-        and player:getCurrentMission(TOAU) > tpz.mission.id.toau.IMMORTAL_SENTRIES
+    if
+        npcUtil.tradeHas(trade, {{"gil", 300}}) and
+        player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_COMPLETED and
+        player:getCurrentMission(TOAU) > tpz.mission.id.toau.IMMORTAL_SENTRIES
     then
         -- Needs a check for at least traded an invitation card to Naja Salaheem
         player:startEvent(794)
@@ -58,7 +59,10 @@ function onTrigger(player, npc)
     local lureWindurst = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT)
     local wildcatWindurst = player:getCharVar("WildcatWindurst")
 
-    if lureWindurst ~= QUEST_COMPLETED and ENABLE_TOAU == 1 then
+    if
+        lureWindurst ~= QUEST_COMPLETED and
+        ENABLE_TOAU == 1
+    then
         if lureWindurst == QUEST_AVAILABLE then
             player:startEvent(736)
         else
@@ -85,7 +89,9 @@ function onEventFinish(player, csid, option)
         player:addQuest(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT)
         player:setCharVar("WildcatWindurst", 0)
         npcUtil.giveKeyItem(player, tpz.ki.GREEN_SENTINEL_BADGE)
-    elseif csid == 739 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT, {
+    elseif
+        csid == 739 and
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT, {
             fame = 150,
             keyItem = tpz.ki.GREEN_INVITATION_CARD,
             var = "WildcatWindurst"

--- a/scripts/zones/Windurst_Woods/npcs/Ibwam.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Ibwam.lua
@@ -45,7 +45,10 @@ Port Windurst (West to East)
 ]]--
 
 function onTrade(player, npc, trade)
-    if npcUtil.tradeHas(trade, {{"gil", 300}}) and player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_COMPLETED and player:getCurrentMission(TOAU) > tpz.mission.id.toau.IMMORTAL_SENTRIES then
+    if npcUtil.tradeHas(trade, {{"gil", 300}})
+        and player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_COMPLETED
+        and player:getCurrentMission(TOAU) > tpz.mission.id.toau.IMMORTAL_SENTRIES
+    then
         -- Needs a check for at least traded an invitation card to Naja Salaheem
         player:startEvent(794)
     end
@@ -82,7 +85,12 @@ function onEventFinish(player, csid, option)
         player:addQuest(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT)
         player:setCharVar("WildcatWindurst", 0)
         npcUtil.giveKeyItem(player, tpz.ki.GREEN_SENTINEL_BADGE)
-    elseif csid == 739 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT, {fame=150, keyItem=tpz.ki.GREEN_INVITATION_CARD, var="WildcatWindurst"}) then
+    elseif csid == 739 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT, {
+            fame = 150,
+            keyItem = tpz.ki.GREEN_INVITATION_CARD,
+            var = "WildcatWindurst"
+        })
+    then
         player:delKeyItem(tpz.ki.GREEN_SENTINEL_BADGE)
         player:messageSpecial(ID.text.KEYITEM_LOST, tpz.ki.GREEN_SENTINEL_BADGE)
     elseif csid == 794 then

--- a/scripts/zones/Windurst_Woods/npcs/Illu_Bohjaa.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Illu_Bohjaa.lua
@@ -35,7 +35,12 @@ end
 function onEventFinish(player, csid, option)
     if csid == 333 and option == 1 then
         player:addQuest(WINDURST, tpz.quest.id.windurst.CREEPY_CRAWLIES)
-    elseif csid == 335 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.CREEPY_CRAWLIES, {gil=600, fame=0, title=tpz.title.CRAWLER_CULLER}) then
+    elseif csid == 335 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.CREEPY_CRAWLIES, {
+            gil = 600,
+            fame = 0,
+            title = tpz.title.CRAWLER_CULLER
+        })
+    then
         player:confirmTrade()
     end
 end

--- a/scripts/zones/Windurst_Woods/npcs/Illu_Bohjaa.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Illu_Bohjaa.lua
@@ -33,9 +33,14 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-    if csid == 333 and option == 1 then
+    if
+        csid == 333 and
+        option == 1
+    then
         player:addQuest(WINDURST, tpz.quest.id.windurst.CREEPY_CRAWLIES)
-    elseif csid == 335 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.CREEPY_CRAWLIES, {
+    elseif
+        csid == 335 and
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.CREEPY_CRAWLIES, {
             gil = 600,
             fame = 0,
             title = tpz.title.CRAWLER_CULLER

--- a/scripts/zones/Windurst_Woods/npcs/Kopua-Mobua_AMAN.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Kopua-Mobua_AMAN.lua
@@ -13,7 +13,10 @@ end
 function onTrigger(player, npc)
     local var = 0
     if player:getMentor() == 0 then
-        if player:getMainLvl() >= 30 and player:getPlaytime() >= 648000 then
+        if
+            player:getMainLvl() >= 30 and
+            player:getPlaytime() >= 648000
+        then
             var = 1
         end
     elseif player:getMentor() >= 1 then

--- a/scripts/zones/Windurst_Woods/npcs/Kopuro-Popuro.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Kopuro-Popuro.lua
@@ -34,7 +34,10 @@ function onTrade(player, npc, trade)
         end
 
     -- THE ALL NEW C-3000
-    elseif allNewC3000 == QUEST_ACCEPTED or allNewC3000 == QUEST_COMPLETED then
+    elseif
+        allNewC3000 == QUEST_ACCEPTED or
+        allNewC3000 == QUEST_COMPLETED
+    then
         if npcUtil.tradeHas(trade, {889, 939}) then
             player:startEvent(657, 0, 889, 939) -- Correct items given, complete quest in onEventUpdate
         else
@@ -52,7 +55,11 @@ function onTrigger(player, npc)
     local allNewC3000 = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.THE_ALL_NEW_C_3000)
 
     -- THE ALL NEW C-3000
-    if legendaryPlanB == QUEST_COMPLETED and allNewC3000 == QUEST_AVAILABLE and player:getFameLevel(WINDURST) >= 4 then
+    if
+        legendaryPlanB == QUEST_COMPLETED and
+        allNewC3000 == QUEST_AVAILABLE and
+        player:getFameLevel(WINDURST) >= 4
+    then
         if player:needToZone() then
             player:startEvent(316) -- Post quest text from legendaryPlanB
         else
@@ -62,11 +69,18 @@ function onTrigger(player, npc)
         player:startEvent(659, 0, 889, 939)
 
     -- A GREETING CARDIAN
-    elseif aGreetingCardian == QUEST_ACCEPTED and aGreetingCardianCS == 5 then
+    elseif
+        aGreetingCardian == QUEST_ACCEPTED and
+        aGreetingCardianCS == 5
+    then
         player:startEvent(301) -- Supplemental text when aGreetingCardian in progress, right before completion
 
     -- LEGENDARY PLAN B
-    elseif aGreetingCardian == QUEST_COMPLETED and legendaryPlanB == QUEST_AVAILABLE and player:getFameLevel(WINDURST) >= 3 then
+    elseif
+        aGreetingCardian == QUEST_COMPLETED and
+        legendaryPlanB == QUEST_AVAILABLE and
+        player:getFameLevel(WINDURST) >= 3
+    then
         if player:needToZone() then
             player:startEvent(306) -- Supplemental text for aGreetingCardian before start of legendaryPlanB
         else
@@ -96,7 +110,10 @@ end
 
 function onEventFinish(player, csid, option)
     -- THE ALL NEW C-2000
-    if csid == 285 and option ~= 2 then  -- option 2 is declining the quest for the second question
+    if
+        csid == 285 and
+        option ~= 2 -- option 2 is declining the quest for the second question
+    then
         player:addQuest(WINDURST, tpz.quest.id.windurst.THE_ALL_NEW_C_2000)
     elseif csid == 292 then
         npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.THE_ALL_NEW_C_2000, {
@@ -109,10 +126,12 @@ function onEventFinish(player, csid, option)
     -- LEGENDARY PLAN B
     elseif csid == 308 then
         player:addQuest(WINDURST, tpz.quest.id.windurst.LEGENDARY_PLAN_B)
-    elseif csid == 314 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.LEGENDARY_PLAN_B, {
-        item = 12749,
-        gil = 700
-    })
+    elseif
+        csid == 314 and
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.LEGENDARY_PLAN_B, {
+            item = 12749,
+            gil = 700
+        })
     then
         player:confirmTrade()
         player:needToZone(true)

--- a/scripts/zones/Windurst_Woods/npcs/Kopuro-Popuro.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Kopuro-Popuro.lua
@@ -98,20 +98,33 @@ function onEventFinish(player, csid, option)
     -- THE ALL NEW C-2000
     if csid == 285 and option ~= 2 then  -- option 2 is declining the quest for the second question
         player:addQuest(WINDURST, tpz.quest.id.windurst.THE_ALL_NEW_C_2000)
-    elseif csid == 292 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.THE_ALL_NEW_C_2000, {fame=80, title=tpz.title.CARDIAN_TUTOR, gil=200}) then
+    elseif csid == 292 then
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.THE_ALL_NEW_C_2000, {
+            fame = 80,
+            title = tpz.title.CARDIAN_TUTOR,
+            gil = 200
+        })
         player:confirmTrade()
 
     -- LEGENDARY PLAN B
     elseif csid == 308 then
         player:addQuest(WINDURST, tpz.quest.id.windurst.LEGENDARY_PLAN_B)
-    elseif csid == 314 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.LEGENDARY_PLAN_B, {item=12749, gil=700}) then
+    elseif csid == 314 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.LEGENDARY_PLAN_B, {
+        item = 12749,
+        gil = 700
+    })
+    then
         player:confirmTrade()
         player:needToZone(true)
 
     -- THE ALL NEW C-3000
     elseif csid == 655 then
         player:addQuest(WINDURST, tpz.quest.id.windurst.THE_ALL_NEW_C_3000)
-    elseif csid == 657 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.THE_ALL_NEW_C_3000, {fame=10, gil=600}) then
+    elseif csid == 657 then
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.THE_ALL_NEW_C_3000, {
+            fame = 10,
+            gil = 600
+        })
         player:confirmTrade()
     end
 end

--- a/scripts/zones/Windurst_Woods/npcs/Kororo.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Kororo.lua
@@ -24,15 +24,28 @@ function onTrigger(player, npc)
     local AGCtime = player:getCharVar("AGreetingCardian_timer")
 
     -- A Greeting Cardian
-    if C2000 == QUEST_COMPLETED and AGreetingCardian == QUEST_AVAILABLE and player:getFameLevel(WINDURST) >= 3 then
+    if
+        C2000 == QUEST_COMPLETED and
+        AGreetingCardian == QUEST_AVAILABLE and
+        player:getFameLevel(WINDURST) >= 3
+    then
         player:startEvent(296) -- A Greeting Cardian quest start
-    elseif AGreetingCardian == QUEST_ACCEPTED and AGCcs == 3 then
-        if player:needToZone() or tonumber(os.date("%j")) == AGCtime then
+    elseif
+        AGreetingCardian == QUEST_ACCEPTED and
+        AGCcs == 3
+    then
+        if
+            player:needToZone() or
+            tonumber(os.date("%j")) == AGCtime
+        then
             player:startEvent(277) -- standard dialog if JP midnight has not passed
         else
             player:startEvent(298) -- A Greeting Cardian part two
         end
-    elseif AGreetingCardian == QUEST_ACCEPTED and AGCcs == 5 then
+    elseif
+        AGreetingCardian == QUEST_ACCEPTED and
+        AGCcs == 5
+    then
         player:startEvent(303) -- A Greeting Cardian finish
 
     -- Might be Legendary Plan B, most likely Lost Chick related.
@@ -57,10 +70,12 @@ function onEventFinish(player, csid, option)
         player:needToZone(true) -- wait one day and zone after next step
     elseif csid == 298 then
         player:setCharVar("AGreetingCardian_Event", 4)
-    elseif csid == 303 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.A_GREETING_CARDIAN, {
-        item = 13330,
-        var = {"AGreetingCardian_timer", "AGreetingCardian_Event"}
-    })
+    elseif
+        csid == 303 and
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.A_GREETING_CARDIAN, {
+            item = 13330,
+            var = {"AGreetingCardian_timer", "AGreetingCardian_Event"}
+        })
     then
         player:needToZone(true) -- zone before starting Legendary Plan B
     end

--- a/scripts/zones/Windurst_Woods/npcs/Kororo.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Kororo.lua
@@ -9,6 +9,7 @@
 local ID = require("scripts/zones/Windurst_Woods/IDs")
 require("scripts/globals/quests")
 require("scripts/globals/titles")
+require("scripts/globals/npc_util")
 -----------------------------------
 
 function onTrade(player, npc, trade)
@@ -56,17 +57,11 @@ function onEventFinish(player, csid, option)
         player:needToZone(true) -- wait one day and zone after next step
     elseif csid == 298 then
         player:setCharVar("AGreetingCardian_Event", 4)
-    elseif csid == 303 then
-        if player:getFreeSlotsCount() == 0 then
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 13330) -- Tourmaline Earring
-        else
-            player:addItem(13330)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, 13330) -- Tourmaline Earring
-            player:addFame(WINDURST, 30)
-            player:completeQuest(WINDURST, tpz.quest.id.windurst.A_GREETING_CARDIAN)
-            player:needToZone(true) -- zone before starting Legendary Plan B
-            player:setCharVar("AGreetingCardian_timer", 0)
-            player:setCharVar("AGreetingCardian_Event", 0) -- finish cleanup of A Greeting Cardian variables
-        end
+    elseif csid == 303 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.A_GREETING_CARDIAN, {
+        item = 13330,
+        var = {"AGreetingCardian_timer", "AGreetingCardian_Event"}
+    })
+    then
+        player:needToZone(true) -- zone before starting Legendary Plan B
     end
 end

--- a/scripts/zones/Windurst_Woods/npcs/Kuoh_Rhel.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Kuoh_Rhel.lua
@@ -21,28 +21,44 @@ function onTrigger(player, npc)
     local chocobilious = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CHOCOBILIOUS)
 
     -- IN A STEW
-    if inAStew == QUEST_AVAILABLE and chocobilious == QUEST_COMPLETED and player:getFameLevel(WINDURST) >= 3 then
+    if
+        inAStew == QUEST_AVAILABLE and
+        chocobilious == QUEST_COMPLETED and
+        player:getFameLevel(WINDURST) >= 3
+    then
         if player:needToZone() then
             player:startEvent(232) -- Post quest dialog from Chocobilious
         else
             player:startEvent(235) -- IAS start
         end
-    elseif inAStewCS == 4 and player:hasKeyItem(tpz.ki.RANPIMONPIS_SPECIAL_STEW) then
+    elseif
+        inAStewCS == 4 and
+        player:hasKeyItem(tpz.ki.RANPIMONPIS_SPECIAL_STEW)
+    then
         player:startEvent(239) -- IAS turn in
     elseif inAStew == QUEST_ACCEPTED then
         player:startEvent(236) -- reminder dialog
     -- Uncomment once conquest tally in place
     --elseif inAStew == QUEST_COMPLETED then
         --player:startEvent(240) -- new dialog between repeats
-    elseif (inAStew == QUEST_COMPLETED) then
+    elseif inAStew == QUEST_COMPLETED then
         player:startEvent(234) -- start repeat
 
     -- CHOCOBILIOUS
-    elseif chocobilious == QUEST_AVAILABLE and player:getFameLevel(WINDURST) >= 2 then
+    elseif
+        chocobilious == QUEST_AVAILABLE and
+        player:getFameLevel(WINDURST) >= 2
+    then
         player:startEvent(224) -- Start quest
-    elseif chocobilious == QUEST_COMPLETED and player:needToZone() then
+    elseif
+        chocobilious == QUEST_COMPLETED and
+        player:needToZone()
+    then
         player:startEvent(232) -- Quest complete
-    elseif chocobilious == QUEST_ACCEPTED and player:getCharVar("ChocobiliousQuest") == 2 then
+    elseif
+        chocobilious == QUEST_ACCEPTED and
+        player:getCharVar("ChocobiliousQuest") == 2
+    then
         player:startEvent(231) -- Talked to Tapoh
     elseif chocobilious == QUEST_ACCEPTED then
         player:startEvent(225) -- Post quest accepted
@@ -58,7 +74,10 @@ end
 
 function onEventFinish(player, csid, option)
     -- CHOCOBILIOUS
-    if csid == 224 and option == 1 then
+    if
+        csid == 224 and
+        option == 1
+    then
         player:addQuest(WINDURST, tpz.quest.id.windurst.CHOCOBILIOUS)
     elseif csid == 231 then
         npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.CHOCOBILIOUS, {
@@ -79,7 +98,10 @@ function onEventFinish(player, csid, option)
             var = "IASvar"
         })
         player:delKeyItem(tpz.ki.RANPIMONPIS_SPECIAL_STEW)
-    elseif csid == 234 and option == 1 then -- start repeat
+    elseif
+        csid == 234 and
+        option == 1
+    then -- start repeat
         player:setCharVar("IASvar", 3)
     end
 end

--- a/scripts/zones/Windurst_Woods/npcs/Kuoh_Rhel.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Kuoh_Rhel.lua
@@ -60,14 +60,24 @@ function onEventFinish(player, csid, option)
     -- CHOCOBILIOUS
     if csid == 224 and option == 1 then
         player:addQuest(WINDURST, tpz.quest.id.windurst.CHOCOBILIOUS)
-    elseif csid == 231 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.CHOCOBILIOUS, {fame=220, gil=1500, var="ChocobiliousQuest"}) then
+    elseif csid == 231 then
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.CHOCOBILIOUS, {
+            fame = 220,
+            gil = 1500,
+            var = "ChocobiliousQuest"
+        })
         player:needToZone(true)
 
     -- IN A STEW
     elseif csid == 235 then
         player:addQuest(WINDURST, tpz.quest.id.windurst.IN_A_STEW)
         player:setCharVar("IASvar", 1)
-    elseif csid == 239 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.IN_A_STEW, {fame=50, gil=900, var="IASvar"}) then
+    elseif csid == 239 then
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.IN_A_STEW, {
+            fame = 50,
+            gil = 900,
+            var = "IASvar"
+        })
         player:delKeyItem(tpz.ki.RANPIMONPIS_SPECIAL_STEW)
     elseif csid == 234 and option == 1 then -- start repeat
         player:setCharVar("IASvar", 3)

--- a/scripts/zones/Windurst_Woods/npcs/Kuzah_Hpirohpon.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Kuzah_Hpirohpon.lua
@@ -12,7 +12,7 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-    if (player:sendGuild(5152, 6, 21, 0)) then
+    if player:sendGuild(5152, 6, 21, 0) then
         player:showText(npc, ID.text.KUZAH_HPIROHPON_DIALOG)
     end
 end

--- a/scripts/zones/Windurst_Woods/npcs/Kyaa_Taali.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Kyaa_Taali.lua
@@ -32,7 +32,10 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-    if csid == 10020 and option == 1 then
+    if
+        csid == 10020 and
+        option == 1
+    then
         player:messageSpecial(ID.text.IMAGE_SUPPORT, 0, 6, 2)
         player:addStatusEffect(tpz.effect.BONECRAFT_IMAGERY, 1, 0, 120)
     end

--- a/scripts/zones/Windurst_Woods/npcs/Lih_Pituu.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Lih_Pituu.lua
@@ -15,13 +15,13 @@ end
 function onTrigger(player, npc)
     local guildMember = isGuildMember(player, 2)
     local SkillLevel = player:getSkillLevel(tpz.skill.BONECRAFT)
-    local Cost = getAdvImageSupportCost(player, tpz.skill.BONECRAFT)
+    local cost = getAdvImageSupportCost(player, tpz.skill.BONECRAFT)
 
     if guildMember == 1 then
         if not player:hasStatusEffect(tpz.effect.BONECRAFT_IMAGERY) then
-            player:startEvent(10018, Cost, SkillLevel, 0, 511, player:getGil(), 0, 7028, 0)
+            player:startEvent(10018, cost, SkillLevel, 0, 511, player:getGil(), 0, 7028, 0)
         else
-            player:startEvent(10018, Cost, SkillLevel, 0, 511, player:getGil(), 28753, 3967, 0)
+            player:startEvent(10018, cost, SkillLevel, 0, 511, player:getGil(), 28753, 3967, 0)
         end
     else
         player:startEvent(10018) -- Standard Dialogue
@@ -32,10 +32,13 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-    local Cost = getAdvImageSupportCost(player, 4)
+    local cost = getAdvImageSupportCost(player, 4)
 
-    if csid == 10018 and option == 1 then
-        player:delGil(Cost)
+    if
+        csid == 10018 and
+        option == 1
+    then
+        player:delGil(cost)
         player:messageSpecial(ID.text.IMAGE_SUPPORT, 0, 6, 0)
         player:addStatusEffect(tpz.effect.BONECRAFT_IMAGERY, 3, 0, 480)
     end

--- a/scripts/zones/Windurst_Woods/npcs/Matata.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Matata.lua
@@ -17,9 +17,15 @@ function onTrigger(player, npc)
     local CB = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CHOCOBILIOUS)
 
     -- IN A STEW
-    if IAS == QUEST_ACCEPTED and IASvar == 1 then
+    if
+        IAS == QUEST_ACCEPTED and
+        IASvar == 1
+    then
         player:startEvent(233, 0, 0, 4545) -- In a Stew in progress
-    elseif IAS == QUEST_ACCEPTED and IASvar == 2 then
+    elseif
+        IAS == QUEST_ACCEPTED and
+        IASvar == 2
+    then
         player:startEvent(237) -- In a Stew reminder
     elseif IAS == QUEST_COMPLETED then
         player:startEvent(241) -- new dialog after In a Stew

--- a/scripts/zones/Windurst_Woods/npcs/Mourices.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Mourices.lua
@@ -12,7 +12,10 @@ require("scripts/globals/npc_util")
 function onTrade(player, npc, trade)
     local missionStatus = player:getCharVar("MissionStatus")
 
-    if player:getCurrentMission(SANDORIA) == tpz.mission.id.sandoria.JOURNEY_TO_WINDURST and npcUtil.tradeHas(trade, {{12298, 2}}) then -- Parana Shield x2
+    if
+        player:getCurrentMission(SANDORIA) == tpz.mission.id.sandoria.JOURNEY_TO_WINDURST and
+        npcUtil.tradeHas(trade, {{12298, 2}}) -- Parana Shield x2
+    then
         if missionStatus == 5 then
             player:startEvent(455) -- before deliver shield to the yagudo
         elseif missionStatus == 6 then
@@ -38,16 +41,25 @@ function onTrigger(player, npc)
         end
     -- San d'Oria Mission 2-3 Part I - Windurst > Bastok
     elseif player:getCurrentMission(SANDORIA) == tpz.mission.id.sandoria.JOURNEY_TO_WINDURST then
-        if missionStatus >= 3 and missionStatus <= 5 then
+        if
+            missionStatus >= 3 and
+            missionStatus <= 5
+        then
             player:startEvent(449)
         elseif missionStatus == 6 then
             player:startEvent(456)
         end
     -- San d'Oria Mission 2-3 Part II - Bastok > Windurst
     elseif player:getCurrentMission(SANDORIA) == tpz.mission.id.sandoria.JOURNEY_TO_WINDURST2 then
-        if missionStatus == 7 or missionStatus == 8 then
+        if
+            missionStatus == 7 or
+            missionStatus == 8
+        then
             player:startEvent(463)
-        elseif missionStatus == 9 or missionStatus == 10 then
+        elseif
+            missionStatus == 9 or
+            missionStatus == 10
+        then
             player:startEvent(467)
         end
     else

--- a/scripts/zones/Windurst_Woods/npcs/Nanaa_Mihgo.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Nanaa_Mihgo.lua
@@ -76,20 +76,22 @@ function onTrigger(player, npc)
         player:startEvent(503) -- standard dialog after
 
         -- THICK AS THIEVES
-    elseif job == tpz.job.THF and lvl >= AF2_QUEST_LEVEL and thickAsThieves == QUEST_AVAILABLE and tenshodoShowdown ==
-        QUEST_COMPLETED then
+    elseif job == tpz.job.THF and lvl >= AF2_QUEST_LEVEL and thickAsThieves == QUEST_AVAILABLE
+        and tenshodoShowdown == QUEST_COMPLETED
+    then
         player:startEvent(504) -- start quest
     elseif thickAsThieves == QUEST_ACCEPTED then
         if player:hasKeyItem(tpz.ki.FIRST_SIGNED_FORGED_ENVELOPE) and
             player:hasKeyItem(tpz.ki.SECOND_SIGNED_FORGED_ENVELOPE) then
             player:startEvent(508) -- complete quest
         else
-            player:startEvent(505, 0, tpz.ki.GANG_WHEREABOUTS_NOTE) -- before completing grappling and gambling sidequests
+            player:startEvent(505, 0, tpz.ki.GANG_WHEREABOUTS_NOTE) -- before complete grappling and gambling sidequests
         end
 
         -- HITTING THE MARQUISATE
-    elseif job == tpz.job.THF and lvl >= AF3_QUEST_LEVEL and thickAsThieves == QUEST_COMPLETED and hittingTheMarquisate ==
-        QUEST_AVAILABLE then
+    elseif job == tpz.job.THF and lvl >= AF3_QUEST_LEVEL and thickAsThieves == QUEST_COMPLETED
+        and hittingTheMarquisate == QUEST_AVAILABLE
+    then
         player:startEvent(512) -- start quest
     elseif hittingTheMarquisateYatnielCS == 3 and hittingTheMarquisateHagainCS == 9 then
         player:startEvent(516) -- finish first part
@@ -97,7 +99,9 @@ function onTrigger(player, npc)
         player:startEvent(517) -- second part
 
         -- ROCK RACKETEER
-    elseif mihgosAmigo == QUEST_COMPLETED and rockRacketeer == QUEST_AVAILABLE and player:getFameLevel(WINDURST) >= 3 then
+    elseif mihgosAmigo == QUEST_COMPLETED and rockRacketeer == QUEST_AVAILABLE
+        and player:getFameLevel(WINDURST) >= 3
+    then
         if player:needToZone() then
             player:startEvent(89) -- complete
         else
@@ -161,10 +165,11 @@ function onEventFinish(player, csid, option)
         player:setCharVar("thickAsThievesGamblingCS", 1)
         npcUtil.giveKeyItem(player,
             {tpz.ki.GANG_WHEREABOUTS_NOTE, tpz.ki.FIRST_FORGED_ENVELOPE, tpz.ki.SECOND_FORGED_ENVELOPE})
-    elseif (csid == 508 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES, {
-        item = 12514,
-        var = "thickAsThievesGamblingCS"
-    })) then
+    elseif csid == 508 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES, {
+            item = 12514,
+            var = "thickAsThievesGamblingCS"
+        })
+    then
         player:delKeyItem(tpz.ki.GANG_WHEREABOUTS_NOTE)
         player:delKeyItem(tpz.ki.FIRST_SIGNED_FORGED_ENVELOPE)
         player:delKeyItem(tpz.ki.SECOND_SIGNED_FORGED_ENVELOPE)
@@ -192,11 +197,12 @@ function onEventFinish(player, csid, option)
     elseif csid == 80 or csid == 81 then
         player:addQuest(WINDURST, tpz.quest.id.windurst.MIHGO_S_AMIGO)
     elseif csid == 88 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.MIHGO_S_AMIGO, {
-        gil = 200,
-        title = tpz.title.CAT_BURGLAR_GROUPIE,
-        fameArea = NORG,
-        fame = 60
-    }) then
+            gil = 200,
+            title = tpz.title.CAT_BURGLAR_GROUPIE,
+            fameArea = NORG,
+            fame = 60
+        })
+    then
         player:confirmTrade()
         player:needToZone(true)
     elseif csid == 494 then

--- a/scripts/zones/Windurst_Woods/npcs/Nanaa_Mihgo.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Nanaa_Mihgo.lua
@@ -44,8 +44,11 @@ function onTrigger(player, npc)
     local lvl = player:getMainLvl()
 
     -- WINDURST 2-1: LOST FOR WORDS
-    if player:getCurrentMission(WINDURST) == tpz.mission.id.windurst.LOST_FOR_WORDS and missionStatus > 0 and
-        missionStatus < 5 then
+    if
+        player:getCurrentMission(WINDURST) == tpz.mission.id.windurst.LOST_FOR_WORDS and
+        missionStatus > 0 and
+        missionStatus < 5
+    then
         if missionStatus == 1 then
             player:startEvent(165, 0, tpz.ki.LAPIS_CORAL, tpz.ki.LAPIS_MONOCLE)
         elseif missionStatus == 2 then
@@ -56,60 +59,89 @@ function onTrigger(player, npc)
             player:startEvent(170)
         end
 
-        -- LURE OF THE WILDCAT (WINDURST)
-    elseif player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
-        not player:getMaskBit(wildcatWindurst, 4) then
+    -- LURE OF THE WILDCAT (WINDURST)
+    elseif
+        player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
+        not player:getMaskBit(wildcatWindurst, 4)
+    then
         player:startEvent(732)
 
-        -- CRYING OVER ONIONS
+    -- CRYING OVER ONIONS
     elseif player:getCharVar("CryingOverOnions") == 1 then
         player:startEvent(598)
 
-        -- THE TENSHODO SHOWDOWN
-    elseif job == tpz.job.THF and lvl >= AF1_QUEST_LEVEL and tenshodoShowdown == QUEST_AVAILABLE then
+    -- THE TENSHODO SHOWDOWN
+    elseif
+        job == tpz.job.THF and
+        lvl >= AF1_QUEST_LEVEL and
+        tenshodoShowdown == QUEST_AVAILABLE
+    then
         player:startEvent(496) -- start quest
     elseif tenshodoShowdownCS == 1 then
         player:startEvent(497) -- before cs at tensho HQ
     elseif tenshodoShowdownCS >= 2 then
         player:startEvent(498) -- after cs at tensho HQ
-    elseif job == tpz.job.THF and lvl < AF2_QUEST_LEVEL and tenshodoShowdown == QUEST_COMPLETED then
+    elseif
+        job == tpz.job.THF and
+        lvl < AF2_QUEST_LEVEL and
+        tenshodoShowdown == QUEST_COMPLETED
+    then
         player:startEvent(503) -- standard dialog after
 
-        -- THICK AS THIEVES
-    elseif job == tpz.job.THF and lvl >= AF2_QUEST_LEVEL and thickAsThieves == QUEST_AVAILABLE
-        and tenshodoShowdown == QUEST_COMPLETED
+    -- THICK AS THIEVES
+    elseif
+        job == tpz.job.THF and
+        lvl >= AF2_QUEST_LEVEL and
+        thickAsThieves == QUEST_AVAILABLE and
+        tenshodoShowdown == QUEST_COMPLETED
     then
         player:startEvent(504) -- start quest
     elseif thickAsThieves == QUEST_ACCEPTED then
-        if player:hasKeyItem(tpz.ki.FIRST_SIGNED_FORGED_ENVELOPE) and
-            player:hasKeyItem(tpz.ki.SECOND_SIGNED_FORGED_ENVELOPE) then
+        if
+            player:hasKeyItem(tpz.ki.FIRST_SIGNED_FORGED_ENVELOPE) and
+            player:hasKeyItem(tpz.ki.SECOND_SIGNED_FORGED_ENVELOPE)
+        then
             player:startEvent(508) -- complete quest
         else
             player:startEvent(505, 0, tpz.ki.GANG_WHEREABOUTS_NOTE) -- before complete grappling and gambling sidequests
         end
 
-        -- HITTING THE MARQUISATE
-    elseif job == tpz.job.THF and lvl >= AF3_QUEST_LEVEL and thickAsThieves == QUEST_COMPLETED
-        and hittingTheMarquisate == QUEST_AVAILABLE
+    -- HITTING THE MARQUISATE
+    elseif
+        job == tpz.job.THF and
+        lvl >= AF3_QUEST_LEVEL and
+        thickAsThieves == QUEST_COMPLETED and
+        hittingTheMarquisate == QUEST_AVAILABLE
     then
         player:startEvent(512) -- start quest
-    elseif hittingTheMarquisateYatnielCS == 3 and hittingTheMarquisateHagainCS == 9 then
+    elseif
+        hittingTheMarquisateYatnielCS == 3 and
+        hittingTheMarquisateHagainCS == 9
+    then
         player:startEvent(516) -- finish first part
     elseif hittingTheMarquisateNanaaCS == 1 then
         player:startEvent(517) -- second part
 
-        -- ROCK RACKETEER
-    elseif mihgosAmigo == QUEST_COMPLETED and rockRacketeer == QUEST_AVAILABLE
-        and player:getFameLevel(WINDURST) >= 3
+    -- ROCK RACKETEER
+    elseif
+        mihgosAmigo == QUEST_COMPLETED and
+        rockRacketeer == QUEST_AVAILABLE and
+        player:getFameLevel(WINDURST) >= 3
     then
         if player:needToZone() then
             player:startEvent(89) -- complete
         else
             player:startEvent(93) -- quest start
         end
-    elseif rockRacketeer == QUEST_ACCEPTED and rockRacketeerCS == 1 then
+    elseif
+        rockRacketeer == QUEST_ACCEPTED and
+        rockRacketeerCS == 1
+    then
         player:startEvent(98) -- advance quest talk to Varun
-    elseif rockRacketeer == QUEST_ACCEPTED and rockRacketeerCS == 2 then
+    elseif
+        rockRacketeer == QUEST_ACCEPTED and
+        rockRacketeerCS == 2
+    then
         player:startEvent(95) -- not sold reminder
     elseif rockRacketeer == QUEST_ACCEPTED then
         player:startEvent(94) -- quest reminder
@@ -139,7 +171,10 @@ end
 
 function onEventFinish(player, csid, option)
     -- WINDURST 2-1: LOST FOR WORDS
-    if csid == 165 and option == 1 then
+    if
+        csid == 165 and
+        option == 1
+    then
         npcUtil.giveKeyItem(player, tpz.ki.LAPIS_MONOCLE)
         player:setCharVar("MissionStatus", 2)
     elseif csid == 169 then
@@ -160,12 +195,20 @@ function onEventFinish(player, csid, option)
         npcUtil.giveKeyItem(player, tpz.ki.LETTER_FROM_THE_TENSHODO)
 
         -- THICK AS THIEVES
-    elseif (csid == 504 and option == 1) then -- start quest "as thick as thieves"
+    elseif
+        csid == 504 and
+        option == 1
+    then -- start quest "as thick as thieves"
         player:addQuest(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES)
         player:setCharVar("thickAsThievesGamblingCS", 1)
-        npcUtil.giveKeyItem(player,
-            {tpz.ki.GANG_WHEREABOUTS_NOTE, tpz.ki.FIRST_FORGED_ENVELOPE, tpz.ki.SECOND_FORGED_ENVELOPE})
-    elseif csid == 508 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES, {
+        npcUtil.giveKeyItem(player, {
+            tpz.ki.GANG_WHEREABOUTS_NOTE,
+            tpz.ki.FIRST_FORGED_ENVELOPE,
+            tpz.ki.SECOND_FORGED_ENVELOPE
+        })
+    elseif
+        csid == 508 and
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES, {
             item = 12514,
             var = "thickAsThievesGamblingCS"
         })
@@ -194,9 +237,14 @@ function onEventFinish(player, csid, option)
         player:setCharVar("rockracketeer_sold", 3)
 
         -- MIHGO'S AMIGO
-    elseif csid == 80 or csid == 81 then
+    elseif
+        csid == 80 or
+        csid == 81
+    then
         player:addQuest(WINDURST, tpz.quest.id.windurst.MIHGO_S_AMIGO)
-    elseif csid == 88 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.MIHGO_S_AMIGO, {
+    elseif
+        csid == 88 and
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.MIHGO_S_AMIGO, {
             gil = 200,
             title = tpz.title.CAT_BURGLAR_GROUPIE,
             fameArea = NORG,

--- a/scripts/zones/Windurst_Woods/npcs/Nhobi_Zalkia.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Nhobi_Zalkia.lua
@@ -16,17 +16,17 @@ end
 
 function onTrigger(player, npc)
     local RegionOwner = GetRegionOwner(tpz.region.KUZOTZ)
+    local stock =
+    {
+        916,   855,  -- Cactuar Needle
+        4412,  299,  -- Thundermelon
+        4491,  184   -- Watermelon
+    }
+
     if RegionOwner ~= tpz.nation.WINDURST then
         player:showText(npc, ID.text.NHOBI_ZALKIA_CLOSED_DIALOG)
     else
         player:showText(npc, ID.text.NHOBI_ZALKIA_OPEN_DIALOG)
-
-        local stock =
-        {
-            916,   855,  -- Cactuar Needle
-            4412,  299,  -- Thundermelon
-            4491,  184   -- Watermelon
-        }
         tpz.shop.general(player, stock, WINDURST)
     end
 end

--- a/scripts/zones/Windurst_Woods/npcs/Nikkoko.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Nikkoko.lua
@@ -32,7 +32,10 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-    if csid == 10014 and option == 1 then
+    if
+        csid == 10014 and
+        option == 1
+    then
         player:messageSpecial(ID.text.IMAGE_SUPPORT, 0, 4, 1)
         player:addStatusEffect(tpz.effect.CLOTHCRAFT_IMAGERY, 1, 0, 120)
     end

--- a/scripts/zones/Windurst_Woods/npcs/Nokkhi_Jinjahl.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Nokkhi_Jinjahl.lua
@@ -93,7 +93,10 @@ function onTrade(player, npc, trade)
     -- check for invalid items
     for i = 0, 8, 1 do
         local itemId = trade:getItemId(i)
-        if itemId > 0 and itemId ~= 948 then
+        if
+            itemId > 0 and
+            itemId ~= 948
+        then
             local validSlot = false
             for k, v in pairs(ammoList) do
                 if v[1] == itemId then
@@ -117,7 +120,10 @@ function onTrade(player, npc, trade)
     end
 
     -- check for correct number of carnations
-    if carnationsNeeded == 0 or trade:getItemQty(948) ~= carnationsNeeded then
+    if
+        carnationsNeeded == 0 or
+        trade:getItemQty(948) ~= carnationsNeeded
+    then
         player:messageSpecial(ID.text.NOKKHI_BAD_COUNT)
         return
     end

--- a/scripts/zones/Windurst_Woods/npcs/Nya_Labiccio.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Nya_Labiccio.lua
@@ -14,6 +14,7 @@ end
 
 function onTrigger(player, npc)
     local RegionOwner = GetRegionOwner(tpz.region.GUSTABERG)
+
     if RegionOwner ~= tpz.nation.WINDURST then
         player:showText(npc, ID.text.NYALABICCIO_CLOSED_DIALOG)
     else

--- a/scripts/zones/Windurst_Woods/npcs/Nya_Labiccio.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Nya_Labiccio.lua
@@ -14,19 +14,18 @@ end
 
 function onTrigger(player, npc)
     local RegionOwner = GetRegionOwner(tpz.region.GUSTABERG)
+    local stock =
+    {
+        1108,  703, -- Sulfur
+        619,    43, -- Popoto
+        611,    36, -- Rye Flour
+        4388,   40  -- Eggplant
+    }
 
     if RegionOwner ~= tpz.nation.WINDURST then
         player:showText(npc, ID.text.NYALABICCIO_CLOSED_DIALOG)
     else
         player:showText(npc, ID.text.NYALABICCIO_OPEN_DIALOG)
-
-        local stock =
-        {
-            1108,  703, -- Sulfur
-            619,    43, -- Popoto
-            611,    36, -- Rye Flour
-            4388,   40  -- Eggplant
-        }
         tpz.shop.general(player, stock, WINDURST)
     end
 end

--- a/scripts/zones/Windurst_Woods/npcs/Ominous_Cloud.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Ominous_Cloud.lua
@@ -54,7 +54,10 @@ function onTrade(player, npc, trade)
     -- check for invalid items
     for i = 0, 8, 1 do
         local itemId = trade:getItemId(i)
-        if itemId > 0 and itemId ~= 951 then
+        if
+            itemId > 0 and
+            itemId ~= 951
+        then
             local validSlot = false
             for k, v in pairs(toolList) do
                 if v[1] == itemId then
@@ -78,7 +81,10 @@ function onTrade(player, npc, trade)
     end
 
     -- check for correct number of wijnfruit
-    if fruitNeeded == 0 or trade:getItemQty(951) ~= fruitNeeded then
+    if
+        fruitNeeded == 0 or
+        trade:getItemQty(951) ~= fruitNeeded
+    then
         player:messageSpecial(ID.text.CLOUD_BAD_COUNT, 951)
         return
     end

--- a/scripts/zones/Windurst_Woods/npcs/Perih_Vashai.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Perih_Vashai.lua
@@ -25,7 +25,10 @@ function onTrade(player, npc, trade)
         player:startEvent(wsQuestEvent)
 
     -- FIRE AND BRIMSTONE
-    elseif player:getCharVar("fireAndBrimstone") == 5 and npcUtil.tradeHas(trade, 1113) then -- old earring
+    elseif
+        player:getCharVar("fireAndBrimstone") == 5 and
+        npcUtil.tradeHas(trade, 1113) -- old earring
+    then
         player:startEvent(537, 0, 13360)
     end
 end
@@ -48,37 +51,62 @@ function onTrigger(player, npc)
         player:startEvent(wsQuestEvent)
 
     -- THREE PATHS
-    elseif player:getCurrentMission(COP) == tpz.mission.id.cop.THREE_PATHS
-        and player:getCharVar("COP_Louverance_s_Path") == 1
+    elseif
+        player:getCurrentMission(COP) == tpz.mission.id.cop.THREE_PATHS and
+        player:getCharVar("COP_Louverance_s_Path") == 1
     then
         player:startEvent(686)
 
     -- THE FANGED ONE
     elseif theFangedOne ~= QUEST_COMPLETED then
-        if theFangedOne == QUEST_AVAILABLE and lvl >= ADVANCED_JOB_LEVEL then
+        if
+            theFangedOne == QUEST_AVAILABLE and
+            lvl >= ADVANCED_JOB_LEVEL
+        then
             player:startEvent(351)
-        elseif theFangedOne == QUEST_ACCEPTED and not player:hasKeyItem(tpz.ki.OLD_TIGERS_FANG) then
+        elseif
+            theFangedOne == QUEST_ACCEPTED and
+            not player:hasKeyItem(tpz.ki.OLD_TIGERS_FANG)
+        then
             player:startEvent(352)
-        elseif player:hasKeyItem(tpz.ki.OLD_TIGERS_FANG) and theFangedOneCS ~= 1 then
+        elseif
+            player:hasKeyItem(tpz.ki.OLD_TIGERS_FANG) and
+            theFangedOneCS ~= 1
+        then
             player:startEvent(357)
         elseif theFangedOneCS == 1 then
             player:startEvent(358)
         end
 
     -- SIN HUNTING
-    elseif sinHunting == QUEST_AVAILABLE and job == tpz.job.RNG and lvl >= AF1_QUEST_LEVEL and sinHuntingCS == 0 then
+    elseif
+        sinHunting == QUEST_AVAILABLE and
+        job == tpz.job.RNG and
+        lvl >= AF1_QUEST_LEVEL and
+        sinHuntingCS == 0
+    then
         player:startEvent(523) -- start RNG AF1
-    elseif sinHuntingCS > 0 and sinHuntingCS < 5 then
+    elseif
+        sinHuntingCS > 0 and
+        sinHuntingCS < 5
+    then
         player:startEvent(524) -- during quest RNG AF1
     elseif sinHuntingCS == 5 then
         player:startEvent(527) -- complete quest RNG AF1
 
     -- FIRE AND BRIMSTONE
-    elseif sinHunting == QUEST_COMPLETED and job == tpz.job.RNG and lvl >= AF2_QUEST_LEVEL
-        and fireAndBrimstone == QUEST_AVAILABLE and fireAndBrimstoneCS == 0
+    elseif
+        sinHunting == QUEST_COMPLETED and
+        job == tpz.job.RNG and
+        lvl >= AF2_QUEST_LEVEL and
+        fireAndBrimstone == QUEST_AVAILABLE and
+        fireAndBrimstoneCS == 0
     then
         player:startEvent(531) -- start RNG AF2
-    elseif fireAndBrimstoneCS > 0 and fireAndBrimstoneCS < 4 then
+    elseif
+        fireAndBrimstoneCS > 0 and
+        fireAndBrimstoneCS < 4
+    then
         player:startEvent(532) -- during RNG AF2
     elseif fireAndBrimstoneCS == 4 then
         player:startEvent(535, 0, 13360, 1113) -- second part RNG AF2
@@ -86,14 +114,24 @@ function onTrigger(player, npc)
         player:startEvent(536, 0, 13360, 1113) -- during second part RNG AF2
 
     -- UNBRIDLED PASSION
-    elseif fireAndBrimstone == QUEST_COMPLETED and job == tpz.job.RNG and lvl >= AF3_QUEST_LEVEL
-        and unbridledPassion == QUEST_AVAILABLE and unbridledPassion == 0
+    elseif
+        fireAndBrimstone == QUEST_COMPLETED and
+        job == tpz.job.RNG and
+        lvl >= AF3_QUEST_LEVEL and
+        unbridledPassion == QUEST_AVAILABLE and
+        unbridledPassion == 0
     then
         player:startEvent(541, 0, 13360) -- start RNG AF3
-    elseif unbridledPassionCS > 0 and unbridledPassionCS < 3 then
-        player:startEvent(542)-- during RNG AF3
-    elseif unbridledPassionCS >= 3 and unbridledPassionCS < 7 then
-        player:startEvent(542)-- during RNG AF3
+    elseif
+        unbridledPassionCS > 0 and
+        unbridledPassionCS < 3
+    then
+        player:startEvent(542) -- during RNG AF3
+    elseif
+        unbridledPassionCS >= 3 and
+        unbridledPassionCS < 7
+    then
+        player:startEvent(542) -- during RNG AF3
     elseif unbridledPassionCS == 7 then
         player:startEvent(546, 0, 14099) -- complete RNG AF3
 
@@ -112,8 +150,10 @@ function onEventFinish(player, csid, option)
     elseif csid == 351 then
         player:addQuest(WINDURST, tpz.quest.id.windurst.THE_FANGED_ONE)
         player:setCharVar("TheFangedOneCS", 1)
-    elseif (csid == 357 or csid == 358)
-        and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.THE_FANGED_ONE, {
+    elseif
+        (csid == 357 or
+        csid == 358) and
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.THE_FANGED_ONE, {
             item = 13117,
             title = tpz.title.THE_FANGED_ONE,
             var = {"TheFangedOne_Event", "TheFangedOneCS" }
@@ -128,7 +168,9 @@ function onEventFinish(player, csid, option)
         player:addQuest(WINDURST, tpz.quest.id.windurst.SIN_HUNTING)
         npcUtil.giveKeyItem(player, tpz.ki.CHIEFTAINNESS_TWINSTONE_EARRING)
         player:setCharVar("sinHunting", 1)
-    elseif csid == 527 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.SIN_HUNTING, {
+    elseif
+        csid == 527 and
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.SIN_HUNTING, {
             item = 17188,
             var = "sinHunting"
         })
@@ -142,7 +184,9 @@ function onEventFinish(player, csid, option)
         player:setCharVar("fireAndBrimstone", 1)
     elseif csid == 535 then -- start second part RNG AF2
         player:setCharVar("fireAndBrimstone", 5)
-    elseif csid == 537 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.FIRE_AND_BRIMSTONE, {
+    elseif
+        csid == 537 and
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.FIRE_AND_BRIMSTONE, {
             item = 12518,
             var = "fireAndBrimstone"
         })
@@ -153,7 +197,9 @@ function onEventFinish(player, csid, option)
     elseif csid == 541 then -- start RNG AF3
         player:addQuest(WINDURST, tpz.quest.id.windurst.UNBRIDLED_PASSION)
         player:setCharVar("unbridledPassion", 1)
-    elseif csid == 546 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.UNBRIDLED_PASSION, {
+    elseif
+        csid == 546 and
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.UNBRIDLED_PASSION, {
             item = 14099,
             var = "unbridledPassion"
         })

--- a/scripts/zones/Windurst_Woods/npcs/Perih_Vashai.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Perih_Vashai.lua
@@ -48,7 +48,9 @@ function onTrigger(player, npc)
         player:startEvent(wsQuestEvent)
 
     -- THREE PATHS
-    elseif player:getCurrentMission(COP) == tpz.mission.id.cop.THREE_PATHS and player:getCharVar("COP_Louverance_s_Path") == 1 then
+    elseif player:getCurrentMission(COP) == tpz.mission.id.cop.THREE_PATHS
+        and player:getCharVar("COP_Louverance_s_Path") == 1
+    then
         player:startEvent(686)
 
     -- THE FANGED ONE
@@ -72,7 +74,9 @@ function onTrigger(player, npc)
         player:startEvent(527) -- complete quest RNG AF1
 
     -- FIRE AND BRIMSTONE
-    elseif sinHunting == QUEST_COMPLETED and job == tpz.job.RNG and lvl >= AF2_QUEST_LEVEL and fireAndBrimstone == QUEST_AVAILABLE and fireAndBrimstoneCS == 0 then
+    elseif sinHunting == QUEST_COMPLETED and job == tpz.job.RNG and lvl >= AF2_QUEST_LEVEL
+        and fireAndBrimstone == QUEST_AVAILABLE and fireAndBrimstoneCS == 0
+    then
         player:startEvent(531) -- start RNG AF2
     elseif fireAndBrimstoneCS > 0 and fireAndBrimstoneCS < 4 then
         player:startEvent(532) -- during RNG AF2
@@ -82,7 +86,9 @@ function onTrigger(player, npc)
         player:startEvent(536, 0, 13360, 1113) -- during second part RNG AF2
 
     -- UNBRIDLED PASSION
-    elseif fireAndBrimstone == QUEST_COMPLETED and job == tpz.job.RNG and lvl >= AF3_QUEST_LEVEL and unbridledPassion == QUEST_AVAILABLE and unbridledPassion == 0 then
+    elseif fireAndBrimstone == QUEST_COMPLETED and job == tpz.job.RNG and lvl >= AF3_QUEST_LEVEL
+        and unbridledPassion == QUEST_AVAILABLE and unbridledPassion == 0
+    then
         player:startEvent(541, 0, 13360) -- start RNG AF3
     elseif unbridledPassionCS > 0 and unbridledPassionCS < 3 then
         player:startEvent(542)-- during RNG AF3
@@ -106,7 +112,13 @@ function onEventFinish(player, csid, option)
     elseif csid == 351 then
         player:addQuest(WINDURST, tpz.quest.id.windurst.THE_FANGED_ONE)
         player:setCharVar("TheFangedOneCS", 1)
-    elseif (csid == 357 or csid == 358) and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.THE_FANGED_ONE, {item=13117, title=tpz.title.THE_FANGED_ONE, var={"TheFangedOne_Event", "TheFangedOneCS"}}) then
+    elseif (csid == 357 or csid == 358)
+        and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.THE_FANGED_ONE, {
+            item = 13117,
+            title = tpz.title.THE_FANGED_ONE,
+            var = {"TheFangedOne_Event", "TheFangedOneCS" }
+            })
+    then
         player:delKeyItem(tpz.ki.OLD_TIGERS_FANG)
         player:unlockJob(tpz.job.RNG)
         player:messageSpecial(ID.text.PERIH_VASHAI_DIALOG)
@@ -116,7 +128,11 @@ function onEventFinish(player, csid, option)
         player:addQuest(WINDURST, tpz.quest.id.windurst.SIN_HUNTING)
         npcUtil.giveKeyItem(player, tpz.ki.CHIEFTAINNESS_TWINSTONE_EARRING)
         player:setCharVar("sinHunting", 1)
-    elseif csid == 527 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.SIN_HUNTING, {item=17188, var="sinHunting"}) then -- complete quest RNG AF1
+    elseif csid == 527 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.SIN_HUNTING, {
+            item = 17188,
+            var = "sinHunting"
+        })
+    then -- complete quest RNG AF1
         player:delKeyItem(tpz.ki.CHIEFTAINNESS_TWINSTONE_EARRING)
         player:delKeyItem(tpz.ki.PERCHONDS_ENVELOPE)
 
@@ -126,14 +142,22 @@ function onEventFinish(player, csid, option)
         player:setCharVar("fireAndBrimstone", 1)
     elseif csid == 535 then -- start second part RNG AF2
         player:setCharVar("fireAndBrimstone", 5)
-    elseif csid == 537 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.FIRE_AND_BRIMSTONE, {item=12518, var="fireAndBrimstone"}) then -- complete quest RNG AF2
+    elseif csid == 537 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.FIRE_AND_BRIMSTONE, {
+            item = 12518,
+            var = "fireAndBrimstone"
+        })
+    then -- complete quest RNG AF2
         player:confirmTrade()
 
     -- UNBRIDLED PASSION
     elseif csid == 541 then -- start RNG AF3
         player:addQuest(WINDURST, tpz.quest.id.windurst.UNBRIDLED_PASSION)
         player:setCharVar("unbridledPassion", 1)
-    elseif csid == 546 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.UNBRIDLED_PASSION, {item=14099, var="unbridledPassion"}) then -- complete quest RNG AF3
+    elseif csid == 546 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.UNBRIDLED_PASSION, {
+            item = 14099,
+            var = "unbridledPassion"
+        })
+    then -- complete quest RNG AF3
         player:delKeyItem(tpz.ki.KOHS_LETTER)
 
     -- FROM SAPLINGS GROW

--- a/scripts/zones/Windurst_Woods/npcs/Peshi_Yohnts.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Peshi_Yohnts.lua
@@ -23,13 +23,13 @@ function onTrigger(player, npc)
     local craftSkill = player:getSkillLevel(tpz.skill.BONECRAFT)
     local testItem = getTestItem(player, npc, tpz.skill.BONECRAFT)
     local guildMember = isGuildMember(player, 2)
+
     if guildMember == 1 then
         guildMember = 64
     end
     if canGetNewRank(player, craftSkill, tpz.skill.BONECRAFT) == 1 then
         getNewRank = 100
     end
-
     player:startEvent(10016, testItem, getNewRank, 30, guildMember, 44, 0, 0, 0)
 end
 
@@ -38,7 +38,10 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-    if csid == 10016 and option == 1 then
+    if
+        csid == 10016 and
+        option == 1
+    then
         local crystal = 4098 -- wind crystal
 
         if player:getFreeSlotsCount() == 0 then

--- a/scripts/zones/Windurst_Woods/npcs/Ponono.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Ponono.lua
@@ -4,8 +4,8 @@
 -- Type: Clothcraft Guild Master
 -- !pos -38.243 -2.25 -120.954 241
 -- TODO Allow players to purchase additional Cuttings
--- TODO Allow players to cancel quest 
--- TODO Requre check for other 3 quests An Understanding General, A Generous General, 
+-- TODO Allow players to cancel quest
+-- TODO Requre check for other 3 quests An Understanding General, A Generous General,
 -----------------------------------
 local ID = require("scripts/zones/Windurst_Woods/IDs")
 require("scripts/globals/crafting")
@@ -45,8 +45,9 @@ function onTrigger(player, npc)
         player:startEvent(700)
     elseif moralManifest == QUEST_COMPLETE or moralManifest == QUEST_ACCEPTED and player:getCharVar("moral") >= 4 then
         player:startEvent(704)
-    elseif player:getCharVar("moral") == 3 and player:getLocalVar("moralZone") == 0 and player:getCharVar("moralWait") <=
-        os.time() then
+    elseif player:getCharVar("moral") == 3 and player:getLocalVar("moralZone") == 0
+        and player:getCharVar("moralWait") <= os.time()
+    then
         player:startEvent(705)
     else
         player:startEvent(10011, testItem, getNewRank, 30, guildMember, 44, 0, 0, 0)

--- a/scripts/zones/Windurst_Woods/npcs/Ponono.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Ponono.lua
@@ -10,16 +10,21 @@
 local ID = require("scripts/zones/Windurst_Woods/IDs")
 require("scripts/globals/crafting")
 require("scripts/globals/status")
+require("scripts/globals/npc_util")
 -----------------------------------
 
 function onTrade(player, npc, trade)
     local newRank = tradeTestItem(player, npc, trade, tpz.skill.CLOTHCRAFT)
     local moralManifest = player:getQuestStatus(OTHER_AREAS_LOG, tpz.quest.id.otherAreas.A_MORAL_MANIFEST)
     local tradeGil = trade:getGil()
+
     if newRank ~= 0 then
         player:setSkillRank(tpz.skill.CLOTHCRAFT, newRank)
         player:startEvent(10012, 0, 0, 0, 0, newRank)
-    elseif moralManifest == QUEST_ACCEPTED and player:getCharVar("moral") == 2 then
+    elseif
+        moralManifest == QUEST_ACCEPTED and
+        player:getCharVar("moral") == 2
+    then
         if npcUtil.tradeHas(trade, {828, 830, {"gil", 10000}}) then -- Trade Velvet Cloth, Rainbow Cloth and 10k
             player:setCharVar("moral", 3)
             player:setLocalVar('moralZone', 1)
@@ -35,23 +40,32 @@ function onTrigger(player, npc)
     local testItem = getTestItem(player, npc, tpz.skill.CLOTHCRAFT)
     local guildMember = isGuildMember(player, 3)
     local moralManifest = player:getQuestStatus(OTHER_AREAS_LOG, tpz.quest.id.otherAreas.A_MORAL_MANIFEST)
+
     if guildMember == 1 then
         guildMember = 10000
     end
     if canGetNewRank(player, craftSkill, tpz.skill.CLOTHCRAFT) == 1 then
         getNewRank = 100
     end
-    if moralManifest == QUEST_ACCEPTED and player:getCharVar("moral") == 1 then
+    if
+        moralManifest == QUEST_ACCEPTED and
+        player:getCharVar("moral") == 1
+    then
         player:startEvent(700)
-    elseif moralManifest == QUEST_COMPLETE or moralManifest == QUEST_ACCEPTED and player:getCharVar("moral") >= 4 then
+    elseif
+        moralManifest == QUEST_COMPLETE or
+        moralManifest == QUEST_ACCEPTED and
+        player:getCharVar("moral") >= 4
+    then
         player:startEvent(704)
-    elseif player:getCharVar("moral") == 3 and player:getLocalVar("moralZone") == 0
-        and player:getCharVar("moralWait") <= os.time()
+    elseif
+        player:getCharVar("moral") == 3 and
+        player:getLocalVar("moralZone") == 0 and
+        player:getCharVar("moralWait") <= os.time()
     then
         player:startEvent(705)
     else
         player:startEvent(10011, testItem, getNewRank, 30, guildMember, 44, 0, 0, 0)
-
     end
 end
 
@@ -66,13 +80,11 @@ function onEventFinish(player, csid, option)
         if npcUtil.giveItem(player, 1867) then
             player:setCharVar("moral", 4)
         end
-    elseif csid == 10011 and option == 1 then
-        if player:getFreeSlotsCount() == 0 then
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 4099)
-        else
-            player:addItem(4099) -- earth crystal
-            player:messageSpecial(ID.text.ITEM_OBTAINED, 4099)
-            signupGuild(player, guild.clothcraft)
-        end
+    elseif
+        csid == 10011 and
+        option == 1 and
+        npcUtil.giveItem(player, 4099)
+    then
+        signupGuild(player, guild.clothcraft)
     end
 end

--- a/scripts/zones/Windurst_Woods/npcs/Rakoh_Buuma.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Rakoh_Buuma.lua
@@ -21,13 +21,16 @@ function onTrigger(player, npc)
         local pRank = player:getRank()
         local cs, p, offset = getMissionOffset(player, 1, CurrentMission, MissionStatus)
 
-        if (CurrentMission <= tpz.mission.id.windurst.THE_SHADOW_AWAITS and (cs ~= 0 or offset ~= 0 or (CurrentMission == tpz.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and offset == 0))) then
+        if CurrentMission <= tpz.mission.id.windurst.THE_SHADOW_AWAITS
+            and (cs ~= 0 or offset ~= 0
+            or (CurrentMission == tpz.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and offset == 0))
+        then
             if cs == 0 then
                 player:showText(npc, ORIGINAL_MISSION_OFFSET + offset) -- dialog after accepting mission
             else
                 player:startEvent(cs, p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8])
             end
-        elseif (CurrentMission ~= tpz.mission.id.windurst.NONE) then
+        elseif CurrentMission ~= tpz.mission.id.windurst.NONE then
             player:startEvent(112)
         elseif not player:hasCompletedMission(WINDURST, tpz.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT) then
             player:startEvent(121)
@@ -42,7 +45,7 @@ function onTrigger(player, npc)
         else
             local flagMission, repeatMission = getMissionMask(player)
             -- NPC dialog changes when starting 3-2 according to whether it's the first time or being repeated
-            if (player:hasCompletedMission(WINDURST, tpz.mission.id.windurst.WRITTEN_IN_THE_STARS)) then
+            if player:hasCompletedMission(WINDURST, tpz.mission.id.windurst.WRITTEN_IN_THE_STARS) then
                 param3 = 1
             else
                 param3 = 0

--- a/scripts/zones/Windurst_Woods/npcs/Rakoh_Buuma.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Rakoh_Buuma.lua
@@ -10,6 +10,7 @@ require("scripts/globals/keyitems")
 require("scripts/globals/missions")
 require("scripts/globals/titles")
 require("scripts/globals/zone")
+require("scripts/globals/npc_util")
 -----------------------------------
 
 function onTrigger(player, npc)
@@ -20,10 +21,14 @@ function onTrigger(player, npc)
         local MissionStatus = player:getCharVar("MissionStatus")
         local pRank = player:getRank()
         local cs, p, offset = getMissionOffset(player, 1, CurrentMission, MissionStatus)
+        local param3 = 0
 
-        if CurrentMission <= tpz.mission.id.windurst.THE_SHADOW_AWAITS
-            and (cs ~= 0 or offset ~= 0
-            or (CurrentMission == tpz.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and offset == 0))
+        if
+            CurrentMission <= tpz.mission.id.windurst.THE_SHADOW_AWAITS and
+            (cs ~= 0 or
+            offset ~= 0 or
+            (CurrentMission == tpz.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and
+            offset == 0))
         then
             if cs == 0 then
                 player:showText(npc, ORIGINAL_MISSION_OFFSET + offset) -- dialog after accepting mission
@@ -47,8 +52,6 @@ function onTrigger(player, npc)
             -- NPC dialog changes when starting 3-2 according to whether it's the first time or being repeated
             if player:hasCompletedMission(WINDURST, tpz.mission.id.windurst.WRITTEN_IN_THE_STARS) then
                 param3 = 1
-            else
-                param3 = 0
             end
             player:startEvent(114, flagMission, 0, param3, 0, tpz.ki.STAR_CRESTED_SUMMONS, repeatMission)
         end
@@ -61,11 +64,17 @@ end
 function onEventFinish(player, csid, option)
     finishMissionTimeline(player, 1, csid, option)
 
-    if csid == 121 and option == 1 then
+    if
+        csid == 121 and
+        option == 1
+    then
         player:addTitle(tpz.title.NEW_BUUMAS_BOOMERS_RECRUIT)
-    elseif csid == 114 and (option == 12 or option == 15) then
-        player:addKeyItem(tpz.ki.STAR_CRESTED_SUMMONS)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.STAR_CRESTED_SUMMONS)
+    elseif
+        csid == 114 and
+        (option == 12 or
+        option == 15)
+    then
+        npcUtil.giveKeyItem(player, tpz.ki.STAR_CRESTED_SUMMONS)
     elseif csid == 632 then
         player:setCharVar("WWoodsRTenText", 1)
     end

--- a/scripts/zones/Windurst_Woods/npcs/Roberta.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Roberta.lua
@@ -5,6 +5,7 @@
 -----------------------------------
 local ID = require("scripts/zones/Windurst_Woods/IDs")
 require("scripts/globals/quests")
+require("scripts/globals/npc_util")
 -----------------------------------
 
 function onTrade(player, npc, trade)
@@ -37,18 +38,13 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-    if (csid == 376 or csid == 377) and option == 1 then
-        if player:getFreeSlotsCount() >= 1 then
-            local blueRibbonProg = player:getCharVar("BlueRibbonBluesProg")
-            if blueRibbonProg < 1 then
-                player:setCharVar("BlueRibbonBluesProg", 1)
-            elseif blueRibbonProg == 3 then
-                player:setCharVar("BlueRibbonBluesProg", 4)
-            end
-            player:addItem(13569)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, 13569)
-        else
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 13569)
+    if (csid == 376 or csid == 377) and option == 1 and npcUtil.giveItem(player, 13569) then
+        local blueRibbonProg = player:getCharVar("BlueRibbonBluesProg")
+
+        if blueRibbonProg < 1 then
+            player:setCharVar("BlueRibbonBluesProg", 1)
+        elseif blueRibbonProg == 3 then
+            player:setCharVar("BlueRibbonBluesProg", 4)
         end
     end
 end

--- a/scripts/zones/Windurst_Woods/npcs/Roberta.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Roberta.lua
@@ -16,12 +16,18 @@ function onTrigger(player, npc)
     if BlueRibbonBlues == QUEST_ACCEPTED then
         local blueRibbonProg = player:getCharVar("BlueRibbonBluesProg")
 
-        if blueRibbonProg >= 2 and player:hasItem(13569) then
+        if
+            blueRibbonProg >= 2 and
+            player:hasItem(13569)
+        then
             player:startEvent(380)
         elseif player:hasItem(13569) then
             player:startEvent(379)
         elseif not player:hasItem(13569) then
-            if blueRibbonProg == 1 or blueRibbonProg == 3 then
+            if
+                blueRibbonProg == 1 or
+                blueRibbonProg == 3
+            then
                 player:startEvent(377, 0, 13569) -- replaces ribbon if lost
             elseif blueRibbonProg < 1 then
                 player:startEvent(376, 0, 13569) -- gives us ribbon
@@ -38,7 +44,12 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-    if (csid == 376 or csid == 377) and option == 1 and npcUtil.giveItem(player, 13569) then
+    if
+        (csid == 376 or
+        csid == 377) and
+        option == 1 and
+        npcUtil.giveItem(player, 13569)
+    then
         local blueRibbonProg = player:getCharVar("BlueRibbonBluesProg")
 
         if blueRibbonProg < 1 then

--- a/scripts/zones/Windurst_Woods/npcs/Ronana.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Ronana.lua
@@ -32,7 +32,10 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-    if csid == 10019 and option == 1 then
+    if
+        csid == 10019 and
+        option == 1
+    then
         player:messageSpecial(ID.text.IMAGE_SUPPORT, 0, 6, 1)
         player:addStatusEffect(tpz.effect.BONECRAFT_IMAGERY, 1, 0, 120)
     end

--- a/scripts/zones/Windurst_Woods/npcs/Sola_Jaab.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Sola_Jaab.lua
@@ -10,7 +10,9 @@ require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.RIDING_ON_THE_CLOUDS) == QUEST_ACCEPTED and player:getCharVar("ridingOnTheClouds_4") == 7 and npcUtil.tradeHas(trade, 1127) then -- Kindred Seal
+    if player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.RIDING_ON_THE_CLOUDS) == QUEST_ACCEPTED
+        and player:getCharVar("ridingOnTheClouds_4") == 7 and npcUtil.tradeHas(trade, 1127)
+    then -- Kindred Seal
         player:confirmTrade()
         player:setCharVar("ridingOnTheClouds_4", 0)
         npcUtil.giveKeyItem(player, tpz.ki.SPIRITED_STONE)

--- a/scripts/zones/Windurst_Woods/npcs/Sola_Jaab.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Sola_Jaab.lua
@@ -10,8 +10,10 @@ require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.RIDING_ON_THE_CLOUDS) == QUEST_ACCEPTED
-        and player:getCharVar("ridingOnTheClouds_4") == 7 and npcUtil.tradeHas(trade, 1127)
+    if
+        player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.RIDING_ON_THE_CLOUDS) == QUEST_ACCEPTED and
+        player:getCharVar("ridingOnTheClouds_4") == 7 and
+        npcUtil.tradeHas(trade, 1127)
     then -- Kindred Seal
         player:confirmTrade()
         player:setCharVar("ridingOnTheClouds_4", 0)

--- a/scripts/zones/Windurst_Woods/npcs/Soni-Muni.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Soni-Muni.lua
@@ -10,8 +10,9 @@ require("scripts/globals/titles")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.THE_AMAZIN_SCORPIO) == QUEST_ACCEPTED
-        and npcUtil.tradeHas(trade, 1017)
+    if
+        player:getQuestStatus(WINDURST, tpz.quest.id.windurst.THE_AMAZIN_SCORPIO) == QUEST_ACCEPTED and
+        npcUtil.tradeHas(trade, 1017)
     then
         player:startEvent(484)
     end
@@ -21,15 +22,18 @@ function onTrigger(player, npc)
     local amazinScorpio = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.THE_AMAZIN_SCORPIO)
     local wildcatWindurst = player:getCharVar("WildcatWindurst")
 
-    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED
-        and not player:getMaskBit(wildcatWindurst, 0)
+    if
+        player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
+        not player:getMaskBit(wildcatWindurst, 0)
     then
         player:startEvent(735)
     elseif amazinScorpio == QUEST_COMPLETED then
         player:startEvent(485)
     elseif amazinScorpio == QUEST_ACCEPTED then
         player:startEvent(482, 0, 0, 1017)
-    elseif amazinScorpio == QUEST_AVAILABLE and player:getFameLevel(WINDURST) >= 2 then
+    elseif
+        amazinScorpio == QUEST_AVAILABLE and
+        player:getFameLevel(WINDURST) >= 2 then
         player:startEvent(481, 0, 0, 1017)
     else
         player:startEvent(421)
@@ -42,7 +46,9 @@ end
 function onEventFinish(player, csid, option)
     if csid == 481 then
         player:addQuest(WINDURST, tpz.quest.id.windurst.THE_AMAZIN_SCORPIO)
-    elseif csid == 484 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.THE_AMAZIN_SCORPIO, {
+    elseif
+        csid == 484 and
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.THE_AMAZIN_SCORPIO, {
             fame = 80,
             title = tpz.title.GREAT_GRAPPLER_SCORPIO,
             gil = 1500

--- a/scripts/zones/Windurst_Woods/npcs/Soni-Muni.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Soni-Muni.lua
@@ -10,7 +10,9 @@ require("scripts/globals/titles")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.THE_AMAZIN_SCORPIO) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 1017) then
+    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.THE_AMAZIN_SCORPIO) == QUEST_ACCEPTED
+        and npcUtil.tradeHas(trade, 1017)
+    then
         player:startEvent(484)
     end
 end
@@ -19,7 +21,9 @@ function onTrigger(player, npc)
     local amazinScorpio = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.THE_AMAZIN_SCORPIO)
     local wildcatWindurst = player:getCharVar("WildcatWindurst")
 
-    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not player:getMaskBit(wildcatWindurst, 0) then
+    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED
+        and not player:getMaskBit(wildcatWindurst, 0)
+    then
         player:startEvent(735)
     elseif amazinScorpio == QUEST_COMPLETED then
         player:startEvent(485)
@@ -38,7 +42,12 @@ end
 function onEventFinish(player, csid, option)
     if csid == 481 then
         player:addQuest(WINDURST, tpz.quest.id.windurst.THE_AMAZIN_SCORPIO)
-    elseif csid == 484 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.THE_AMAZIN_SCORPIO, {fame=80, title=tpz.title.GREAT_GRAPPLER_SCORPIO, gil=1500}) then
+    elseif csid == 484 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.THE_AMAZIN_SCORPIO, {
+            fame = 80,
+            title = tpz.title.GREAT_GRAPPLER_SCORPIO,
+            gil = 1500
+        })
+    then
         player:confirmTrade()
     elseif csid == 735 then
         player:setMaskBit(player:getCharVar("WildcatWindurst"), "WildcatWindurst", 0, true)

--- a/scripts/zones/Windurst_Woods/npcs/Spare_Five.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Spare_Five.lua
@@ -14,7 +14,10 @@ function onTrigger(player, npc)
     local AGreetingCardian = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.A_GREETING_CARDIAN)
     local AGCcs = player:getCharVar("AGreetingCardian_Event")
 
-    if AGreetingCardian == QUEST_ACCEPTED and AGCcs == 2 then
+    if
+        AGreetingCardian == QUEST_ACCEPTED and
+        AGCcs == 2
+    then
         player:startEvent(295) -- A Greeting Cardian step two
     else
         player:startEvent(282) -- standard dialog

--- a/scripts/zones/Windurst_Woods/npcs/Spare_Four.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Spare_Four.lua
@@ -14,7 +14,10 @@ function onTrigger(player, npc)
     local AGreetingCardian = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.A_GREETING_CARDIAN)
     local AGCcs = player:getCharVar("AGreetingCardian_Event")
 
-    if AGreetingCardian == QUEST_ACCEPTED and AGCcs == 2 then
+    if
+        AGreetingCardian == QUEST_ACCEPTED and
+        AGCcs == 2
+    then
         player:startEvent(295) -- A Greeting Cardian step two
     else
         player:startEvent(281) -- standard dialog

--- a/scripts/zones/Windurst_Woods/npcs/Spare_One.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Spare_One.lua
@@ -14,7 +14,10 @@ function onTrigger(player, npc)
     local AGreetingCardian = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.A_GREETING_CARDIAN)
     local AGCcs = player:getCharVar("AGreetingCardian_Event")
 
-    if AGreetingCardian == QUEST_ACCEPTED and AGCcs == 2 then
+    if
+        AGreetingCardian == QUEST_ACCEPTED and
+        AGCcs == 2
+    then
         player:startEvent(295) -- A Greeting Cardian step two
     else
         player:startEvent(278) -- standard dialog

--- a/scripts/zones/Windurst_Woods/npcs/Spare_Three.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Spare_Three.lua
@@ -14,7 +14,10 @@ function onTrigger(player, npc)
     local AGreetingCardian = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.A_GREETING_CARDIAN)
     local AGCcs = player:getCharVar("AGreetingCardian_Event")
 
-    if AGreetingCardian == QUEST_ACCEPTED and AGCcs == 2 then
+    if
+        AGreetingCardian == QUEST_ACCEPTED and
+        AGCcs == 2
+    then
         player:startEvent(295) -- A Greeting Cardian step two
     else
         player:startEvent(280) -- standard dialog

--- a/scripts/zones/Windurst_Woods/npcs/Spare_Two.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Spare_Two.lua
@@ -14,7 +14,10 @@ function onTrigger(player, npc)
     local AGreetingCardian = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.A_GREETING_CARDIAN)
     local AGCcs = player:getCharVar("AGreetingCardian_Event")
 
-    if AGreetingCardian == QUEST_ACCEPTED and AGCcs == 2 then
+    if
+        AGreetingCardian == QUEST_ACCEPTED and
+        AGCcs == 2
+    then
         player:startEvent(295) -- A Greeting Cardian step two
     else
         player:startEvent(279) -- standard dialog

--- a/scripts/zones/Windurst_Woods/npcs/Tapoh_Lihzeh.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Tapoh_Lihzeh.lua
@@ -12,7 +12,9 @@ require("scripts/globals/titles")
 
 function onTrade(player, npc, trade)
     -- CHOCOBILIOUS
-    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CHOCOBILIOUS) == QUEST_ACCEPTED and player:getCharVar("ChocobiliousQuest") == 1 and npcUtil.tradeHas(trade, 938) then
+    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CHOCOBILIOUS) == QUEST_ACCEPTED
+        and player:getCharVar("ChocobiliousQuest") == 1 and npcUtil.tradeHas(trade, 938)
+    then
         player:startEvent(229, 0, 938)
 
     -- PAYING LIP SERVICE
@@ -65,7 +67,10 @@ function onEventFinish(player, csid, option)
         player:addQuest(WINDURST, tpz.quest.id.windurst.PAYING_LIP_SERVICE)
     elseif csid == 479 then
         if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.PAYING_LIP_SERVICE) == QUEST_ACCEPTED then
-            npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.PAYING_LIP_SERVICE, {fame=60, title=tpz.title.KISSER_MAKEUPPER})
+            npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.PAYING_LIP_SERVICE, {
+                fame = 60,
+                title = tpz.title.KISSER_MAKEUPPER
+            })
         else
             player:addFame(WINDURST, 8)
         end

--- a/scripts/zones/Windurst_Woods/npcs/Tapoh_Lihzeh.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Tapoh_Lihzeh.lua
@@ -12,8 +12,10 @@ require("scripts/globals/titles")
 
 function onTrade(player, npc, trade)
     -- CHOCOBILIOUS
-    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CHOCOBILIOUS) == QUEST_ACCEPTED
-        and player:getCharVar("ChocobiliousQuest") == 1 and npcUtil.tradeHas(trade, 938)
+    if
+        player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CHOCOBILIOUS) == QUEST_ACCEPTED and
+        player:getCharVar("ChocobiliousQuest") == 1 and
+        npcUtil.tradeHas(trade, 938)
     then
         player:startEvent(229, 0, 938)
 
@@ -33,9 +35,15 @@ function onTrigger(player, npc)
     local payingLipService = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.PAYING_LIP_SERVICE)
 
     -- CHOCOBILIOUS
-    if chocobilious == QUEST_ACCEPTED and chocobiliousCS == 2 then
+    if
+        chocobilious == QUEST_ACCEPTED and
+        chocobiliousCS == 2
+    then
         player:startEvent(230) -- after trading
-    elseif chocobilious == QUEST_ACCEPTED and chocobiliousCS == 1 then
+    elseif
+        chocobilious == QUEST_ACCEPTED and
+        chocobiliousCS == 1
+    then
         player:startEvent(228, 0, 938) -- after first talk
     elseif chocobilious == QUEST_ACCEPTED then
         player:startEvent(227, 0, 938) -- first talk
@@ -63,7 +71,10 @@ function onEventFinish(player, csid, option)
         player:setCharVar("ChocobiliousQuest", 2)
 
     -- PAYING LIP SERVICE
-    elseif csid == 477 and option == 1 then
+    elseif
+        csid == 477 and
+        option == 1
+    then
         player:addQuest(WINDURST, tpz.quest.id.windurst.PAYING_LIP_SERVICE)
     elseif csid == 479 then
         if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.PAYING_LIP_SERVICE) == QUEST_ACCEPTED then

--- a/scripts/zones/Windurst_Woods/npcs/Taraihi-Perunhi.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Taraihi-Perunhi.lua
@@ -16,20 +16,20 @@ end
 
 function onTrigger(player, npc)
     local RegionOwner = GetRegionOwner(tpz.region.DERFLAND)
+    local stock =
+    {
+        4352,  128, -- Derfland Pear
+        617,   142, -- Ginger
+        4545,   62, -- Gysahl Greens
+        1412, 1656, -- Olive Flower
+        633,    14, -- Olive Oil
+        951,   110  -- Wijnruit
+    }
+
     if RegionOwner ~= tpz.nation.WINDURST then
         player:showText(npc, ID.text.TARAIHIPERUNHI_CLOSED_DIALOG)
     else
         player:showText(npc, ID.text.TARAIHIPERUNHI_OPEN_DIALOG)
-
-        local stock =
-        {
-            4352,  128, -- Derfland Pear
-            617,   142, -- Ginger
-            4545,   62, -- Gysahl Greens
-            1412, 1656, -- Olive Flower
-            633,    14, -- Olive Oil
-            951,   110  -- Wijnruit
-        }
         tpz.shop.general(player, stock, WINDURST)
     end
 end

--- a/scripts/zones/Windurst_Woods/npcs/Terude-Harude.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Terude-Harude.lua
@@ -33,7 +33,10 @@ end
 
 function onEventFinish(player, csid, option)
     local Cost = getAdvImageSupportCost(player, 8)
-    if csid == 10013 and option == 1 then
+    if
+        csid == 10013 and
+        option == 1
+    then
         player:delGil(Cost)
         player:messageSpecial(ID.text.IMAGE_SUPPORT, 0, 4, 0)
         player:addStatusEffect(tpz.effect.CLOTHCRAFT_IMAGERY, 3, 0, 480)

--- a/scripts/zones/Windurst_Woods/npcs/Umumu.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Umumu.lua
@@ -20,7 +20,9 @@ function onTrigger(player, npc)
     local MakingHeadlines = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.MAKING_HEADLINES)
     local WildcatWindurst = player:getCharVar("WildcatWindurst")
 
-    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not player:getMaskBit(WildcatWindurst, 3) then
+    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED
+        and not player:getMaskBit(WildcatWindurst, 3)
+    then
         player:startEvent(731)
     elseif MakingHeadlines == 1 then
         local prog = player:getCharVar("QuestMakingHeadlines_var")

--- a/scripts/zones/Windurst_Woods/npcs/Umumu.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Umumu.lua
@@ -7,6 +7,7 @@
 local ID = require("scripts/zones/Windurst_Woods/IDs")
 require("scripts/globals/quests")
 require("scripts/globals/titles")
+require("scripts/globals/npc_util")
 -----------------------------------
 
 function onTrade(player, npc, trade)
@@ -20,8 +21,9 @@ function onTrigger(player, npc)
     local MakingHeadlines = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.MAKING_HEADLINES)
     local WildcatWindurst = player:getCharVar("WildcatWindurst")
 
-    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED
-        and not player:getMaskBit(WildcatWindurst, 3)
+    if
+        player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
+        not player:getMaskBit(WildcatWindurst, 3)
     then
         player:startEvent(731)
     elseif MakingHeadlines == 1 then
@@ -60,8 +62,7 @@ end
 function onEventFinish(player, csid, option)
     if csid == 381 then
         local prog = player:getCharVar("QuestMakingHeadlines_var")
-        player:addKeyItem(tpz.ki.WINDURST_WOODS_SCOOP)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.WINDURST_WOODS_SCOOP)
+        npcUtil.giveKeyItem(player, tpz.ki.WINDURST_WOODS_SCOOP)
         player:setCharVar("QuestMakingHeadlines_var", prog+8)
     elseif csid == 731 then
         player:setMaskBit(player:getCharVar("WildcatWindurst"), "WildcatWindurst", 3, true)

--- a/scripts/zones/Windurst_Woods/npcs/Valeriano.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Valeriano.lua
@@ -13,8 +13,6 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-    player:showText(npc, ID.text.VALERIANO_SHOP_DIALOG)
-
     local stock =
     {
         4394,    10, -- Ginger Cookie
@@ -31,6 +29,8 @@ function onTrigger(player, npc)
         5059, 28520, -- Scroll of Water Carol II
         4996, 123880  -- Scroll of Mage's Ballad III
     }
+
+    player:showText(npc, ID.text.VALERIANO_SHOP_DIALOG)
     tpz.shop.general(player, stock, WINDURST)
 end
 

--- a/scripts/zones/Windurst_Woods/npcs/Varun.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Varun.lua
@@ -9,7 +9,10 @@ require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getCharVar("rockracketeer_sold") == 5 and npcUtil.tradeHas(trade, 598) then -- Sharp Stone
+    if
+        player:getCharVar("rockracketeer_sold") == 5 and
+        npcUtil.tradeHas(trade, 598) -- Sharp Stone
+    then
         player:startEvent(102, 2100)
     end
 end
@@ -18,9 +21,15 @@ function onTrigger(player, npc)
     local rockRacketeer = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.ROCK_RACKETEER)
     local rockRacketeerCS = player:getCharVar("rockracketeer_sold")
 
-    if rockRacketeer == QUEST_ACCEPTED and rockRacketeerCS == 3 then
+    if
+        rockRacketeer == QUEST_ACCEPTED and
+        rockRacketeerCS == 3
+    then
         player:startEvent(100) -- talk about lost stone
-    elseif rockRacketeer == QUEST_ACCEPTED and rockRacketeerCS == 4 then
+    elseif
+        rockRacketeer == QUEST_ACCEPTED and
+        rockRacketeerCS == 4
+    then
         player:startEvent(101, 0, 598) -- send player to Palborough Mines
 
     else
@@ -36,7 +45,9 @@ function onEventFinish(player, csid, option)
         player:setCharVar("rockracketeer_sold", 4)
     elseif csid == 101 then
         player:setCharVar("rockracketeer_sold", 5)
-    elseif csid == 102 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.ROCK_RACKETEER, {
+    elseif
+        csid == 102 and
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.ROCK_RACKETEER, {
             gil = 2100,
             var = "rockracketeer_sold"
         })

--- a/scripts/zones/Windurst_Woods/npcs/Varun.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Varun.lua
@@ -36,7 +36,11 @@ function onEventFinish(player, csid, option)
         player:setCharVar("rockracketeer_sold", 4)
     elseif csid == 101 then
         player:setCharVar("rockracketeer_sold", 5)
-    elseif csid == 102 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.ROCK_RACKETEER, {gil=2100, var="rockracketeer_sold"}) then
+    elseif csid == 102 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.ROCK_RACKETEER, {
+            gil = 2100,
+            var = "rockracketeer_sold"
+        })
+    then
         player:confirmTrade()
     end
 end

--- a/scripts/zones/Windurst_Woods/npcs/Wije_Tiren.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Wije_Tiren.lua
@@ -12,8 +12,6 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-    player:showText(npc, ID.text.WIJETIREN_SHOP_DIALOG)
-
     local stock = {
         4148,   290,       --Antidote
         4509,    10,       --Distilled Water
@@ -24,6 +22,8 @@ function onTrigger(player, npc)
         5014,    98,       --Scroll of Herb Pastoral
         2864,  9200        --Federation Waystone
     }
+
+    player:showText(npc, ID.text.WIJETIREN_SHOP_DIALOG)
     tpz.shop.general(player, stock, WINDURST)
 end
 


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

would love a second set of eyes to take a look at it in case i messed something up, but this is only styleguide fixes and replacement of additem to use npcutil.giveitem

