### PR TITLE
Lindwurm drops were not accurate for skin

### DIFF
--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -7927,9 +7927,10 @@ INSERT INTO `mob_droplist` VALUES (1523,0,0,1000,2637,1000);
 INSERT INTO `mob_droplist` VALUES (1523,0,0,1000,11368,410);
 INSERT INTO `mob_droplist` VALUES (1523,0,0,1000,11369,420);
 INSERT INTO `mob_droplist` VALUES (1524,0,0,1000,3097,140);
-INSERT INTO `mob_droplist` VALUES (1525,0,0,1000,853,100);
-INSERT INTO `mob_droplist` VALUES (1525,0,0,1000,1277,110);
-INSERT INTO `mob_droplist` VALUES (1525,0,0,1000,17983,100);
+INSERT INTO `mob_droplist` VALUES (1525,0,0,1000,853,100);     -- Lindwurm ; Raptor skin ; Uncommon
+INSERT INTO `mob_droplist` VALUES (1525,0,0,1000,1277,1000);   -- Lindwurm ; Lindwurm skin ; 100% + Very common
+INSERT INTO `mob_droplist` VALUES (1525,0,0,1000,1277,240);    -- Lindwurm ; Lindwurm skin ; 100% + Very common
+INSERT INTO `mob_droplist` VALUES (1525,0,0,1000,17983,100);   -- Lindwurm ; Valiant knife ; Uncommon
 INSERT INTO `mob_droplist` VALUES (1526,2,0,1000,920,0);
 INSERT INTO `mob_droplist` VALUES (1526,0,0,1000,2614,1000);
 INSERT INTO `mob_droplist` VALUES (1526,0,0,1000,11367,470);


### PR DESCRIPTION
   Source: ffxidb

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Fixing Lindwurm drops to roughly match ffxidb
