### PR TITLE
styleguide fixes for windurst walls + switch to npcUtil + fix global vars

### DIFF
--- a/scripts/zones/Windurst_Walls/npcs/Ambrosius.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Ambrosius.lua
@@ -6,54 +6,42 @@
 -----------------------------------
 require("scripts/globals/quests")
 require("scripts/globals/settings")
+require("scripts/globals/npc_util")
 -----------------------------------
 
-function onTrigger(player, npc)
-    QuestStatus = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.THE_POSTMAN_ALWAYS_KO_S_TWICE)
-
-    if (QuestStatus == QUEST_AVAILABLE) then
-        player:startEvent(48)
-    elseif (QuestStatus == QUEST_ACCEPTED) then
-        player:startEvent(49)
-    elseif (QuestStatus == QUEST_COMPLETED) then
-        player:startEvent(56)
-    end
-end
-
 function onTrade(player, npc, trade)
-    QuestStatus = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.THE_POSTMAN_ALWAYS_KO_S_TWICE)
+    local QuestStatus = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.THE_POSTMAN_ALWAYS_KO_S_TWICE)
+    local reward = 0
 
-    if (QuestStatus ~= QUEST_AVAILABLE) then
-        reward = 0
+    if QuestStatus ~= QUEST_AVAILABLE then
+        if npcUtil.tradeHas(trade, 584) then reward = reward+1 end
+        if npcUtil.tradeHas(trade, 585) then reward = reward+1 end
+        if npcUtil.tradeHas(trade, 586) then reward = reward+1 end
+        if npcUtil.tradeHas(trade, 587) then reward = reward+1 end
 
-        if (trade:hasItemQty(584, 1)) then reward = reward+1 end
-        if (trade:hasItemQty(585, 1)) then reward = reward+1 end
-        if (trade:hasItemQty(586, 1)) then reward = reward+1 end
-        if (trade:hasItemQty(587, 1)) then reward = reward+1 end
-
-        if (trade:getItemCount() == reward) then
-            if (reward == 1) then
-                if (QuestStatus == QUEST_ACCEPTED) then
+        if trade:getItemCount() == reward then
+            if reward == 1 then
+                if QuestStatus == QUEST_ACCEPTED then
                     player:startEvent(52, GIL_RATE*50)
-                elseif (QuestStatus == QUEST_COMPLETED) then
+                elseif QuestStatus == QUEST_COMPLETED then
                     player:startEvent(57, GIL_RATE*50)
                 end
-            elseif (reward == 2) then
-                if (QuestStatus == QUEST_ACCEPTED) then
+            elseif reward == 2 then
+                if QuestStatus == QUEST_ACCEPTED then
                     player:startEvent(53, GIL_RATE*150, 2)
-                elseif (QuestStatus == QUEST_COMPLETED) then
+                elseif QuestStatus == QUEST_COMPLETED then
                     player:startEvent(58, GIL_RATE*150, 2)
                 end
-            elseif (reward == 3) then
-                if (QuestStatus == QUEST_ACCEPTED) then
+            elseif reward == 3 then
+                if QuestStatus == QUEST_ACCEPTED then
                     player:startEvent(54, GIL_RATE*250, 3)
-                elseif (QuestStatus == QUEST_COMPLETED) then
+                elseif QuestStatus == QUEST_COMPLETED then
                     player:startEvent(59, GIL_RATE*250, 3)
                 end
-            elseif (reward == 4) then
-                if (QuestStatus == QUEST_ACCEPTED) then
+            elseif reward == 4 then
+                if QuestStatus == QUEST_ACCEPTED then
                     player:startEvent(55, GIL_RATE*500, 4)
-                elseif (QuestStatus == QUEST_COMPLETED) then
+                elseif QuestStatus == QUEST_COMPLETED then
                     player:startEvent(60, GIL_RATE*500, 4)
                 end
             end
@@ -61,48 +49,65 @@ function onTrade(player, npc, trade)
     end
 end
 
+function onTrigger(player, npc)
+    local QuestStatus = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.THE_POSTMAN_ALWAYS_KO_S_TWICE)
+
+    if QuestStatus == QUEST_AVAILABLE then
+        player:startEvent(48)
+    elseif QuestStatus == QUEST_ACCEPTED then
+        player:startEvent(49)
+    elseif QuestStatus == QUEST_COMPLETED then
+        player:startEvent(56)
+    end
+end
+
 function onEventUpdate(player, csid, option)
-    -- printf("Update CSID: %u", csid)
 end
 
 function onEventFinish(player, csid, option)
-    -- printf("Finish CSID: %u", csid)
 
-    if (csid == 48 and option == 0) then
+    if
+        csid == 48 and
+        option == 0
+    then
         player:addQuest(WINDURST, tpz.quest.id.windurst.THE_POSTMAN_ALWAYS_KO_S_TWICE)
-    elseif (csid == 52) then
+    elseif csid == 52 then
         player:tradeComplete()
-        player:addGil(GIL_RATE*50)
-        player:addFame(WINDURST, 80)
-        player:completeQuest(WINDURST, tpz.quest.id.windurst.THE_POSTMAN_ALWAYS_KO_S_TWICE)
-    elseif (csid == 53) then
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.THE_POSTMAN_ALWAYS_KO_S_TWICE, {
+            fame = 80,
+            gil = 50
+        })
+    elseif csid == 53 then
         player:tradeComplete()
-        player:addGil(GIL_RATE*150)
-        player:addFame(WINDURST, 80)
-        player:completeQuest(WINDURST, tpz.quest.id.windurst.THE_POSTMAN_ALWAYS_KO_S_TWICE)
-    elseif (csid == 54) then
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.THE_POSTMAN_ALWAYS_KO_S_TWICE, {
+            fame = 80,
+            gil = 150
+        })
+    elseif csid == 54 then
         player:tradeComplete()
-        player:addGil(GIL_RATE*250)
-        player:addFame(WINDURST, 80)
-        player:completeQuest(WINDURST, tpz.quest.id.windurst.THE_POSTMAN_ALWAYS_KO_S_TWICE)
-    elseif (csid == 55) then
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.THE_POSTMAN_ALWAYS_KO_S_TWICE, {
+            fame = 80,
+            gil = 250
+        })
+    elseif csid == 55 then
         player:tradeComplete()
-        player:addGil(GIL_RATE*500)
-        player:addFame(WINDURST, 80)
-        player:completeQuest(WINDURST, tpz.quest.id.windurst.THE_POSTMAN_ALWAYS_KO_S_TWICE)
-    elseif (csid == 57) then
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.THE_POSTMAN_ALWAYS_KO_S_TWICE, {
+            fame = 80,
+            gil = 500
+        })
+    elseif csid == 57 then
         player:tradeComplete()
         player:addGil(GIL_RATE*50)
         player:addFame(WINDURST, 5)
-    elseif (csid == 58) then
+    elseif csid == 58 then
         player:tradeComplete()
         player:addGil(GIL_RATE*150)
         player:addFame(WINDURST, 15)
-    elseif (csid == 59) then
+    elseif csid == 59 then
         player:tradeComplete()
         player:addGil(GIL_RATE*250)
         player:addFame(WINDURST, 25)
-    elseif (csid == 60) then
+    elseif csid == 60 then
         player:tradeComplete()
         player:addGil(GIL_RATE*500)
         player:addFame(WINDURST, 50)

--- a/scripts/zones/Windurst_Walls/npcs/Chomomo.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Chomomo.lua
@@ -11,24 +11,21 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-
-    local WildcatWindurst = player:getCharVar("WildcatWindurst")
-
-    if (player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and player:getMaskBit(WildcatWindurst, 8) == false) then
+    if
+        player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
+        player:getMaskBit(player:getCharVar("WildcatWindurst"), 8) == false
+    then
         player:startEvent(499)
     else
         player:startEvent(325)
     end
-
 end
 
 function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-
-    if (csid == 499) then
+    if csid == 499 then
         player:setMaskBit(player:getCharVar("WildcatWindurst"), "WildcatWindurst", 8, true)
     end
-
 end

--- a/scripts/zones/Windurst_Walls/npcs/Hiwon-Biwon.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Hiwon-Biwon.lua
@@ -7,6 +7,7 @@
 require("scripts/globals/quests")
 require("scripts/globals/settings")
 require("scripts/globals/titles")
+require("scripts/globals/npc_util")
 local ID = require("scripts/zones/Windurst_Walls/IDs")
 -----------------------------------
 
@@ -22,23 +23,23 @@ function onTrigger(player, npc)
     local CFA2 = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CURSES_FOILED_AGAIN_2)
 
     -- Curses, Foiled ... Again!?
-    if (CFA2 == QUEST_ACCEPTED and player:hasItem(552) == false) then
+    if CFA2 == QUEST_ACCEPTED and player:hasItem(552) == false then
         player:startEvent(182) -- get Hiwon's hair
-    elseif (CFA2 == QUEST_COMPLETED and MakingHeadlines ~= QUEST_ACCEPTED) then
+    elseif CFA2 == QUEST_COMPLETED and MakingHeadlines ~= QUEST_ACCEPTED then
         player:startEvent(185) -- New Dialog after CFA2
 
     -- Making Headlines
-    elseif (MakingHeadlines == 1) then
+    elseif MakingHeadlines == 1 then
         prog = player:getCharVar("QuestMakingHeadlines_var")
-        --  Variable to track if player has talked to 4 NPCs and a door
+        -- Variable to track if player has talked to 4 NPCs and a door
         --  1 = Kyume
-        -- 2 = Yujuju
-        -- 4 = Hiwom
-        -- 8 = Umumu
+        --  2 = Yujuju
+        --  4 = Hiwom
+        --  8 = Umumu
         -- 16 = Mahogany Door
-        if (testflag(tonumber(prog), 4) == false) then
-            if (player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CURSES_FOILED_AGAIN_1) == 1) then
-                if (math.random(1, 2) == 1) then
+        if testflag(tonumber(prog), 4) == false then
+            if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CURSES_FOILED_AGAIN_1) == QUEST_ACCEPTED then
+                if math.random(1, 2) == 1 then
                     player:startEvent(283) -- Give scoop while sick
                 else
                     player:startEvent(284) -- Give scoop while sick
@@ -51,45 +52,38 @@ function onTrigger(player, npc)
         end
     else
         local rand = math.random(1, 5)
-        if (rand == 1) then
-            print (rand)
+        if rand == 1 then
             player:startEvent(305) -- Standard Conversation
-        elseif (rand == 2) then
-            print (rand)
+        elseif rand == 2 then
             player:startEvent(306) -- Standard Conversation
-        elseif (rand == 3) then
-            print (rand)
+        elseif rand == 3 then
             player:startEvent(168) -- Standard Conversation
-        elseif (rand == 4) then
-            print (rand)
+        elseif rand == 4 then
             player:startEvent(170) -- Standard Conversation
-        elseif (rand == 5) then
-            print (rand)
+        elseif rand == 5 then
             player:startEvent(169) -- Standard Conversation
         end
     end
 end
 
 function onEventUpdate(player, csid, option)
-
 end
 
 function onEventFinish(player, csid, option)
+    local prog = player:getCharVar("QuestMakingHeadlines_var")
 
     -- Making Headlines
-    if (csid == 281 or csid == 283 or csid == 284) then
-        prog = player:getCharVar("QuestMakingHeadlines_var")
+    if
+        csid == 281 or
+        csid == 283 or
+        csid == 284
+    then
         player:addKeyItem(tpz.ki.WINDURST_WALLS_SCOOP)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.WINDURST_WALLS_SCOOP)
         player:setCharVar("QuestMakingHeadlines_var", prog+4)
 
     -- Curses, Foiled...Again!?
