### PR TITLE
Add RoE Disable switch in settings.lua

### DIFF
--- a/scripts/globals/settings.lua
+++ b/scripts/globals/settings.lua
@@ -35,6 +35,9 @@ REGIME_WAIT = 1 -- Make people wait till 00:00 game time as in retail. If it's 0
 FOV_REWARD_ALLIANCE = 0 -- Allow Fields of Valor rewards while being a member of an alliance. (default retail behavior: 0)
 GOV_REWARD_ALLIANCE = 1 -- Allow Grounds of Valor rewards while being a member of an alliance. (default retail behavior: 1)
 
+-- Records of Eminence
+ENABLE_ROE = 1
+
 -- TREASURE CASKETS
 -- Retail droprate = 0.1 (10%) with no other effects active
 -- Set to 0 to disable caskets.

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -6814,7 +6814,7 @@ inline int32 CLuaBaseEntity::setEminenceProgress(lua_State *L)
 
     // Determine threshold for sending progress messages
     bool progressNotify {true};
-    if (uint32 threshold = roeutils::RoeCache.NotifyThresholds[recordID]; threshold > 1)
+    if (uint32 threshold = roeutils::RoeSystem.NotifyThresholds[recordID]; threshold > 1)
     {
         uint32 prevStep = static_cast<uint32>(roeutils::GetEminenceRecordProgress(PChar, recordID) / threshold);
         uint32 nextStep = static_cast<uint32>(progress / threshold);

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -6062,8 +6062,11 @@ void SmallPacket0x10B(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x10C(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
-    roeutils::AddEminenceRecord(PChar, data.ref<uint32>(0x04));
-    PChar->pushPacket(new CRoeSparkUpdatePacket(PChar));
+    if (roeutils::RoeSystem.RoeEnabled)
+    {
+        roeutils::AddEminenceRecord(PChar, data.ref<uint32>(0x04));
+        PChar->pushPacket(new CRoeSparkUpdatePacket(PChar));
+    }
     return;
 }
 
@@ -6075,8 +6078,11 @@ void SmallPacket0x10C(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x10D(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
-    roeutils::DelEminenceRecord(PChar, data.ref<uint32>(0x04));
-    PChar->pushPacket(new CRoeSparkUpdatePacket(PChar));
+    if (roeutils::RoeSystem.RoeEnabled)
+    {
+        roeutils::DelEminenceRecord(PChar, data.ref<uint32>(0x04));
+        PChar->pushPacket(new CRoeSparkUpdatePacket(PChar));
+    }
     return;
 }
 
@@ -6137,12 +6143,20 @@ void SmallPacket0x111(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x112(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
-    // Send spark updates + current RoE quests
+    // Send spark updates
     PChar->pushPacket(new CRoeSparkUpdatePacket(PChar));
-    PChar->pushPacket(new CRoeUpdatePacket(PChar));
-    // 4-part Eminence Completion bitmap
-    for(int i = 0; i < 4; i++)
-        PChar->pushPacket(new CRoeQuestLogPacket(PChar, i));
+
+    if (roeutils::RoeSystem.RoeEnabled)
+    {
+        // Current RoE quests
+        PChar->pushPacket(new CRoeUpdatePacket(PChar));
+
+        // 4-part Eminence Completion bitmap
+        for (int i = 0; i < 4; i++)
+        {
+            PChar->pushPacket(new CRoeQuestLogPacket(PChar, i));
+        }
+    }
 
     return;
 }

--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -33,13 +33,16 @@
 #include "packets/roe_update.h"
 
 std::array<RoeCheckHandler, ROE_NONE> RoeHandlers;
-RoeSystemData roeutils::RoeCache;
+RoeSystemData roeutils::RoeSystem;
 
 namespace roeutils
 {
 void init()
 {
     lua_State* L = luautils::LuaHandle;
+    lua_getglobal(L, "ENABLE_ROE");
+    roeutils::RoeSystem.RoeEnabled = lua_isnil(L, -1) || lua_tointeger(L, -1);
+    lua_pop(L, 1);
     lua_register(L, "RoeRegisterHandler", roeutils::RegisterHandler);
     lua_register(L, "RoeParseRecords", roeutils::ParseRecords);
     RoeHandlers.fill(RoeCheckHandler());
@@ -84,9 +87,9 @@ int32 RegisterHandler(lua_State* L)
 
 int32 ParseRecords(lua_State* L)
 {
-    roeutils::RoeCache.ImplementedRecords.reset();
-    roeutils::RoeCache.RepeatableRecords.reset();
-    roeutils::RoeCache.NotifyThresholds.fill(1);
+    roeutils::RoeSystem.ImplementedRecords.reset();
+    roeutils::RoeSystem.RepeatableRecords.reset();
+    roeutils::RoeSystem.NotifyThresholds.fill(1);
 
     if (lua_isnil(L, -1) || !lua_istable(L, -1))
         return 0;
@@ -97,12 +100,12 @@ int32 ParseRecords(lua_State* L)
     {
         // Set Implemented bit.
         uint32 recordID = static_cast<uint32>(lua_tointeger(L, -2));
-        roeutils::RoeCache.ImplementedRecords.set(recordID);
+        roeutils::RoeSystem.ImplementedRecords.set(recordID);
 
         // Set notification threshold
         lua_getfield(L, -1, "notify");
         if (!lua_isnil(L, -1))
-            roeutils::RoeCache.NotifyThresholds[recordID] = static_cast<uint32>((lua_tointeger(L, -1)));
+            roeutils::RoeSystem.NotifyThresholds[recordID] = static_cast<uint32>((lua_tointeger(L, -1)));
         lua_pop(L, 1);
 
         // Set repeatability bit
@@ -112,7 +115,7 @@ int32 ParseRecords(lua_State* L)
             lua_getfield(L, -1, "repeatable");
             if (lua_toboolean(L, -1))
             {
-                roeutils::RoeCache.RepeatableRecords.set(recordID);
+                roeutils::RoeSystem.RepeatableRecords.set(recordID);
             }
             lua_pop(L, 1);
         }
@@ -126,7 +129,7 @@ int32 ParseRecords(lua_State* L)
 
 bool event(ROE_EVENT eventID, CCharEntity* PChar, RoeDatagramList payload)
 {
-    if (!PChar || PChar->objtype != TYPE_PC)
+    if (!RoeSystem.RoeEnabled || !PChar || PChar->objtype != TYPE_PC)
         return false;
 
     RoeCheckHandler& handler = RoeHandlers[eventID];
@@ -230,9 +233,8 @@ bool GetEminenceRecordCompletion(CCharEntity* PChar, uint16 recordID)
 
 bool AddEminenceRecord(CCharEntity* PChar, uint16 recordID)
 {
-
     // We deny taking records which aren't implemented in the Lua
-    if (!roeutils::RoeCache.ImplementedRecords.test(recordID))
+    if (!roeutils::RoeSystem.ImplementedRecords.test(recordID))
     {
         std::string message = "The record #" + std::to_string(recordID) + " is not implemented at this time.";
         PChar->pushPacket(new CChatMessagePacket(PChar, MESSAGE_NS_SAY, message, "RoE System"));
@@ -240,7 +242,7 @@ bool AddEminenceRecord(CCharEntity* PChar, uint16 recordID)
     }
 
     // Prevent packet-injection for re-taking completed records which aren't marked repeatable.
-    if (roeutils::GetEminenceRecordCompletion(PChar, recordID) && !roeutils::RoeCache.RepeatableRecords.test(recordID))
+    if (roeutils::GetEminenceRecordCompletion(PChar, recordID) && !roeutils::RoeSystem.RepeatableRecords.test(recordID))
         return false;
 
     // Per above, this i < 30 is correct.

--- a/src/map/roe.h
+++ b/src/map/roe.h
@@ -52,6 +52,7 @@ enum ROE_EVENT
 
 struct RoeSystemData
 {
+    bool RoeEnabled;
     std::bitset<4096> ImplementedRecords;
     std::bitset<4096> RepeatableRecords;
     std::array<uint32, 4096> NotifyThresholds;
@@ -96,7 +97,7 @@ typedef std::vector<RoeDatagram> RoeDatagramList;
 
 namespace roeutils
 {
-extern RoeSystemData RoeCache;
+extern RoeSystemData RoeSystem;
 
 void init();
 int32 RegisterHandler(lua_State* L);

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -76,6 +76,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "../weapon_skill.h"
 #include "../item_container.h"
 #include "../recast_container.h"
+#include "../roe.h"
 #include "../status_effect_container.h"
 #include "../linkshell.h"
 #include "../universal_container.h"
@@ -4006,6 +4007,9 @@ namespace charutils
 
     void SaveEminenceData(CCharEntity* PChar)
     {
+        if (!roeutils::RoeSystem.RoeEnabled)
+            return;
+
         const char* Query =
             "UPDATE chars "
             "SET "


### PR DESCRIPTION
This still maintains support for showing the player's Spark amount and giving/removing spark currency (In case any server wants alternate ways to obtain them or custom usage.)

Summary of fail-out conditions when RoE Disabled:
- Client RoE packets won't be replied to (Take record, Remove record, Quest Log.) RoE client menu will be blank.
- RoE Events bail-out immediately.
- No RoE writes to DB

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits