### PR TITLE
Changed pos so it would display cutscene without freezing.

### DIFF
--- a/scripts/zones/Nyzul_Isle/Zone.lua
+++ b/scripts/zones/Nyzul_Isle/Zone.lua
@@ -35,7 +35,7 @@ end
 function onEventFinish(player, csid, option)
 
     if csid == 1 then
-        player:setPos(0, 0, 0, 0, 72)
+        player:setPos(126.6543, 0, 20.1798, 0, 72)
     end
 end
 

--- a/scripts/zones/Nyzul_Isle/instances/nashmeiras_plea.lua
+++ b/scripts/zones/Nyzul_Isle/instances/nashmeiras_plea.lua
@@ -35,15 +35,15 @@ function onInstanceProgressUpdate(instance, progress)
     if (progress == 4) then
         local chars = instance:getChars()
 
-        for i, v in pairs(chars) do
-            v:startEvent(203)
-        end
-
         DespawnMob(ID.mob[59].RAZFAHD, instance)
         SpawnMob(ID.mob[59].ALEXANDER, instance)
 
     elseif(progress == 5) then
         instance:complete()
+		v:setPos(126.6543, 0, 20.1798, 0, 72)
+		for i, v in pairs(chars) do
+			v:startEvent(203)
+        end
     end
 end
 
@@ -56,7 +56,7 @@ function onInstanceComplete(instance)
             v:setCharVar("AhtUrganStatus", 2)
         end
 
-        v:setPos(0, 0, 0, 0, 72)
+        v:setPos(126.6543, 0, 20.1798, 0, 72)
     end
 end
 


### PR DESCRIPTION
Changed the pos so that it leaves the character outside the instance afterwards, having it at <0, 0, 0, 0, zoneId) was causing issues with the cutscene displaying properly, it would freeze.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