-    elseif (csid == 182) then
-        if (player:getFreeSlotsCount() == 0) then
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 552) -- Hiwon's hair
-        else
-            player:addItem(552)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, 552) -- Hiwon's hair
-        end
+    elseif csid == 182 then
+        npcUtil.giveItem(player, 552) -- Hiwon's hair
     end
 end

--- a/scripts/zones/Windurst_Walls/npcs/Hiwon-Biwon.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Hiwon-Biwon.lua
@@ -23,9 +23,15 @@ function onTrigger(player, npc)
     local CFA2 = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CURSES_FOILED_AGAIN_2)
 
     -- Curses, Foiled ... Again!?
-    if CFA2 == QUEST_ACCEPTED and player:hasItem(552) == false then
+    if
+        CFA2 == QUEST_ACCEPTED and
+        player:hasItem(552) == false
+    then
         player:startEvent(182) -- get Hiwon's hair
-    elseif CFA2 == QUEST_COMPLETED and MakingHeadlines ~= QUEST_ACCEPTED then
+    elseif
+        CFA2 == QUEST_COMPLETED and
+        MakingHeadlines ~= QUEST_ACCEPTED
+    then
         player:startEvent(185) -- New Dialog after CFA2
 
     -- Making Headlines

--- a/scripts/zones/Windurst_Walls/npcs/Jack_of_Diamonds.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Jack_of_Diamonds.lua
@@ -5,12 +5,12 @@
 -- Working 100%
 -------------------------------------
 require("scripts/globals/settings")
+require("scripts/globals/npc_util")
+-----------------------------------
 
 function onTrade(player, npc, trade)
-    if (trade:getItemCount() == 1 and trade:hasItemQty(536, 1) == true) then
+    if npcUtil.tradeHasExactly(trade, 536) then
         player:startEvent(10002, GIL_RATE*50)
-        player:addGil(GIL_RATE*50)
-        player:tradeComplete()
     end
 end
 
@@ -22,4 +22,8 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
+    if csid == 10002 then
+        player:addGil(GIL_RATE*50)
+        player:tradeComplete()
+    end
 end

--- a/scripts/zones/Windurst_Walls/npcs/Kalupa-Tawalupa.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Kalupa-Tawalupa.lua
@@ -16,25 +16,28 @@ function onTrigger(player, npc)
     local ToBee = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.TO_BEE_OR_NOT_TO_BEE)
     local ToBeeOrNotStatus = player:getCharVar("ToBeeOrNot_var")
 
-    if (ToBeeOrNotStatus == 10) then
-        player:startEvent(66) -- During Too Bee quest before honey given to Zayhi: "are you alright sir"
-    elseif (ToBee == QUEST_ACCEPTED and ToBeeOrNotStatus > 0) then
-            player:startEvent(72) -- During Too Bee quest after some honey was given to Zayhi: "hey did that honey help you just now?"
-    elseif (ToBee == QUEST_COMPLETED and player:needToZone()) then
-        player:startEvent(77) -- After Too Bee quest but before zone: "well I guess a tooth ache is to be expected"
+    -- TO BEE OR NOT TO BEE
+    if ToBeeOrNotStatus == 10 then
+        player:startEvent(66) -- Before honey given to Zayhi: "are you alright sir"
+    elseif
+        ToBee == QUEST_ACCEPTED and
+        ToBeeOrNotStatus > 0
+    then
+        player:startEvent(72) -- After some honey was given to Zayhi: "hey did that honey help you just now?"
+    elseif
+        ToBee == QUEST_COMPLETED
+        and player:needToZone()
+    then
+        player:startEvent(77) -- Before zone: "well I guess a tooth ache is to be expected"
+
+    -- DEFAULT DIALOG
     else
-        player:startEvent(298) -- Normal conversation
+        player:startEvent(298)
     end
 end
 
--- CS/Event ID List for NPC
+-- CS/Event ID List for NPC (MISSING)
 -- *CS 443 - player:startEvent(443) -- Long Star Sybil CS
--- CS 298 - player:startEvent(298) -- Normal conversation
--- *CS 64 - player:startEvent(64) -- Zayhi Coughing
--- CS 66 - player:startEvent(66) -- During Too Bee quest before honey given to Zayhi: "are you alright sir"
--- CS 72 - player:startEvent(72) -- During Too Bee quest after some honey was given to Zayhi: "hey did that honey help you just now?"
--- *CS 75 - player:startEvent(75) -- Combo CS: During Too Bee quest, kicked off from Zayhi
--- CS 77 - player:startEvent(77) -- After Too Bee quest but before zone: "well I guess a tooth ache is to be expected"
 function onEventUpdate(player, csid, option)
 end
 

--- a/scripts/zones/Windurst_Walls/npcs/Komulili.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Komulili.lua
@@ -15,7 +15,7 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-    if (option == 1) then
+    if option == 1 then
         player:setPos(-111.919, -8.75, 92.093, 62, 240) -- {R}
     end
 end

--- a/scripts/zones/Windurst_Walls/npcs/Koru-Moru.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Koru-Moru.lua
@@ -33,8 +33,8 @@ function onTrade(player, npc, trade)
         player:startEvent(211)
     elseif npcUtil.tradeHasExactly(trade, 1127) then -- Trade Kindred seal
         if
-            player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.RIDING_ON_THE_CLOUDS) == QUEST_ACCEPTED
-            and player:getCharVar("ridingOnTheClouds_4") == 4
+            player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.RIDING_ON_THE_CLOUDS) == QUEST_ACCEPTED and
+            player:getCharVar("ridingOnTheClouds_4") == 4
         then
             player:setCharVar("ridingOnTheClouds_4", 0)
             player:tradeComplete()

--- a/scripts/zones/Windurst_Walls/npcs/Koru-Moru.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Koru-Moru.lua
@@ -10,45 +10,51 @@ require("scripts/globals/keyitems")
 require("scripts/globals/settings")
 require("scripts/globals/quests")
 require("scripts/globals/titles")
+require("scripts/globals/npc_util")
 -----------------------------------
 
 function onTrade(player, npc, trade)
     local qStarStruck = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.STAR_STRUCK)
-    local count = trade:getItemCount()
 
-    if (trade:hasItemQty(544, 1) and count == 1 and trade:getGil() == 0) then
-        if (player:getQuestStatus(WINDURST, tpz.quest.id.windurst.MAKING_THE_GRADE) == QUEST_ACCEPTED) then
-            if (player:getCharVar("QuestMakingTheGrade_prog") == 1) then
+    if npcUtil.tradeHasExactly(trade, 544) then
+        if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.MAKING_THE_GRADE) == QUEST_ACCEPTED then
+            if player:getCharVar("QuestMakingTheGrade_prog") == 1 then
                 player:startEvent(285) -- MAKING THE GRADE: Turn in Test Answer & Told to go back to Fuepepe & Chomoro
             else
                 player:startEvent(287) -- MAKING THE GRADE: Have test answers but not talked/given to Fuepepe
             end
         end
-    elseif (trade:hasItemQty(584, 1) and count == 1 and trade:getGil() == 0) then
+    elseif npcUtil.tradeHasExactly(trade, 584) then
         player:startEvent(199)
-    elseif (qStarStruck == QUEST_ACCEPTED and trade:hasItemQty(582, 1) and count == 1 and trade:getGil() == 0) then
+    elseif
+        qStarStruck == QUEST_ACCEPTED and
+        npcUtil.tradeHasExactly(trade, 582)
+    then
         player:startEvent(211)
-    elseif (trade:hasItemQty(1127, 1) and trade:getItemCount() == 1) then -- Trade Kindred seal
-        if (player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.RIDING_ON_THE_CLOUDS) == QUEST_ACCEPTED and player:getCharVar("ridingOnTheClouds_4") == 4) then
+    elseif npcUtil.tradeHasExactly(trade, 1127) then -- Trade Kindred seal
+        if
+            player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.RIDING_ON_THE_CLOUDS) == QUEST_ACCEPTED
+            and player:getCharVar("ridingOnTheClouds_4") == 4
+        then
             player:setCharVar("ridingOnTheClouds_4", 0)
             player:tradeComplete()
-            player:addKeyItem(tpz.ki.SPIRITED_STONE)
-            player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.SPIRITED_STONE)
+            npcUtil.giveKeyItem(player, tpz.ki.SPIRITED_STONE)
         end
-    elseif (trade:hasItemQty(16511, 1) and count == 1 and trade:getGil() == 0) then
-        if (player:getQuestStatus(WINDURST, tpz.quest.id.windurst.BLAST_FROM_THE_PAST) == QUEST_ACCEPTED) then
+    elseif npcUtil.tradeHasExactly(trade, 16511) then
+        if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.BLAST_FROM_THE_PAST) == QUEST_ACCEPTED then
             player:startEvent(224) -- Complete quest!
         else
             player:startEvent(225) -- not the shell
         end
-    elseif (trade:hasItemQty(829, 1) and count == 1 and trade:getGil() == 0) then
-        if (player:getQuestStatus(WINDURST, tpz.quest.id.windurst.THE_ROOT_OF_THE_PROBLEM) == QUEST_ACCEPTED) then
+    elseif npcUtil.tradeHasExactly(trade, 829) then
+        if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.THE_ROOT_OF_THE_PROBLEM) == QUEST_ACCEPTED then
             player:startEvent(349)
-            player:tradeComplete()
-            player:setCharVar("rootProblem", 2)
         end
-    elseif (trade:hasItemQty(17299, 4) and count == 4 and trade:getGil() == 0) then -- trade:getItemCount() is apparently checking total of all 8 slots combined. Could have sworn that wasn't how it worked before.
-        if (player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CLASS_REUNION) == QUEST_ACCEPTED and player:getCharVar("ClassReunionProgress") == 2) then
+    elseif npcUtil.tradeHasExactly(trade, {{17299, 4}}) then
+        if
+            player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CLASS_REUNION) == QUEST_ACCEPTED and
+            player:getCharVar("ClassReunionProgress") == 2
+        then
             player:startEvent(407) -- now Koru remembers something that you need to inquire his former students.
         end
     end
@@ -68,63 +74,127 @@ function onTrigger(player, npc)
     local CarbuncleDebacle = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CARBUNCLE_DEBACLE)
     local CarbuncleDebacleProgress = player:getCharVar("CarbuncleDebacleProgress")
 
-    if (blastFromPast == QUEST_AVAILABLE and qStarStruck == QUEST_COMPLETED and player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CLASS_REUNION) ~= QUEST_ACCEPTED and player:getFameLevel(WINDURST) >= 3 and player:needToZone() == false) then
+    if
+        blastFromPast == QUEST_AVAILABLE and
+        qStarStruck == QUEST_COMPLETED and
+        ClassReunion ~= QUEST_ACCEPTED and
+        player:getFameLevel(WINDURST) >= 3 and
+        player:needToZone() == false
+    then
         player:startEvent(214)
-    elseif (blastFromPast == QUEST_ACCEPTED and blastProg >= 2) then
+    elseif
+        blastFromPast == QUEST_ACCEPTED and
+        blastProg >= 2
+    then
         player:startEvent(215)
-    elseif (blastFromPast == QUEST_ACCEPTED) then
+    elseif blastFromPast == QUEST_ACCEPTED then
         player:startEvent(216)
-    elseif (player:getQuestStatus(WINDURST, tpz.quest.id.windurst.MAKING_THE_GRADE) == QUEST_ACCEPTED) then
+    elseif player:getQuestStatus(WINDURST, tpz.quest.id.windurst.MAKING_THE_GRADE) == QUEST_ACCEPTED then
         local makingGradeProg = player:getCharVar("QuestMakingTheGrade_prog")
-        if (makingGradeProg == 0 and player:hasItem(544)) then
+
+        if
+            makingGradeProg == 0 and
+            player:hasItem(544)
+        then
             player:startEvent(287) -- MAKING THE GRADE: Have test answers but not talked/given to Fuepepe
