### PR TITLE
San d'Oria 8-1 key item can only be obtained once

### DIFF
--- a/scripts/zones/Quicksand_Caves/npcs/Fountain_of_Kings.lua
+++ b/scripts/zones/Quicksand_Caves/npcs/Fountain_of_Kings.lua
@@ -1,6 +1,7 @@
 -----------------------------------
 -- Area: Quicksand Caves
 --  NPC: Fountain of Kings
+-- Involved in Mission: San d'Oria 8-1
 -- !pos 567 18 -939 208
 -----------------------------------
 local ID = require("scripts/zones/Quicksand_Caves/IDs")
@@ -11,14 +12,20 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-    if (player:getCurrentMission(SANDORIA) == tpz.mission.id.sandoria.COMING_OF_AGE and player:getCharVar("MissionStatus") == 2
-        and not GetMobByID(ID.mob.VALOR):isSpawned() and not GetMobByID(ID.mob.HONOR):isSpawned()) then
-        SpawnMob(ID.mob.VALOR)
-        SpawnMob(ID.mob.HONOR)
-    elseif (player:getCurrentMission(SANDORIA) == tpz.mission.id.sandoria.COMING_OF_AGE and player:getCharVar("MissionStatus") == 3
-        and not GetMobByID(ID.mob.VALOR):isSpawned() and not GetMobByID(ID.mob.HONOR):isSpawned()) then
-        player:addKeyItem(tpz.ki.DROPS_OF_AMNIO)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.DROPS_OF_AMNIO)
+    -- Player is on San d'Oria mission 8-1 "Coming of Age":
+    if player:getCurrentMission(SANDORIA) == tpz.mission.id.sandoria.COMING_OF_AGE then
+        local missionStatus = player:getCharVar("MissionStatus")
+        local mob1 = GetMobByID(ID.mob.VALOR):isSpawned()
+        local mob2 = GetMobByID(ID.mob.HONOR):isSpawned()
+
+        if missionStatus == 2 and not mob1 and not mob2 then
+            SpawnMob(ID.mob.VALOR)
+            SpawnMob(ID.mob.HONOR)
+        elseif missionStatus == 3 and not mob1 and not mob2 and not player:hasKeyItem(tpz.ki.DROPS_OF_AMNIO) then
+            player:addKeyItem(tpz.ki.DROPS_OF_AMNIO)
+            player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.DROPS_OF_AMNIO)
+        end
+    -- Default
     else
         player:messageSpecial(ID.text.POOL_OF_WATER)
     end


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

This commit adds a check for whether the player already obtained the key item of the quest's current step. Without this, and the former code, the key item could be obtained an infinite number of times by clicking the fountain again and again after killing the Mantas.

Also reduces the conditions path, applies style guide and adds locals for re-use.