### PR TITLE
Guildshops truncated list of items

### DIFF
--- a/src/map/packets/guild_menu_buy.cpp
+++ b/src/map/packets/guild_menu_buy.cpp
@@ -68,5 +68,5 @@ CGuildMenuBuyPacket::CGuildMenuBuyPacket(CCharEntity* PChar, CItemContainer* PGu
         }
     }
     ref<uint8>(0xF4) = ItemCount;
-    ref<uint8>(0xF5) = PacketCount + 0xC0;
+    ref<uint8>(0xF5) = PacketCount + 0x80;
 }


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Cooking guild had truncated list of items because of incorrect packet flag