-        elseif (makingGradeProg == 1) then
+        elseif makingGradeProg == 1 then
             player:startEvent(285) -- MAKING THE GRADE: Turn in Test Answer & Told to go back to Fuepepe & Chomoro
-        elseif (makingGradeProg >= 2) then
+        elseif makingGradeProg >= 2 then
             player:startEvent(286) -- MAKING THE GRADE: Reminder to go away
         else
             player:startEvent(193)
         end
-    elseif (qStarStruck == QUEST_ACCEPTED) then
+    elseif qStarStruck == QUEST_ACCEPTED then
         player:startEvent(198)
-    elseif ((qStarStruck == QUEST_AVAILABLE) and (ClassReunion ~= QUEST_ACCEPTED) and player:hasItem(584)) then
+    elseif
+        qStarStruck == QUEST_AVAILABLE and
+        ClassReunion ~= QUEST_ACCEPTED and
+        player:hasItem(584)
+    then
         player:startEvent(197)
-    ----------------------------------------------------------
-    -- Carbuncle Debacle
-    elseif (CarbuncleDebacle == QUEST_ACCEPTED and CarbuncleDebacleProgress == 1 or CarbuncleDebacleProgress == 2) then
+
+    -- CARBUNCLE DEBACLE
+    elseif
+        CarbuncleDebacle == QUEST_ACCEPTED and
+        (CarbuncleDebacleProgress == 1 or
+        CarbuncleDebacleProgress == 2)
+    then
         player:startEvent(416) -- go and see Ripapa
-    elseif (CarbuncleDebacle == QUEST_ACCEPTED and CarbuncleDebacleProgress == 4) then
+    elseif
+        CarbuncleDebacle == QUEST_ACCEPTED and
+        CarbuncleDebacleProgress == 4
+    then
         player:startEvent(417) -- now go and see Agado-Pugado
-    elseif (CarbuncleDebacle == QUEST_ACCEPTED and CarbuncleDebacleProgress == 5) then
+    elseif
+        CarbuncleDebacle == QUEST_ACCEPTED and
+        CarbuncleDebacleProgress == 5
+    then
         player:startEvent(418) -- Uran-Mafran must be stopped
-    elseif (CarbuncleDebacle == QUEST_ACCEPTED and CarbuncleDebacleProgress == 7) then
+    elseif
+        CarbuncleDebacle == QUEST_ACCEPTED and
+        CarbuncleDebacleProgress == 7
+    then
         player:startEvent(419) -- ending cs
-    elseif (ThePuppetMaster == QUEST_COMPLETED and ClassReunion == QUEST_COMPLETED and CarbuncleDebacle == QUEST_COMPLETED) then
+    elseif
+        ThePuppetMaster == QUEST_COMPLETED and
+        ClassReunion == QUEST_COMPLETED and
+        CarbuncleDebacle == QUEST_COMPLETED
+    then
         player:startEvent(420) -- new cs after all 3 SMN AFs done
-    ----------------------------------------------------------
-    -- Class Reunion
-    elseif (ClassReunion == QUEST_ACCEPTED and ClassReunionProgress == 1) then
+
+    -- CLASS REUNION
+    elseif
+        ClassReunion == QUEST_ACCEPTED and
+        ClassReunionProgress == 1
+    then
         player:startEvent(412, 0, 450, 17299, 0, 0, 0, 0, 0) -- bring Koru 4 astragaloi
-    elseif (ClassReunion == QUEST_ACCEPTED and ClassReunionProgress == 2) then
+    elseif
+        ClassReunion == QUEST_ACCEPTED and
+        ClassReunionProgress == 2
+    then
         player:startEvent(414, 0, 0, 17299, 0, 0, 0, 0, 0) -- reminder to bring 4 astragaloi
-    elseif ((ClassReunion == QUEST_ACCEPTED and ClassReunionProgress >= 3) and (talk1 ~= 1 or talk2 ~= 1)) then
+    elseif
+        ClassReunion == QUEST_ACCEPTED and
+        ClassReunionProgress >= 3 and
+        (talk1 ~= 1 or
+        talk2 ~= 1)
+    then
         player:startEvent(408) -- reminder to visit the students
-    elseif (ClassReunion == QUEST_ACCEPTED and ClassReunionProgress == 6 and talk1 == 1 and talk2 == 1) then
-            player:startEvent(410) -- ending cs
-    elseif (ThePuppetMaster == QUEST_COMPLETED and ClassReunion == QUEST_COMPLETED) then
+    elseif
+        ClassReunion == QUEST_ACCEPTED and
+        ClassReunionProgress == 6 and
+        talk1 == 1 and
+        talk2 == 1
+    then
+        player:startEvent(410) -- ending cs
+    elseif
+        ThePuppetMaster == QUEST_COMPLETED and
+        ClassReunion == QUEST_COMPLETED
+    then
         player:startEvent(411) -- new cs after completed AF2
-    ----------------------------------------------------------
-    -- The Puppet Master
-    elseif (ThePuppetMaster == QUEST_ACCEPTED and ThePuppetMasterProgress == 4) then
+
+    -- THE PUPPET MASTER
+    elseif
+        ThePuppetMaster == QUEST_ACCEPTED and
+        ThePuppetMasterProgress == 4
+    then
         player:startEvent(404) -- ending cs
-    elseif (ThePuppetMaster == QUEST_COMPLETED and ClassReunion ~= 2) then
+    elseif
+        ThePuppetMaster == QUEST_COMPLETED and
+        ClassReunion ~= 2
+    then
         player:startEvent(405) -- new cs after completed AF1
-    ----------------------------------------------------------
-    elseif (rootProblem == QUEST_ACCEPTED and player:getCharVar("rootProblem") == 1) then
+
+    -- THE ROOT OF THE PROBLEM
+    elseif rootProblem == QUEST_ACCEPTED and
+        player:getCharVar("rootProblem") == 1
+    then
         player:startEvent(348, 0, 829)
     else
-        if (qStarStruck == QUEST_COMPLETED) then
+        if qStarStruck == QUEST_COMPLETED then
             player:startEvent(213)
+
+        -- DEFAULT DIALOG
         else
             player:startEvent(193)
         end
@@ -135,83 +205,84 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-
-    if (csid == 285) then  -- Giving him KI from Principle
+    if csid == 285 then  -- Giving him KI from Principle
         player:tradeComplete()
-        player:addKeyItem(tpz.ki.TATTERED_TEST_SHEET)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.TATTERED_TEST_SHEET)
+        npcUtil.giveKeyItem(player, tpz.ki.TATTERED_TEST_SHEET)
         player:setCharVar("QuestMakingTheGrade_prog", 2)
-    elseif (csid == 211) then
+    elseif
+        csid == 211 and
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.STAR_STRUCK, {
+            fame = 20,
+            item = 12502
+        })
+    then
         player:tradeComplete()
-        player:addItem(12502)
-        player:messageSpecial(ID.text.ITEM_OBTAINED, 12502)
-        player:completeQuest(WINDURST, tpz.quest.id.windurst.STAR_STRUCK)
         player:needToZone(true)
-        player:addFame(WINDURST, 20)
-    elseif (csid == 199) then
+    elseif csid == 199 then
         player:tradeComplete()
-        player:messageSpecial(ID.text.GIL_OBTAINED, 50)
-        player:addGil(50)
-    elseif (csid == 197 and option == 0) then
+        player:messageSpecial(ID.text.GIL_OBTAINED, GIL_RATE*50)
+        player:addGil(GIL_RATE*50)
+    elseif
+        csid == 197 and
+        option == 0
+    then
         player:addQuest(WINDURST, tpz.quest.id.windurst.STAR_STRUCK)
-    elseif (csid == 214 and option == 0) then
+    elseif
+        csid == 214 and
+        option == 0
+    then
         player:addQuest(WINDURST, tpz.quest.id.windurst.BLAST_FROM_THE_PAST)
-    elseif (csid == 224) then
+    elseif
+        csid == 224 and
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.BLAST_FROM_THE_PAST, {
+            item = 17030,
+            title = tpz.title.FOSSILIZED_SEA_FARER,
+            var = "BlastFromThePast_Prog"
+        })
+    then
         player:tradeComplete()
-        player:setCharVar("BlastFromThePast_Prog", 0)
-        player:completeQuest(WINDURST, tpz.quest.id.windurst.BLAST_FROM_THE_PAST)
-        player:addItem(17030)
-        player:messageSpecial(ID.text.ITEM_OBTAINED, 17030)
-        player:addTitle(tpz.title.FOSSILIZED_SEA_FARER)
-        player:addFame(WINDURST, 30)
         player:needToZone(true)
-    elseif (csid == 404) then
-        if (player:getFreeSlotsCount() ~= 0) then
-            player:addItem(17532)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, 17532)
-            player:completeQuest(WINDURST, tpz.quest.id.windurst.THE_PUPPET_MASTER)
-            player:setCharVar("ThePuppetMasterProgress", 0)
-            player:needToZone(true)
-            player:addFame(WINDURST, 20)
-        else
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 17532)
-        end
-    elseif (csid == 412) then
+    elseif csid == 349 then
+        player:tradeComplete()
+        player:setCharVar("rootProblem", 2)
+    elseif
+        csid == 404 and
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.THE_PUPPET_MASTER, {
+            item = 17532,
+            fame = 20,
+            var = "ThePuppetMasterProgress"
+        })
+    then
+        player:needToZone(true)
+    elseif csid == 412 then
         player:delKeyItem(tpz.ki.CARBUNCLES_TEAR)
         player:setCharVar("ClassReunionProgress", 2)
-    elseif (csid == 407) then
+    elseif csid == 407 then
         player:tradeComplete()
         player:setCharVar("ClassReunionProgress", 3)
-    elseif (csid == 410) then
-        if (player:getFreeSlotsCount() ~= 0) then
-            player:addItem(14228)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, 14228)
-            player:completeQuest(WINDURST, tpz.quest.id.windurst.CLASS_REUNION)
-            player:setCharVar("ClassReunionProgress", 0)
-            player:setCharVar("ClassReunion_TalkedToFurakku", 0)
-            player:setCharVar("ClassReunion_TalkedToFupepe", 0)
-            player:needToZone(true)
-            player:addFame(WINDURST, 40)
-        else
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 14228)
-        end
-    elseif (csid == 416) then
+    elseif
+        csid == 410 and
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.CLASS_REUNION, {
+            item = 14228,
+            fame = 40,
+            var = {"ClassReunionProgress", "ClassReunion_TalkedToFurakku", "ClassReunion_TalkedToFupepe"}
+        })
+    then
+        player:needToZone(true)
+    elseif csid == 416 then
         player:setCharVar("CarbuncleDebacleProgress", 2)
-    elseif (csid == 417) then
+    elseif csid == 417 then
         player:setCharVar("CarbuncleDebacleProgress", 5)
-        player:addKeyItem(tpz.ki.DAZEBREAKER_CHARM)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.DAZEBREAKER_CHARM)
-    elseif (csid == 419) then
-        if (player:getFreeSlotsCount() ~= 0) then
-            player:addItem(12520) -- Evoker's Horn
-            player:messageSpecial(ID.text.ITEM_OBTAINED, 12520)
-            player:addTitle(tpz.title.PARAGON_OF_SUMMONER_EXCELLENCE)
-            player:completeQuest(WINDURST, tpz.quest.id.windurst.CARBUNCLE_DEBACLE)
-            player:addFame(WINDURST, 60)
-            player:setCharVar("CarbuncleDebacleProgress", 0)
-            player:needToZone(true)
-        else
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 12520)
-        end
+        npcUtil.giveKeyItem(player, tpz.ki.DAZEBREAKER_CHARM)
+    elseif
+        csid == 419 and
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.CARBUNCLE_DEBACLE, {
+            item = 12520,
+            fame = 60,
+            title = tpz.title.PARAGON_OF_SUMMONER_EXCELLENCE,
+            var = "CarbuncleDebacleProgress"
+        })
+    then
+        player:needToZone(true)
     end
 end

