### PR TITLE
Correcting ZilartStatus checks

### DIFF
--- a/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Darkness.lua
+++ b/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Darkness.lua
@@ -22,10 +22,10 @@ function onTrigger(player, npc)
             player:setCharVar("ZilartStatus", ZilartStatus + 2)
             player:messageSpecial(ID.text.YOU_PLACE_THE, tpz.ki.DARK_FRAGMENT)
 
-            if (ZilartStatus == 255) then
+            if (player:getCharVar("ZilartStatus") == 257) then
                 player:startEvent(1)
             end
-        elseif (ZilartStatus == 255) then -- Execute cutscene if the player is interrupted.
+        elseif (ZilartStatus == 257) then -- Execute cutscene if the player is interrupted.
             player:startEvent(1)
         else
             player:messageSpecial(ID.text.IS_SET_IN_THE_PEDESTAL, tpz.ki.DARK_FRAGMENT)

--- a/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Earth.lua
+++ b/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Earth.lua
@@ -22,10 +22,10 @@ function onTrigger(player, npc)
             player:setCharVar("ZilartStatus", ZilartStatus + 4)
             player:messageSpecial(ID.text.YOU_PLACE_THE, tpz.ki.EARTH_FRAGMENT)
 
-            if (ZilartStatus == 255) then
+            if (player:getCharVar("ZilartStatus") == 257) then
                 player:startEvent(1)
             end
-        elseif (ZilartStatus == 255) then -- Execute cutscene if the player is interrupted.
+        elseif (ZilartStatus == 257) then -- Execute cutscene if the player is interrupted.
             player:startEvent(1)
         else
             player:messageSpecial(ID.text.IS_SET_IN_THE_PEDESTAL, tpz.ki.EARTH_FRAGMENT)

--- a/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Fire.lua
+++ b/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Fire.lua
@@ -22,10 +22,10 @@ function onTrigger(player, npc)
             player:setCharVar("ZilartStatus", ZilartStatus + 1)
             player:messageSpecial(ID.text.YOU_PLACE_THE, tpz.ki.FIRE_FRAGMENT)
 
-            if (ZilartStatus == 255) then
+            if (player:getCharVar("ZilartStatus") == 257) then
                 player:startEvent(1)
             end
-        elseif (ZilartStatus == 255) then -- Execute cutscene if the player is interrupted.
+        elseif (ZilartStatus == 257) then -- Execute cutscene if the player is interrupted.
             player:startEvent(1)
         else
             player:messageSpecial(ID.text.IS_SET_IN_THE_PEDESTAL, tpz.ki.FIRE_FRAGMENT)

--- a/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Ice.lua
+++ b/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Ice.lua
@@ -22,10 +22,10 @@ function onTrigger(player, npc)
             player:setCharVar("ZilartStatus", ZilartStatus + 8)
             player:messageSpecial(ID.text.YOU_PLACE_THE, tpz.ki.ICE_FRAGMENT)
 
-            if (ZilartStatus == 255) then
+            if (player:getCharVar("ZilartStatus") == 257) then
                 player:startEvent(1)
             end
-        elseif (ZilartStatus == 255) then -- Execute cutscene if the player is interrupted.
+        elseif (ZilartStatus == 257) then -- Execute cutscene if the player is interrupted.
             player:startEvent(1)
         else
             player:messageSpecial(ID.text.IS_SET_IN_THE_PEDESTAL, tpz.ki.ICE_FRAGMENT)

--- a/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Light.lua
+++ b/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Light.lua
@@ -22,10 +22,10 @@ function onTrigger(player, npc)
             player:setCharVar("ZilartStatus", ZilartStatus + 16)
             player:messageSpecial(ID.text.YOU_PLACE_THE, tpz.ki.LIGHT_FRAGMENT)
 
-            if (ZilartStatus == 255) then
+            if (player:getCharVar("ZilartStatus") == 257) then
                 player:startEvent(1)
             end
-        elseif (ZilartStatus == 255) then -- Execute cutscene if the player is interrupted.
+        elseif (ZilartStatus == 257) then -- Execute cutscene if the player is interrupted.
             player:startEvent(1)
         else
             player:messageSpecial(ID.text.IS_SET_IN_THE_PEDESTAL, tpz.ki.LIGHT_FRAGMENT)

--- a/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Lightning.lua
+++ b/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Lightning.lua
@@ -22,10 +22,10 @@ function onTrigger(player, npc)
             player:setCharVar("ZilartStatus", ZilartStatus + 32)
             player:messageSpecial(ID.text.YOU_PLACE_THE, tpz.ki.LIGHTNING_FRAGMENT)
 
-            if (ZilartStatus == 255) then
+            if (player:getCharVar("ZilartStatus") == 257) then
                 player:startEvent(1)
             end
-        elseif (ZilartStatus == 255) then -- Execute cutscene if the player is interrupted.
+        elseif (ZilartStatus == 257) then -- Execute cutscene if the player is interrupted.
             player:startEvent(1)
         else
             player:messageSpecial(ID.text.IS_SET_IN_THE_PEDESTAL, tpz.ki.LIGHTNING_FRAGMENT)

--- a/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Water.lua
+++ b/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Water.lua
@@ -22,10 +22,10 @@ function onTrigger(player, npc)
             player:setCharVar("ZilartStatus", ZilartStatus + 64)
             player:messageSpecial(ID.text.YOU_PLACE_THE, tpz.ki.WATER_FRAGMENT)
 
-            if (ZilartStatus == 255) then
+            if (player:getCharVar("ZilartStatus") == 257) then
                 player:startEvent(1)
             end
-        elseif (ZilartStatus == 255) then -- Execute cutscene if the player is interrupted.
+        elseif (ZilartStatus == 257) then -- Execute cutscene if the player is interrupted.
             player:startEvent(1)
         else
             player:messageSpecial(ID.text.IS_SET_IN_THE_PEDESTAL, tpz.ki.WATER_FRAGMENT)

--- a/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Wind.lua
+++ b/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Wind.lua
@@ -22,10 +22,10 @@ function onTrigger(player, npc)
             player:setCharVar("ZilartStatus", ZilartStatus + 128)
             player:messageSpecial(ID.text.YOU_PLACE_THE, tpz.ki.WIND_FRAGMENT)
 
-            if (ZilartStatus == 255) then
+            if (player:getCharVar("ZilartStatus") == 257) then
                 player:startEvent(1)
             end
-        elseif (ZilartStatus == 255) then -- Execute cutscene if the player is interrupted.
+        elseif (ZilartStatus == 257) then -- Execute cutscene if the player is interrupted.
             player:startEvent(1)
         else
             player:messageSpecial(ID.text.IS_SET_IN_THE_PEDESTAL, tpz.ki.WIND_FRAGMENT)


### PR DESCRIPTION
1: ZilartStatus needs to be '257' not '255', because it started at 2 and 255 was added.
2: You need to re-get the char var when checking to start cutscene upon selecting the last Pedestal because it was added to, so the check looks at the old stored variable instead of the updated one.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

