### PR TITLE
Fixed pos so cutscene displays properly.

### DIFF
--- a/scripts/zones/Periqia/Zone.lua
+++ b/scripts/zones/Periqia/Zone.lua
@@ -34,7 +34,7 @@ function onEventFinish(player, csid, option)
     local chars = instance:getChars()
     if csid == 102 then
         for i, v in pairs(chars) do
-            v:setPos(0, 0, 0, 0, 79)
+            v:setPos(-349.4024, -1.1756, -20.1566, 0, 79)
         end
     end
 end

--- a/scripts/zones/Periqia/instances/shades_of_vengeance.lua
+++ b/scripts/zones/Periqia/instances/shades_of_vengeance.lua
@@ -30,6 +30,7 @@ function onInstanceFailure(instance)
 
     for i, v in pairs(chars) do
         v:messageSpecial(ID.text.MISSION_FAILED, 10, 10)
+		v:setPos(-349.4024, -1.1756, -20.1566, 0, 79)
         v:startEvent(102)
     end
 end
@@ -51,6 +52,7 @@ function onInstanceComplete(instance)
             v:setCharVar("AhtUrganStatus", 1)
         end
 
+		v:setPos(-349.4024, -1.1756, -20.1566, 0, 79)
         v:startEvent(102)
     end
 


### PR DESCRIPTION
Changed the pos so that it leaves the character outside the instance afterwards, having it at <0, 0, 0, 0, zoneId) was causing issues with the cutscene displaying properly, it would freeze.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