--- a/scripts/zones/Windurst_Walls/npcs/Luuh_Koplehn.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Luuh_Koplehn.lua
@@ -12,9 +12,7 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-    local qStarStruck = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.STAR_STRUCK)
-
-    if (qStarStruck == QUEST_ACCEPTED) then
+    if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.STAR_STRUCK) == QUEST_ACCEPTED then
         player:startEvent(200)
     else
         player:startEvent(322)

--- a/scripts/zones/Windurst_Walls/npcs/Moan-Maon.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Moan-Maon.lua
@@ -11,10 +11,10 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-
-    local WildcatWindurst = player:getCharVar("WildcatWindurst")
-
-    if (player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and player:getMaskBit(WildcatWindurst, 7) == false) then
+    if
+        player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
+        player:getMaskBit(player:getCharVar("WildcatWindurst"), 7) == false
+    then
         player:startEvent(497)
     else
         player:startEvent(307)
@@ -26,9 +26,7 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-
-    if (csid == 497) then
+    if csid == 497 then
         player:setMaskBit(player:getCharVar("WildcatWindurst"), "WildcatWindurst", 7, true)
     end
-
 end

--- a/scripts/zones/Windurst_Walls/npcs/Naih_Arihmepp.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Naih_Arihmepp.lua
@@ -11,10 +11,10 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-
-    local WildcatWindurst = player:getCharVar("WildcatWindurst")
-
-    if (player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and player:getMaskBit(WildcatWindurst, 9) == false) then
+    if
+        player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
+        player:getMaskBit(player:getCharVar("WildcatWindurst"), 9) == false
+    then
         player:startEvent(500)
     else
         player:startEvent(326)
@@ -25,9 +25,7 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-
-    if (csid == 500) then
+    if csid == 500 then
         player:setMaskBit(player:getCharVar("WildcatWindurst"), "WildcatWindurst", 9, true)
     end
-
 end

--- a/scripts/zones/Windurst_Walls/npcs/Ojha_Rhawash.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Ojha_Rhawash.lua
@@ -19,7 +19,8 @@ local flowerChild = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.FLOWER
         else
             player:startEvent(10000, 0, 239, 2)
         end
-    elseif npcUtil.tradeHasExactly(trade, 957) or   -- Amaryllis
+    elseif
+        npcUtil.tradeHasExactly(trade, 957) or      -- Amaryllis
         npcUtil.tradeHasExactly(trade, 2554) or     -- Asphodel
         npcUtil.tradeHasExactly(trade, 948) or      -- Carnation
         npcUtil.tradeHasExactly(trade, 1120) or     -- Casablanca
@@ -63,9 +64,7 @@ function onEventFinish(player, csid, option)
     if csid == 10000 then
         player:tradeComplete()
         if option == 3002 then
-            npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.FLOWER_CHILD, {
-                fame = 120,
-            })
+            npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.FLOWER_CHILD, {fame = 120})
             player:moghouseFlag(4)
             player:messageSpecial(ID.text.MOGHOUSE_EXIT)
         elseif option == 1 then

--- a/scripts/zones/Windurst_Walls/npcs/Ojha_Rhawash.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Ojha_Rhawash.lua
@@ -3,58 +3,46 @@
 --  NPC: Ojha Rhawash
 -- Starts and Finishes Quest: Flower Child
 -- !pos -209 0 -134 239
-
 -----------------------------------
 local ID = require("scripts/zones/Windurst_Walls/IDs")
 require("scripts/globals/settings")
 require("scripts/globals/quests")
-
+require("scripts/globals/npc_util")
+-----------------------------------
 
 function onTrade(player, npc, trade)
+local flowerChild = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.FLOWER_CHILD)
 
-count = trade:getItemCount()
-gil = trade:getGil()
-
-itemQuality = 0
-    if (trade:getItemCount() == 1 and trade:getGil() == 0) then
-        if (trade:hasItemQty(956, 1)) then        -- Lilac
-            itemQuality = 2
-        elseif (trade:hasItemQty(957, 1)  or        -- Amaryllis
-                trade:hasItemQty(2554, 1) or        -- Asphodel
-                trade:hasItemQty(948, 1)  or        -- Carnation
-                trade:hasItemQty(1120, 1) or        -- Casablanca
-                trade:hasItemQty(1413, 1) or        -- Cattleya
-                trade:hasItemQty(636, 1)  or        -- Chamomile
-                trade:hasItemQty(959, 1)  or        -- Dahlia
-                trade:hasItemQty(835, 1)  or        -- Flax Flower
-                trade:hasItemQty(2507, 1) or        -- Lycopodium Flower
-                trade:hasItemQty(958, 1)  or        -- Marguerite
-                trade:hasItemQty(1412, 1) or        -- Olive Flower
-                trade:hasItemQty(938, 1)  or        -- Papaka Grass
-                trade:hasItemQty(1411, 1) or        -- Phalaenopsis
-                trade:hasItemQty(949, 1)  or        -- Rain Lily
-                trade:hasItemQty(941, 1)  or        -- Red Rose
-                trade:hasItemQty(1725, 1) or        -- Snow Lily
-                trade:hasItemQty(1410, 1) or        -- Sweet William
-                trade:hasItemQty(950, 1)  or        -- Tahrongi Cactus
-                trade:hasItemQty(2960, 1) or        -- Water Lily
-                trade:hasItemQty(951, 1)) then    -- Wijnruit
-            itemQuality = 1
-        end
-    end
-
-    FlowerChild = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.FLOWER_CHILD)
-
-    if (itemQuality == 2) then
-        if (FlowerChild == QUEST_COMPLETED) then
+    if npcUtil.tradeHasExactly(trade, 956) then -- Lilac
+        if flowerChild == QUEST_COMPLETED then
             player:startEvent(10000, 0, 239, 4)
         else
             player:startEvent(10000, 0, 239, 2)
         end
-    elseif (itemQuality == 1) then
-        if (FlowerChild == QUEST_COMPLETED) then
+    elseif npcUtil.tradeHasExactly(trade, 957) or   -- Amaryllis
+        npcUtil.tradeHasExactly(trade, 2554) or     -- Asphodel
+        npcUtil.tradeHasExactly(trade, 948) or      -- Carnation
+        npcUtil.tradeHasExactly(trade, 1120) or     -- Casablanca
+        npcUtil.tradeHasExactly(trade, 1413) or     -- Cattleya
+        npcUtil.tradeHasExactly(trade, 636) or      -- Chamomile
+        npcUtil.tradeHasExactly(trade, 959) or      -- Dahlia
+        npcUtil.tradeHasExactly(trade, 835) or      -- Flax Flower
+        npcUtil.tradeHasExactly(trade, 2507) or     -- Lycopodium Flower
+        npcUtil.tradeHasExactly(trade, 958) or      -- Marguerite
+        npcUtil.tradeHasExactly(trade, 1412) or     -- Olive Flower
+        npcUtil.tradeHasExactly(trade, 938) or      -- Papaka Grass
+        npcUtil.tradeHasExactly(trade, 1411) or     -- Phalaenopsis
+        npcUtil.tradeHasExactly(trade, 949) or      -- Rain Lily
+        npcUtil.tradeHasExactly(trade, 941) or      -- Red Rose
+        npcUtil.tradeHasExactly(trade, 1725) or     -- Snow Lily
+        npcUtil.tradeHasExactly(trade, 1410) or     -- Sweet William
+        npcUtil.tradeHasExactly(trade, 950)  or     -- Tahrongi Cactus
+        npcUtil.tradeHasExactly(trade, 2960) or     -- Water Lily
+        npcUtil.tradeHasExactly(trade, 951)         -- Wijnruit
+    then
+        if flowerChild == QUEST_COMPLETED then
             player:startEvent(10000, 0, 239, 5)
-        elseif (FlowerChild == QUEST_ACCEPTED) then
+        elseif flowerChild == QUEST_ACCEPTED then
             player:startEvent(10000, 0, 239, 3)
         else
             player:startEvent(10000, 0, 239, 1)
@@ -62,7 +50,6 @@ itemQuality = 0
     else
         player:startEvent(10000, 0, 239, 0)
     end
-
 end
 
 function onTrigger(player, npc)
@@ -73,15 +60,16 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-
-    if (csid == 10000 and option == 3002) then
+    if csid == 10000 then
         player:tradeComplete()
-        player:completeQuest(WINDURST, tpz.quest.id.windurst.FLOWER_CHILD)
-        player:addFame(WINDURST, 120)
-        player:moghouseFlag(4)
-        player:messageSpecial(ID.text.MOGHOUSE_EXIT)
-    elseif (csid == 10000 and option == 1) then
-        player:tradeComplete()
-        player:addQuest(WINDURST, tpz.quest.id.windurst.FLOWER_CHILD)
+        if option == 3002 then
+            npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.FLOWER_CHILD, {
+                fame = 120,
+            })
+            player:moghouseFlag(4)
+            player:messageSpecial(ID.text.MOGHOUSE_EXIT)
+        elseif option == 1 then
+            player:addQuest(WINDURST, tpz.quest.id.windurst.FLOWER_CHILD)
+        end
     end
 end

--- a/scripts/zones/Windurst_Walls/npcs/Raamimi.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Raamimi.lua
@@ -17,46 +17,46 @@ function onTrigger(player, npc)
     local ToBee = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.TO_BEE_OR_NOT_TO_BEE)
     local ToBeeOrNotStatus = player:getCharVar("ToBeeOrNot_var")
 
-    if (ToBeeOrNotStatus == 10 and ToBee == QUEST_AVAILABLE) then
+    -- TO BEE OR NOT TO BEE
+    if
+        ToBeeOrNotStatus == 10 and
+        ToBee == QUEST_AVAILABLE
+    then
         player:startEvent(67) -- Quest Started - He gives you honey
-    elseif (ToBee == QUEST_ACCEPTED) then
+    elseif ToBee == QUEST_ACCEPTED then
         player:startEvent(68) -- After honey is given to player...... but before 5th hondy is given to Zayhi
-    elseif (ToBee == QUEST_COMPLETED and ToBeeOrNotStatus == 5) then
+    elseif
+        ToBee == QUEST_COMPLETED and
+        ToBeeOrNotStatus == 5
+    then
         player:startEvent(80) -- Quest Finish - Gives Mulsum
-    elseif (ToBee == QUEST_COMPLETED and ToBeeOrNotStatus == 0 and player:needToZone()) then
+    elseif
+        ToBee == QUEST_COMPLETED and
+        ToBeeOrNotStatus == 0 and
+        player:needToZone()
+    then
         player:startEvent(79) -- After Quest but before zoning "it's certainly gotten quiet around here..."
+
+    -- DEFAULT DIALOG
     else
         player:startEvent(296)
     end
 end
 
--- Event ID List for NPC
---  player:startEvent(296) -- Standard Conversation
---  player:startEvent(67) -- Quest is kicked off already, he gives you honey
--- player:startEvent(68) -- After honey is given to player...... before given to Zayhi????
---  player:startEvent(80) -- Quest Finish - Gives Mulsum
---  player:startEvent(79) -- After Quest but before zoning: "it's certainly gotten quiet around here..."
-
 function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-    if (csid == 67) then
