### PR TITLE
Zilart "Return to Delkfutt's Tower" CS in lower tower optional

### DIFF
--- a/scripts/zones/Stellar_Fulcrum/Zone.lua
+++ b/scripts/zones/Stellar_Fulcrum/Zone.lua
@@ -23,7 +23,7 @@ function onZoneIn(player, prevZone)
 
     local cs = -1
 
-    if (player:getCurrentMission(ZILART) == tpz.mission.id.zilart.RETURN_TO_DELKFUTTS_TOWER and player:getCharVar("ZilartStatus") == 2) then
+    if (player:getCurrentMission(ZILART) == tpz.mission.id.zilart.RETURN_TO_DELKFUTTS_TOWER and player:getCharVar("ZilartStatus") >= 0) then
         cs = 0
     end
 


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Players are now able to teleport directly to the BCNM. The Lower Delkfutt Tower cutscene should be optional.
To be honest I don't know how I feel about this one. Different guides say different things about this and most don't even mention the cutscene in the Lower Tower. Tokenr says it is optional by now. Maybe others can confirm this too.