-        if (player:getFreeSlotsCount() == 0) then
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 4370) -- Cannot give Honey because player Inventory is full
-        else
-            player:addQuest(WINDURST, tpz.quest.id.windurst.TO_BEE_OR_NOT_TO_BEE)
-            player:addItem(4370)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, 4370) -- Gives player Honey x1
-        end
-    elseif (csid == 80) then -- After Honey#5: ToBee quest Finish (tooth hurts from all the Honey)
-        if (player:getFreeSlotsCount() == 0) then
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 4156) -- Cannot give Mulsum because player Inventory is full
-        else
-            player:setCharVar("ToBeeOrNot_var", 0)
-            player:addItem(4156, 3) -- Mulsum x3
-            player:messageSpecial(ID.text.ITEMS_OBTAINED, 4156, 3)
-            player:needToZone(true)
-        end
+    if
+        csid == 67 and
+        npcUtil.giveItem(player, 4370)
+    then
+        player:addQuest(WINDURST, tpz.quest.id.windurst.TO_BEE_OR_NOT_TO_BEE)
+    elseif
+        csid == 80 and
+        npcUtil.giveItem(player, {{4156, 3}})
+    then -- After Honey#5: ToBee quest Finish
+        player:setCharVar("ToBeeOrNot_var", 0)
+        player:needToZone(true)
     end
 end

--- a/scripts/zones/Windurst_Walls/npcs/Ran.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Ran.lua
@@ -10,7 +10,7 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-    if (math.random() >= .5) then
+    if math.random(1, 2) == 1 then
         player:startEvent(272)
     else
         player:startEvent(273)

--- a/scripts/zones/Windurst_Walls/npcs/Rutango-Botango.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Rutango-Botango.lua
@@ -16,25 +16,28 @@ function onTrigger(player, npc)
     local ToBee = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.TO_BEE_OR_NOT_TO_BEE)
     local ToBeeOrNotStatus = player:getCharVar("ToBeeOrNot_var")
 
-    if (ToBeeOrNotStatus == 10) then
+    -- TO BEE OR NOT TO BEE
+    if ToBeeOrNotStatus == 10 then
         player:startEvent(65) -- During Too Bee quest before honey given to Zayhi:  "Oh Crumb...lost his voice"
-    elseif (ToBee == QUEST_ACCEPTED and ToBeeOrNotStatus > 0) then
+    elseif
+        ToBee == QUEST_ACCEPTED and
+        ToBeeOrNotStatus > 0
+    then
         player:startEvent(71) -- During Too Bee quest after some honey was given to Zayhi: "lap up more honey"
-    elseif (ToBee == QUEST_COMPLETED and player:needToZone()) then
+    elseif
+        ToBee == QUEST_COMPLETED and
+        player:needToZone()
+    then
         player:startEvent(76) -- After Too Bee quest but before zone: "master let me speak for you"
     else
-        player:startEvent(297) -- Standard Conversation
+
+    -- DEFAULT DIALOG
+        player:startEvent(297)
     end
 end
 
 -- CS/Event ID List for NPC
 -- *Rutango-Botango    CS 443 - player:startEvent(443) -- Long Star Sybil CS
--- Rutango-Botango    CS 297 - player:startEvent(297) -- Standard Conversation
--- *Rutango-Botango    CS 64 - player:startEvent(64) -- Zayhi Coughing
--- Rutango-Botango    CS 65 - player:startEvent(65) -- During Too Bee quest before honey given to Zayhi:  "Oh Crumb...lost his voice"
--- Rutango-Botango    CS 71 - player:startEvent(71) -- During Too Bee quest after some honey was given to Zayhi: "lap up more honey"
--- *Rutango-Botango    CS 75 - player:startEvent(75) -- Combo CS: During Too Bee quest, kicked off from Zayhi
--- Rutango-Botango    CS 76 - player:startEvent(76) -- After Too Bee quest but before zone: "master let me speak for you"
 function onEventUpdate(player, csid, option)
 end
 

--- a/scripts/zones/Windurst_Walls/npcs/Scavnix.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Scavnix.lua
@@ -13,7 +13,7 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-    if (player:sendGuild(60418, 11, 22, 6)) then
+    if player:sendGuild(60418, 11, 22, 6) then
         player:showText(npc, ID.text.SCAVNIX_SHOP_DIALOG)
     end
 end

--- a/scripts/zones/Windurst_Walls/npcs/Shantotto.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Shantotto.lua
@@ -2,13 +2,15 @@
 -- Area: Windurst Walls (239)
 --  NPC: Shantotto
 -- !pos 122 -2 112 239
--- CSID's missing in autoEventID please check the old forums under resources for all of shantotto's csid's. I found them all manually.
+-- CSID's missing in autoEventID please check the old forums under resources for all of shantotto's csid's.
+-- I found them all manually.
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/quests")
 require("scripts/globals/settings")
 require("scripts/globals/titles")
 require("scripts/globals/wsquest")
+require("scripts/globals/npc_util")
 local ID = require("scripts/zones/Windurst_Walls/IDs")
 -----------------------------------
 
@@ -16,7 +18,6 @@ local wsQuest = tpz.wsquest.retribution
 
 function onTrade(player, npc, trade)
     local wsQuestEvent = tpz.wsquest.getTradeEvent(wsQuest, player, trade)
-    local count = trade:getItemCount()
 
     if wsQuestEvent ~= nil then
         if wsQuestEvent == 448 then
@@ -25,17 +26,17 @@ function onTrade(player, npc, trade)
             player:startEvent(wsQuestEvent)
         end
 
-    -- Curses Foiled Again!
-    elseif (player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CURSES_FOILED_AGAIN_1) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(928, 1) and trade:hasItemQty(880, 2) and count == 3) then
+    -- CURSES FOILED AGAIN!
+    elseif player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CURSES_FOILED_AGAIN_1) == QUEST_ACCEPTED then
+        if npcUtil.tradeHasExactly(trade, {{928, 1}, {880, 2}}) then
             player:startEvent(173, 0, 0, 0, 0, 0, 0, 928, 880) -- Correct items given, complete quest.
         else
             player:startEvent(172, 0, 0, 0, 0, 0, 0, 928, 880) -- Incorrect or not enough items
         end
 
-    -- Curses, Foiled ... Again!?
-    elseif (player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CURSES_FOILED_AGAIN_2) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(17316, 2) and trade:hasItemQty(940, 1) and trade:hasItemQty(552, 1) and count == 4) then
+    -- CURSES, FOILED ... AGAIN!?
+    elseif player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CURSES_FOILED_AGAIN_2) == QUEST_ACCEPTED then
+        if npcUtil.tradeHasExactly(trade, {{17316, 2}, {940, 1}, {552, 1}}) then
             player:startEvent(183) -- Correct items given, complete quest.
         else
             player:startEvent(181, 0, 0, 0, 0, 0, 0, 17316, 940) -- Incorrect or not enough items
@@ -54,87 +55,124 @@ function onTrigger(player, npc)
 
     if wsQuestEvent ~= nil then
         player:startEvent(wsQuestEvent)
-    elseif (player:getCurrentMission(WINDURST) == tpz.mission.id.windurst.THE_JESTER_WHO_D_BE_KING and player:getCharVar("MissionStatus") == 7) then
+    elseif
+        player:getCurrentMission(WINDURST) == tpz.mission.id.windurst.THE_JESTER_WHO_D_BE_KING and
+        player:getCharVar("MissionStatus") == 7
+    then
         player:startEvent(397, 0, 0, 0, 282)
-    elseif (player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and player:getMaskBit(WildcatWindurst, 6) == false) then
+    elseif
+        player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
+        player:getMaskBit(WildcatWindurst, 6) == false
+    then
         player:startEvent(498)
-    elseif (player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CLASS_REUNION) == QUEST_ACCEPTED and player:getCharVar("ClassReunionProgress") == 3) then
+    elseif
+        player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CLASS_REUNION) == QUEST_ACCEPTED and
+        player:getCharVar("ClassReunionProgress") == 3
+    then
         player:startEvent(409) -- she mentions that Sunny-Pabonny left for San d'Oria
 
     -- AMK
     elseif player:getCurrentMission(AMK) == tpz.mission.id.amk.CURSES_A_HORRIFICALLY_HARROWING_HEX then
         player:startEvent(506)
 
-    -------------------------------------------------------
-    -- Curses Foiled Again!
-    elseif (foiledAgain == QUEST_AVAILABLE) then
+    -- CURSES, FOILED...AGAIN!?
+    elseif foiledAgain == QUEST_AVAILABLE then
         player:startEvent(171, 0, 0, 0, 0, 0, 0, 928, 880)
-    elseif (foiledAgain == QUEST_ACCEPTED) then
+    elseif foiledAgain == QUEST_ACCEPTED then
         player:startEvent(172, 0, 0, 0, 0, 0, 0, 928, 880)
-    elseif (foiledAgain == QUEST_COMPLETED and CFA2 == QUEST_AVAILABLE and CFAtimer == 0) then
+    elseif
+        foiledAgain == QUEST_COMPLETED and
+        CFA2 == QUEST_AVAILABLE and
+        CFAtimer == 0
+    then
         local cDay = VanadielDayOfTheYear()
         local cYear = VanadielYear()
         local dFinished = player:getCharVar("CursesFoiledAgainDay")
         local yFinished = player:getCharVar("CursesFoiledAgainYear")
 
-        -- player:PrintToPlayer("Vana Day and year:  "..cDay..", "..cYear)
-        -- player:PrintToPlayer("Database Day and year:  "..dFinished..", "..yFinished)
-
-        if (cDay == dFinished and cYear == yFinished) then
+        if
+            cDay == dFinished and
+            cYear == yFinished
+        then
             player:startEvent(174)
-        elseif (cDay == dFinished + 1 and cYear == yFinished) then
+        elseif
+            cDay == dFinished + 1 and
+            cYear == yFinished
+        then
             player:startEvent(178)
-        elseif ((cDay >= dFinished + 2 and cYear == yFinished) or (cYear > yFinished)) then
+        elseif
+            (cDay >= dFinished + 2 and
+            cYear == yFinished) or
+            cYear > yFinished
+        then
             player:startEvent(179)
         end
 
-
-    -- Curses, Foiled...Again!?
-    elseif (foiledAgain == QUEST_COMPLETED and CFA2 == QUEST_AVAILABLE and player:getFameLevel(WINDURST) >= 2 and player:getMainLvl() >= 5 and CFAtimer == 1) then
+    -- CURSES, FOILED...AGAIN!?
+    elseif
+        foiledAgain == QUEST_COMPLETED and
+        CFA2 == QUEST_AVAILABLE and
+        player:getFameLevel(WINDURST) >= 2 and
+        player:getMainLvl() >= 5 and
+        CFAtimer == 1
+    then
         player:startEvent(180, 0, 0, 0, 0, 928, 880, 17316, 940)        -- Quest Start
-    elseif (CFA2 == QUEST_ACCEPTED) then
+    elseif
+        CFA2 == QUEST_ACCEPTED
+    then
         player:startEvent(181, 0, 0, 0, 0, 0, 0, 17316, 940)  -- Reminder dialog
 
-
-    -- Curses, Foiled A-Golem!?
-    elseif (CFA2 == QUEST_COMPLETED and FoiledAGolem == QUEST_AVAILABLE and player:getFameLevel(WINDURST) >= 4 and player:getMainLvl() >= 10) then
+    -- CURSES, FOILED A-GOLEM!?
+    elseif
+        CFA2 == QUEST_COMPLETED and
+        FoiledAGolem == QUEST_AVAILABLE and
+        player:getFameLevel(WINDURST) >= 4 and
+        player:getMainLvl() >= 10
+    then
         player:startEvent(340)  --quest start
-    elseif (golemdelivery == 1) then
+    elseif golemdelivery == 1 then
         player:startEvent(342)  -- finish
-    elseif (FoiledAGolem == QUEST_ACCEPTED) then
+    elseif FoiledAGolem == QUEST_ACCEPTED then
         player:startEvent(341)  -- reminder dialog
 
-
-    -- Standard dialog
-    elseif (FoiledAGolem == QUEST_COMPLETED) then
+    -- DEFAULT DIALOG (after FOILED A-GOLEM!?)
+    elseif FoiledAGolem == QUEST_COMPLETED then
         player:startEvent(343)  -- new standard dialog after Curses, Foiled A-Golem!?
 
-    elseif (CFA2 == QUEST_COMPLETED) then
+    -- DEFAULT DIALOG (after CURSES, FOILED AGAIN!?)
+    elseif CFA2 == QUEST_COMPLETED then
         player:startEvent(184)     -- New standard dialog after CFA2
-    elseif (player:hasCompletedMission(WINDURST, tpz.mission.id.windurst.THE_JESTER_WHO_D_BE_KING) and player:getCharVar("ShantottoCS") == 1) then
+    elseif
+        player:hasCompletedMission(WINDURST, tpz.mission.id.windurst.THE_JESTER_WHO_D_BE_KING) and
+        player:getCharVar("ShantottoCS") == 1
+    then
         player:startEvent(399, 0, 0, 282)
+
+    -- DEFAULT DIALOG
     else
         player:startEvent(164)
     end
 end
 
 function onEventFinish(player, csid, option)
-    if (csid == 173) then
-        if (player:getFreeSlotsCount() == 0) then
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 17081)
-        else
-            player:tradeComplete()
-            player:setCharVar("CursesFoiledAgainDay", VanadielDayOfTheYear())
-            player:setCharVar("CursesFoiledAgainYear", VanadielYear())
-            player:addFame(WINDURST, 80)
-            player:addItem(17081)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, 17081)
-            player:completeQuest(WINDURST, tpz.quest.id.windurst.CURSES_FOILED_AGAIN_1)
-        end
-    elseif (csid == 171 and option ~= 1) then
+    if
+        csid == 173 and
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.CURSES_FOILED_AGAIN_1, {
+            item = 17081,
+            fame = 80,
+            var = "ThePuppetMasterProgress"
+        })
+    then
+        player:tradeComplete()
+        player:setCharVar("CursesFoiledAgainDay", VanadielDayOfTheYear())
+        player:setCharVar("CursesFoiledAgainYear", VanadielYear())
+    elseif
+        csid == 171 and
+        option ~= 1
+    then
         player:addQuest(WINDURST, tpz.quest.id.windurst.CURSES_FOILED_AGAIN_1)
 
-    elseif (csid == 179) then
+    elseif csid == 179 then
         player:setCharVar("CursesFoiledAgainDayFinished", 0)
         player:setCharVar("CursesFoiledAgainYearFinished", 0)
         player:setCharVar("CursesFoiledAgainDay", 0)
@@ -142,51 +180,47 @@ function onEventFinish(player, csid, option)
         player:setCharVar("CursesFoiledAgain", 1) -- Used to acknowledge that the two days have passed, Use this to initiate next quest
         player:needToZone(true)
 
-    elseif (csid == 180 and option == 3) then
+    elseif
+        csid == 180 and
+        option == 3
+    then
         player:setCharVar("CursesFoiledAgain", 0)
         player:addQuest(WINDURST, tpz.quest.id.windurst.CURSES_FOILED_AGAIN_2)
         player:setTitle(tpz.title.TARUTARU_MURDER_SUSPECT)
 
-    elseif (csid == 183) then
-        if (player:getFreeSlotsCount() == 0) then
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 17116)
-        else
-            player:tradeComplete()
-            player:setTitle(tpz.title.HEXER_VEXER)
-            player:addItem(17116)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, 17116)
-            player:completeQuest(WINDURST, tpz.quest.id.windurst.CURSES_FOILED_AGAIN_2)
-            player:needToZone(true)
-            player:addFame(WINDURST, 90)
-        end
+    elseif
+        csid == 183 and
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.CURSES_FOILED_AGAIN_2, {
+            item = 17116,
+            fame = 90,
+            title = tpz.title.HEXER_VEXER
+        })
+    then
+        player:tradeComplete()
+        player:needToZone(true)
 
-    elseif (csid == 340) then
-        if (option == 1) then
+    elseif csid == 340 then
+        if option == 1 then
             player:addQuest(WINDURST, tpz.quest.id.windurst.CURSES_FOILED_A_GOLEM)
         else
             player:setTitle(tpz.title.TOTAL_LOSER)
         end
 
-    elseif (csid == 342) then
-        if (player:getFreeSlotsCount() == 0) then
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 4870)
-        else
-            player:completeQuest(WINDURST, tpz.quest.id.windurst.CURSES_FOILED_A_GOLEM)
-            player:setCharVar("foiledagolemdeliverycomplete", 0)
-            player:addItem(4870)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, 4870)
-            player:setTitle(tpz.title.DOCTOR_SHANTOTTOS_FLAVOR_OF_THE_MONTH)
-            player:addFame(WINDURST, 120)
-        end
-    elseif (csid == 409) then
+    elseif csid == 342 then
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.CURSES_FOILED_A_GOLEM, {
+            item = 4870,
+            fame = 120,
+            title = tpz.title.DOCTOR_SHANTOTTOS_FLAVOR_OF_THE_MONTH,
+            var = "foiledagolemdeliverycomplete"
+        })
+    elseif csid == 409 then
         player:setCharVar("ClassReunionProgress", 4)
-    elseif (csid == 498) then
+    elseif csid == 498 then
         player:setMaskBit(player:getCharVar("WildcatWindurst"), "WildcatWindurst", 6, true)
-    elseif (csid == 397) then
-        player:addKeyItem(tpz.ki.GLOVE_OF_PERPETUAL_TWILIGHT)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.GLOVE_OF_PERPETUAL_TWILIGHT)
+    elseif csid == 397 then
+        npcutil.giveKeyItem(player, tpz.ki.GLOVE_OF_PERPETUAL_TWILIGHT)
         player:setCharVar("MissionStatus", 8)
-    elseif (csid == 399) then
+    elseif csid == 399 then
         player:setCharVar("ShantottoCS", 0)
 
     elseif csid == 506 then

--- a/scripts/zones/Windurst_Walls/npcs/Yoran-Oran.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Yoran-Oran.lua
@@ -14,15 +14,15 @@ require("scripts/globals/npc_util")
 
 function onTrade(player, npc, trade)
     if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.MANDRAGORA_MAD) ~= QUEST_AVAILABLE then
-        if npcUtil.tradeHas(trade, 17344, true) then
+        if npcUtil.tradeHasExactly(trade, 17344) then
             player:startEvent(251, GIL_RATE*200)
-        elseif npcUtil.tradeHas(trade, 934, true) then
+        elseif npcUtil.tradeHasExactly(trade, 934) then
             player:startEvent(252, GIL_RATE*250)
-        elseif npcUtil.tradeHas(trade, 1154, true) then
+        elseif npcUtil.tradeHasExactly(trade, 1154) then
             player:startEvent(253, GIL_RATE*1200)
-        elseif npcUtil.tradeHas(trade, 4369, true) then
+        elseif npcUtil.tradeHasExactly(trade, 4369) then
             player:startEvent(254, GIL_RATE*120)
-        elseif npcUtil.tradeHas(trade, 1150, true) then
+        elseif npcUtil.tradeHasExactly(trade, 1150) then
             player:startEvent(255, GIL_RATE*5500)
         else
             player:startEvent(250)
@@ -38,29 +38,39 @@ function onTrigger(player, npc)
     local MissionStatus = player:getCharVar("MissionStatus")
 
     --optional windy 9-1
-    if player:getCurrentMission(WINDURST) == tpz.mission.id.windurst.DOLL_OF_THE_DEAD and MissionStatus == 4 then
+    if
+        player:getCurrentMission(WINDURST) == tpz.mission.id.windurst.DOLL_OF_THE_DEAD and
+        MissionStatus == 4
+    then
         player:startEvent(439, 0, 17868, 1181)
-    elseif player:getCurrentMission(COP) == tpz.mission.id.cop.THE_ROAD_FORKS and MEMORIES_OF_A_MAIDEN == 3 then
-        player:startEvent(469)
-    elseif player:getCurrentMission(COP) == tpz.mission.id.cop.THE_ROAD_FORKS and MEMORIES_OF_A_MAIDEN == 6 then
-        player:startEvent(470, 0, 587, 581, 586)
-    elseif player:getCurrentMission(COP) == tpz.mission.id.cop.THE_ROAD_FORKS and player:hasKeyItem(tpz.ki.MIMEO_FEATHER) then
-        player:startEvent(471)
-    elseif player:getCurrentMission(COP) == tpz.mission.id.cop.THE_ROAD_FORKS and MEMORIES_OF_A_MAIDEN == 11 then
-        player:startEvent(472)
-    elseif player:getCurrentMission(COP) == tpz.mission.id.cop.THREE_PATHS and LouverancePath == 3 then
-        player:startEvent(481)
-    elseif player:getCurrentMission(COP) == tpz.mission.id.cop.THREE_PATHS and player:getCharVar("COP_Ulmia_s_Path") == 4 then
-        player:startEvent(473)
+    elseif player:getCurrentMission(COP) == tpz.mission.id.cop.THE_ROAD_FORKS then
+        if MEMORIES_OF_A_MAIDEN == 3 then
+            player:startEvent(469)
+        elseif MEMORIES_OF_A_MAIDEN == 6 then
+            player:startEvent(470, 0, 587, 581, 586)
+        elseif player:hasKeyItem(tpz.ki.MIMEO_FEATHER) then
+            player:startEvent(471)
+        elseif MEMORIES_OF_A_MAIDEN == 11 then
+            player:startEvent(472)
+        end
+    elseif player:getCurrentMission(COP) == tpz.mission.id.cop.THREE_PATHS then
+        if LouverancePath == 3 then
+            player:startEvent(481)
+        elseif player:getCharVar("COP_Ulmia_s_Path") == 4 then
+            player:startEvent(473)
+        end
     elseif blastFromPast == QUEST_ACCEPTED then
         local blastPastProg = player:getCharVar("BlastFromThePast_Prog")
-        if (blastPastProg == 1) then
+
+        if blastPastProg == 1 then
             player:startEvent(221)
-            player:setCharVar("BlastFromThePast_Prog", 2)
-        elseif (blastPastProg == 2) then
+        elseif blastPastProg == 2 then
             player:startEvent(222)
         end
-    elseif blastFromPast == QUEST_COMPLETED and player:needToZone() == true then
+    elseif
+        blastFromPast == QUEST_COMPLETED and
+        player:needToZone() == true
+    then
         player:startEvent(223)
     elseif MandragoraMad == QUEST_AVAILABLE then
         player:startEvent(249)
@@ -75,7 +85,9 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-    if csid == 249 then
+    if csid == 221 then
+        player:setCharVar("BlastFromThePast_Prog", 2)
+    elseif csid == 249 then
         player:addQuest(WINDURST, tpz.quest.id.windurst.MANDRAGORA_MAD)
     elseif csid == 469 then
         player:setCharVar("MEMORIES_OF_A_MAIDEN_Status", 4)
@@ -96,25 +108,34 @@ function onEventFinish(player, csid, option)
     elseif csid == 439 then
         player:setCharVar("MissionStatus", 5)
     elseif csid == 251 then
-        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.MANDRAGORA_MAD, { fame = 10 })
-        player:addGil(GIL_RATE*200)
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.MANDRAGORA_MAD, {
+            fame = 10,
+            gil = 200
+        })
         player:confirmTrade()
     elseif csid == 252 then
-        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.MANDRAGORA_MAD, { fame = 25 })
-        player:addGil(GIL_RATE*250)
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.MANDRAGORA_MAD, {
+            fame = 25,
+            gil = 250
+        })
         player:confirmTrade()
     elseif csid == 253 then
-        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.MANDRAGORA_MAD, { fame = 50 })
-        player:addGil(GIL_RATE*1200)
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.MANDRAGORA_MAD, {
+            fame = 50,
+            gil = 1200
+        })
         player:confirmTrade()
     elseif csid == 254 then
-        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.MANDRAGORA_MAD, { fame = 10 })
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.MANDRAGORA_MAD, {
             fame = 10,
-        player:addGil(GIL_RATE*120)
+            gil = 120
+        })
         player:confirmTrade()
     elseif csid == 255 then
-        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.MANDRAGORA_MAD, { fame = 100 })
-        player:addGil(GIL_RATE*5500)
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.MANDRAGORA_MAD, {
+            fame = 100,
+            gil = 5500
+        })
         player:confirmTrade()
     end
 end

--- a/scripts/zones/Windurst_Walls/npcs/Yoriri.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Yoriri.lua
@@ -11,10 +11,10 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-
-    local WildcatWindurst = player:getCharVar("WildcatWindurst")
-
-    if (player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and player:getMaskBit(WildcatWindurst, 5) == false) then
+    if
+        player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
+        player:getMaskBit(player:getCharVar("WildcatWindurst"), 5) == false
+    then
         player:startEvent(496)
     else
         player:startEvent(313)
@@ -25,9 +25,7 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-
     if (csid == 496) then
         player:setMaskBit(player:getCharVar("WildcatWindurst"), "WildcatWindurst", 5, true)
     end
-
 end

--- a/scripts/zones/Windurst_Walls/npcs/Zayhi-Bauhi.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Zayhi-Bauhi.lua
@@ -7,6 +7,7 @@
 -----------------------------------
 require("scripts/globals/settings")
 require("scripts/globals/quests")
+require("scripts/globals/npc_util")
 -----------------------------------
 
 function onTrade(player, npc, trade)
@@ -33,59 +34,61 @@ function onTrigger(player, npc)
     local PostmanKOsTwice = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.THE_POSTMAN_ALWAYS_KO_S_TWICE)
     local ToBeeOrNotStatus = player:getCharVar("ToBeeOrNot_var")
 
-    if ((player:getFameLevel(WINDURST) >= 2 and PostmanKOsTwice == QUEST_COMPLETED and ToBee == QUEST_AVAILABLE) or (ToBee == QUEST_ACCEPTED and ToBeeOrNotStatus == 10)) then
+    -- TO BEE OR NOT TO BEE
+    if
+        (player:getFameLevel(WINDURST) >= 2 and
+        PostmanKOsTwice == QUEST_COMPLETED and
+        ToBee == QUEST_AVAILABLE) or
+        (ToBee == QUEST_ACCEPTED and
+        ToBeeOrNotStatus == 10)
+    then
         player:startEvent(64)   -- Just Before Quest Start "Too Bee or Not Too Be" (Speech given with lots of coughing)
-    elseif (ToBee == QUEST_ACCEPTED) then
-        if (ToBeeOrNotStatus == 1) then
+    elseif ToBee == QUEST_ACCEPTED then
+        if ToBeeOrNotStatus == 1 then
             player:startEvent(69) -- After Honey#1: Clearing throat
-        elseif (ToBeeOrNotStatus == 2) then
+        elseif ToBeeOrNotStatus == 2 then
             player:startEvent(70) -- After Honey#2: Tries to speak again... coughs
-        elseif (ToBeeOrNotStatus == 3) then
+        elseif ToBeeOrNotStatus == 3 then
             player:startEvent(73) -- After Honey#3: Tries to speak again... coughs..asked for more Honey
-        elseif (ToBeeOrNotStatus == 4) then
+        elseif ToBeeOrNotStatus == 4 then
             player:startEvent(74) -- After Honey#4: Feels like its getting a lot better but there is still iritaion
         end
-    elseif (ToBee == QUEST_COMPLETED and player:needToZone()) then
+    elseif
+        ToBee == QUEST_COMPLETED and
+        player:needToZone()
+    then
         player:startEvent(78) -- ToBee After Quest Finish but before zone (tooth still hurts)
+
+    -- DEFAULT DIALOG
     else
         player:startEvent(299) -- Normal speech
     end
 end
 
 --        Event ID List for NPC
---      player:startEvent(299) -- Normal speach
 --      player:startEvent(61) -- Normal speach
---      player:startEvent(64) -- Start quest "Too Bee or Not Too Be" (Speech given with lots of coughing)
---      player:startEvent(69) -- After Honey#1: Clearing throat
---      player:startEvent(70) -- After Honey#2: Tries to speak again... coughs
---      player:startEvent(73) -- After Honey#3: Tries to speak again... coughs..asked for more Honey
---      player:startEvent(74) -- After Honey#4: Feels like its getting a lot better but there is still iritaion
---      player:startEvent(75) -- After Honey#5: ToBee quest Finish (tooth hurts from all the Honey)
---      player:startEvent(78) -- ToBee After Quest Finish but before zone (tooth still hurts)
 function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-
-    if (csid == 64) then
+    if csid == 64 then
         player:setCharVar("ToBeeOrNot_var", 10)
-    elseif (csid == 69) then -- After Honey#1: Clearing throat
+    elseif csid == 69 then -- After Honey#1: Clearing throat
         player:tradeComplete()
         player:setCharVar("ToBeeOrNot_var", 1)
-    elseif (csid == 70) then -- After Honey#2: Tries to speak again... coughs
+    elseif csid == 70 then -- After Honey#2: Tries to speak again... coughs
         player:tradeComplete()
         player:setCharVar("ToBeeOrNot_var", 2)
-    elseif (csid == 73) then -- After Honey#3: Tries to speak again... coughs..asked for more Honey
+    elseif csid == 73 then -- After Honey#3: Tries to speak again... coughs..asked for more Honey
         player:tradeComplete()
         player:setCharVar("ToBeeOrNot_var", 3)
-    elseif (csid == 74) then -- After Honey#4: Feels like its getting a lot better but there is still iritaion
+    elseif csid == 74 then -- After Honey#4: Feels like its getting a lot better but there is still iritaion
         player:tradeComplete()
         player:setCharVar("ToBeeOrNot_var", 4)
-    elseif (csid == 75) then -- After Honey#5: ToBee quest Finish (tooth hurts from all the Honey)
+    elseif csid == 75 then -- After Honey#5: ToBee quest Finish (tooth hurts from all the Honey)
         player:tradeComplete()
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.TO_BEE_OR_NOT_TO_BEE)
         player:setCharVar("ToBeeOrNot_var", 5)
-        player:addFame(WINDURST, 30)
-        player:completeQuest(WINDURST, tpz.quest.id.windurst.TO_BEE_OR_NOT_TO_BEE)
         player:needToZone(true)
     end
 end

--- a/scripts/zones/Windurst_Walls/npcs/Zokima-Rokima.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Zokima-Rokima.lua
@@ -10,41 +10,48 @@ require("scripts/globals/settings")
 require("scripts/globals/titles")
 require("scripts/globals/keyitems")
 require("scripts/globals/missions")
+require("scripts/globals/npc_util")
 -----------------------------------
 
 function onTrigger(player, npc)
 
-    if (player:getNation() ~= tpz.nation.WINDURST) then
+    if player:getNation() ~= tpz.nation.WINDURST then
         player:startEvent(87) -- for other nation
     else
-        CurrentMission = player:getCurrentMission(WINDURST)
-        MissionStatus = player:getCharVar("MissionStatus")
-        pRank = player:getRank()
-        cs, p, offset = getMissionOffset(player, 4, CurrentMission, MissionStatus)
+        local CurrentMission = player:getCurrentMission(WINDURST)
+        local MissionStatus = player:getCharVar("MissionStatus")
+        local pRank = player:getRank()
+        local cs, p, offset = getMissionOffset(player, 4, CurrentMission, MissionStatus)
 
-        if (CurrentMission <= tpz.mission.id.windurst.THE_SHADOW_AWAITS and (cs ~= 0 or offset ~= 0 or (CurrentMission == tpz.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and offset == 0))) then
-            if (cs == 0) then
+        if
+            CurrentMission <= tpz.mission.id.windurst.THE_SHADOW_AWAITS and
+            (cs ~= 0 or
+            offset ~= 0 or
+            (CurrentMission == tpz.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and
+            offset == 0))
+        then
+            if cs == 0 then
                 player:showText(npc, ORIGINAL_MISSION_OFFSET + offset) -- dialog after accepting mission
             else
                 player:startEvent(cs, p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8])
             end
-        elseif (CurrentMission ~= tpz.mission.id.windurst.NONE) then
+        elseif CurrentMission ~= tpz.mission.id.windurst.NONE then
             player:startEvent(91)
-        elseif (player:hasCompletedMission(WINDURST, tpz.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT) == false) then
+        elseif player:hasCompletedMission(WINDURST, tpz.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT) == false then
             player:startEvent(96)
-        elseif (player:hasCompletedMission(WINDURST, tpz.mission.id.windurst.THE_HEART_OF_THE_MATTER) == false) then
+        elseif player:hasCompletedMission(WINDURST, tpz.mission.id.windurst.THE_HEART_OF_THE_MATTER) == false then
             player:startEvent(106)
-        elseif (player:hasCompletedMission(WINDURST, tpz.mission.id.windurst.THE_PRICE_OF_PEACE) == false) then
+        elseif player:hasCompletedMission(WINDURST, tpz.mission.id.windurst.THE_PRICE_OF_PEACE) == false then
             player:startEvent(111)
-        elseif (player:hasKeyItem(tpz.ki.MESSAGE_TO_JEUNO_WINDURST)) then
+        elseif player:hasKeyItem(tpz.ki.MESSAGE_TO_JEUNO_WINDURST) then
             player:startEvent(150)
         else
-            flagMission, repeatMission = getMissionMask(player)
+            local flagMission, repeatMission = getMissionMask(player)
+            local param3 = 0
+
             -- NPC dialog changes when starting 3-2 according to whether it's the first time or being repeated
-            if (player:hasCompletedMission(WINDURST, tpz.mission.id.windurst.WRITTEN_IN_THE_STARS)) then
+            if player:hasCompletedMission(WINDURST, tpz.mission.id.windurst.WRITTEN_IN_THE_STARS) then
                 param3 = 1
-            else
-                param3 = 0
             end
             player:startEvent(93, flagMission, 0, param3, 0, tpz.ki.STAR_CRESTED_SUMMONS, repeatMission)
         end
@@ -56,14 +63,18 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-
     finishMissionTimeline(player, 4, csid, option)
 
-    if (csid == 96 and option == 1) then
+    if
+        csid == 96 and
+        option == 1
+    then
         player:addTitle(tpz.title.HEAVENS_TOWER_GATEHOUSE_RECRUIT)
-    elseif (csid == 93 and (option == 12 or option == 15)) then
-        player:addKeyItem(tpz.ki.STAR_CRESTED_SUMMONS)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.STAR_CRESTED_SUMMONS)
+    elseif
+        csid == 93 and
+        (option == 12 or
+        option == 15)
+    then
+        npcUtil.giveKeyItem(player, tpz.ki.STAR_CRESTED_SUMMONS)
     end
-
 end

--- a/scripts/zones/Windurst_Walls/npcs/Zokima-Rokima.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Zokima-Rokima.lua
@@ -37,11 +37,11 @@ function onTrigger(player, npc)
             end
         elseif CurrentMission ~= tpz.mission.id.windurst.NONE then
             player:startEvent(91)
-        elseif player:hasCompletedMission(WINDURST, tpz.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT) == false then
+        elseif not player:hasCompletedMission(WINDURST, tpz.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT) then
             player:startEvent(96)
-        elseif player:hasCompletedMission(WINDURST, tpz.mission.id.windurst.THE_HEART_OF_THE_MATTER) == false then
+        elseif not player:hasCompletedMission(WINDURST, tpz.mission.id.windurst.THE_HEART_OF_THE_MATTER) then
             player:startEvent(106)
-        elseif player:hasCompletedMission(WINDURST, tpz.mission.id.windurst.THE_PRICE_OF_PEACE) == false then
+        elseif not player:hasCompletedMission(WINDURST, tpz.mission.id.windurst.THE_PRICE_OF_PEACE) then
             player:startEvent(111)
         elseif player:hasKeyItem(tpz.ki.MESSAGE_TO_JEUNO_WINDURST) then
             player:startEvent(150)

--- a/scripts/zones/Windurst_Walls/npcs/_6n2.lua
+++ b/scripts/zones/Windurst_Walls/npcs/_6n2.lua
@@ -11,48 +11,80 @@ require("scripts/globals/keyitems")
 require("scripts/globals/missions")
 require("scripts/globals/quests")
 require("scripts/globals/status")
+require("scripts/globals/npc_util")
 -----------------------------------
 
 function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-    local ThePuppetMaster = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.THE_PUPPET_MASTER)
-    local ClassReunion = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CLASS_REUNION)
-    local CarbuncleDebacle = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CARBUNCLE_DEBACLE)
+    local thePuppetMaster = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.THE_PUPPET_MASTER)
+    local classReunion = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CLASS_REUNION)
+    local carbuncleDebacle = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CARBUNCLE_DEBACLE)
+
     -- Check for Missions first (priority?)
-    if (player:getCurrentMission(WINDURST) == tpz.mission.id.windurst.LOST_FOR_WORDS and player:getCharVar("MissionStatus") == 5) then
+    if
+        player:getCurrentMission(WINDURST) == tpz.mission.id.windurst.LOST_FOR_WORDS and
+        player:getCharVar("MissionStatus") == 5
+    then
         player:startEvent(337)
     else
-        ----------------------------------------------------
-        -- SMN unlock quest
-        if (player:getQuestStatus(WINDURST, tpz.quest.id.windurst.I_CAN_HEAR_A_RAINBOW) == QUEST_AVAILABLE and player:getMainLvl() >= 30 and player:hasItem(1125)) then
+
+        -- I CAN HEAR A RAINBOW
+        if
+            player:getQuestStatus(WINDURST, tpz.quest.id.windurst.I_CAN_HEAR_A_RAINBOW) == QUEST_AVAILABLE and
+            player:getMainLvl() >= 30 and player:hasItem(1125)
+        then
             player:startEvent(384, 1125, 1125, 1125, 1125, 1125, 1125, 1125, 1125)
-        elseif (player:getQuestStatus(WINDURST, tpz.quest.id.windurst.I_CAN_HEAR_A_RAINBOW) == QUEST_ACCEPTED) then
+        elseif player:getQuestStatus(WINDURST, tpz.quest.id.windurst.I_CAN_HEAR_A_RAINBOW) == QUEST_ACCEPTED then
             player:startEvent(385, 1125, 1125, 1125, 1125, 1125, 1125, 1125, 1125)
-        ----------------------------------------------------
-        -- The Puppet Master (AF weapon)
-        elseif (player:getMainLvl() >= AF1_QUEST_LEVEL and player:getMainJob() == tpz.job.SMN and ThePuppetMaster == QUEST_AVAILABLE and player:needToZone() == false and ClassReunion ~= QUEST_ACCEPTED and CarbuncleDebacle ~= QUEST_ACCEPTED) then -- you need to be on SMN as well to repeat the quest
+
+        -- THE PUPPET MASTER
+        elseif
+            player:getMainLvl() >= AF1_QUEST_LEVEL and
+            player:getMainJob() == tpz.job.SMN and
+            thePuppetMaster == QUEST_AVAILABLE and
+            player:needToZone() == false and
+            classReunion ~= QUEST_ACCEPTED and
+            carbuncleDebacle ~= QUEST_ACCEPTED
+        then -- you need to be on SMN as well to repeat the quest
             player:startEvent(402) -- Carby asks for your help, visit Juroro
-        elseif (player:getQuestStatus(WINDURST, tpz.quest.id.windurst.THE_PUPPET_MASTER) == QUEST_ACCEPTED and player:getCharVar("ThePuppetMasterProgress") == 1) then
+        elseif
+            player:getQuestStatus(WINDURST, tpz.quest.id.windurst.THE_PUPPET_MASTER) == QUEST_ACCEPTED and
+            player:getCharVar("ThePuppetMasterProgress") == 1
+        then
             player:startEvent(403) -- reminder to visit Juroro
-        ----------------------------------------------------
-        -- Class Reunion (AF pants)
-        elseif (player:getMainLvl() >= AF2_QUEST_LEVEL and player:getMainJob() == tpz.job.SMN and ThePuppetMaster == QUEST_COMPLETED and ClassReunion == QUEST_AVAILABLE and player:needToZone() == false) then
+
+        -- CLASS REUNION
+        elseif
+            player:getMainLvl() >= AF2_QUEST_LEVEL and
+            player:getMainJob() == tpz.job.SMN and
+            thePuppetMaster == QUEST_COMPLETED and
+            classReunion == QUEST_AVAILABLE and
+            player:needToZone() == false
+        then
             player:startEvent(413) -- Carby asks for your help again.
-        ----------------------------------------------------
-        -- Carbuncle Debacle (AF head)
-        elseif (player:getMainLvl() >= AF3_QUEST_LEVEL and player:getMainJob() == tpz.job.SMN and ClassReunion == QUEST_COMPLETED and CarbuncleDebacle == QUEST_AVAILABLE and player:needToZone() == false) then
+
+        -- CARBUNCLE DEBACLE
+        elseif
+            player:getMainLvl() >= AF3_QUEST_LEVEL and
+            player:getMainJob() == tpz.job.SMN and
+            classReunion == QUEST_COMPLETED and
+            carbuncleDebacle == QUEST_AVAILABLE and
+            player:needToZone() == false
+        then
             player:startEvent(415) -- Carby begs for your help
         ----------------------------------------------------
-        elseif (player:hasKeyItem(tpz.ki.JOKER_CARD)) then
+        elseif player:hasKeyItem(tpz.ki.JOKER_CARD) then
             player:startEvent(387, 0, tpz.ki.JOKER_CARD)
-        elseif (player:getCharVar("WildCard") == 1) then
+        elseif player:getCharVar("WildCard") == 1 then
             player:startEvent(386)
-        elseif (player:getCharVar("OnionRings") == 1) then
+        elseif player:getCharVar("OnionRings") == 1 then
             player:startEvent(289)
-        elseif (player:getCharVar("KnowOnesOnions") == 1) then
+        elseif player:getCharVar("KnowOnesOnions") == 1 then
             player:startEvent(288, 0, 4387)
+
+        -- DEFAULT DIALOG
         else
             player:messageSpecial(ID.text.DOORS_SEALED_SHUT) -- "The doors are firmly sealed shut."
         end
@@ -62,49 +94,45 @@ function onTrigger(player, npc)
 end
 
 function onEventUpdate(player, csid, option)
-    -- printf("CSID2: %u", csid)
-    -- printf("RESULT2: %u", option)
 end
 
 function onEventFinish(player, csid, option)
-
-    if (csid == 288) then
+    if csid == 288 then
         player:setCharVar("KnowOnesOnions", 2)
-    elseif (csid == 289) then
-        if npcUtil.completeQuest(
-            player,
-            WINDURST,
-            tpz.quest.id.windurst.ONION_RINGS,
-            {item = 17029, tpz.title.STAR_ONION_BRIGADIER, var = {"OnionRingsTime", "OnionRings"}, fame=10})
-        then
-            player:delKeyItem(tpz.ki.OLD_RING)
-        end
-    elseif (csid == 384) then
+    elseif
+        csid == 289 and
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.ONION_RINGS, {
+            item = 17029,
+            tpz.title.STAR_ONION_BRIGADIER,
+            var = {"OnionRingsTime", "OnionRings"},
+            fame = 10
+        })
+    then
+        player:delKeyItem(tpz.ki.OLD_RING)
+    elseif csid == 384 then
         player:addQuest(WINDURST, tpz.quest.id.windurst.I_CAN_HEAR_A_RAINBOW)
-    elseif (csid == 386) then
+    elseif csid == 386 then
         player:setCharVar("WildCard", 2)
-    elseif (csid == 387) then
+    elseif csid == 387 then
         player:delKeyItem(tpz.ki.JOKER_CARD)
         player:addGil(GIL_RATE*8000)
         player:messageSpecial(ID.text.GIL_OBTAINED, GIL_RATE*8000)
-    elseif (csid == 337) then
+    elseif csid == 337 then
         -- Mark the progress
         player:setCharVar("MissionStatus", 6)
-    elseif (csid == 402) then
-        if (player:getQuestStatus(WINDURST, tpz.quest.id.windurst.THE_PUPPET_MASTER) == QUEST_COMPLETED) then
+    elseif csid == 402 then
+        if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.THE_PUPPET_MASTER) == QUEST_COMPLETED then
             player:delQuest(WINDURST, tpz.quest.id.windurst.THE_PUPPET_MASTER)
             player:addQuest(WINDURST, tpz.quest.id.windurst.THE_PUPPET_MASTER) -- this needs only if you repeat this quest
         end
         player:setCharVar("ThePuppetMasterProgress", 1)
         player:addQuest(WINDURST, tpz.quest.id.windurst.THE_PUPPET_MASTER)
-    elseif (csid == 413) then
+    elseif csid == 413 then
         player:setCharVar("ClassReunionProgress", 1)
         player:addQuest(WINDURST, tpz.quest.id.windurst.CLASS_REUNION)
-        player:addKeyItem(tpz.ki.CARBUNCLES_TEAR)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.CARBUNCLES_TEAR)
-    elseif (csid == 415) then
+        npcUtil.giveKeyItem(player, tpz.ki.CARBUNCLES_TEAR)
+    elseif csid == 415 then
         player:addQuest(WINDURST, tpz.quest.id.windurst.CARBUNCLE_DEBACLE)
         player:setCharVar("CarbuncleDebacleProgress", 1)
     end
-
 end

--- a/scripts/zones/Windurst_Walls/npcs/_6n2.lua
+++ b/scripts/zones/Windurst_Walls/npcs/_6n2.lua
@@ -33,7 +33,8 @@ function onTrigger(player, npc)
         -- I CAN HEAR A RAINBOW
         if
             player:getQuestStatus(WINDURST, tpz.quest.id.windurst.I_CAN_HEAR_A_RAINBOW) == QUEST_AVAILABLE and
-            player:getMainLvl() >= 30 and player:hasItem(1125)
+            player:getMainLvl() >= 30 and
+            player:hasItem(1125)
         then
             player:startEvent(384, 1125, 1125, 1125, 1125, 1125, 1125, 1125, 1125)
         elseif player:getQuestStatus(WINDURST, tpz.quest.id.windurst.I_CAN_HEAR_A_RAINBOW) == QUEST_ACCEPTED then

--- a/scripts/zones/Windurst_Walls/npcs/_6n8.lua
+++ b/scripts/zones/Windurst_Walls/npcs/_6n8.lua
@@ -12,10 +12,15 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-    X = player:getXPos()
-    Z = player:getZPos()
+    local X = player:getXPos()
+    local Z = player:getZPos()
 
-    if ((X >= 1.51 and X <= 9.49) and (Z >= 273.1 and Z <= 281)) then
+    if
+        X >= 1.51 and
+        X <= 9.49 and
+        Z >= 273.1 and
+        Z <= 281
+    then
         if player:hasKeyItem(tpz.ki.RHINOSTERY_CERTIFICATE) then
             player:startEvent(401)
         else
@@ -24,6 +29,7 @@ function onTrigger(player, npc)
     else
         player:startEvent(395)
     end
+
     return 1
 end
 


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Would love a second set of eyes as it was a mass change and nothing was tested.