### PR TITLE
Apocalypse Nigh branch: implement remaining mechanics

### DIFF
--- a/scripts/globals/bcnm.lua
+++ b/scripts/globals/bcnm.lua
@@ -112,7 +112,7 @@ local battlefields = {
 
     [36] = {                -- EMPYREAL PARADOX
         { 0, 1056,    0},   -- Dawn (PM8-4)
-     -- { 1, 1057,    0},   -- Apocalypse Nigh (Quest)
+        { 1, 1057,    0},   -- Apocalypse Nigh (Quest)
      -- { 2,    ?,    0},   -- Both Paths Taken (ROVM2-9-2)
      -- { 3,    ?,    0},   -- *Dawn (HTMBF)
      -- { 4,    ?,    0},   -- The Winds of Time (ROVM3-1-26)

--- a/scripts/zones/Empyreal_Paradox/mobs/Ealdnarche.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Ealdnarche.lua
@@ -2,9 +2,6 @@
 -- Area: Emperial Paradox
 --  Mob: Eald'narche
 -- Apocalypse Nigh Final Fight
--- TODO:
---   Highly evasive. Sushi and/or Madrigal recommended.
---   Very high magic defense (e.g., Thunder IV ~65 dmg).
 -----------------------------------
 
 function onMobInitialize(mob)
@@ -12,6 +9,11 @@ function onMobInitialize(mob)
     mob:setMobMod(tpz.mobMod.TELEPORT_START, 988)
     mob:setMobMod(tpz.mobMod.TELEPORT_END, 989)
     mob:setMobMod(tpz.mobMod.TELEPORT_TYPE, 1)
+    mob:setMod(tpz.mod.MDEF, 50);
+end
+
+function onMobSpawn(mob)
+    mob:addMod(tpz.mod.EVA, 50)
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/Empyreal_Paradox/mobs/Ealdnarche.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Ealdnarche.lua
@@ -3,7 +3,6 @@
 --  Mob: Eald'narche
 -- Apocalypse Nigh Final Fight
 -- TODO:
---   Initially facing the wrong direction.
 --   Highly evasive. Sushi and/or Madrigal recommended.
 --   Very high magic defense (e.g., Thunder IV ~65 dmg).
 -----------------------------------

--- a/scripts/zones/Empyreal_Paradox/mobs/Kamlanaut.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Kamlanaut.lua
@@ -5,8 +5,37 @@
 -- TODO:
 --   Can perform three TP attacks upon reaching 100%+ TP, giving very little rest for healers.
 --   He can do 3 Great Wheels in a row, devastating any melee jobs in range.
---   When using enspell TP moves, nukes of the matching element heal him.
 -----------------------------------
+require("scripts/globals/status")
+-----------------------------------
+
+local skillToAbsorb =
+{
+    [823] = tpz.mod.FIRE_ABSORB,  -- fire_blade
+    [824] = tpz.mod.ICE_ABSORB,   -- frost_blade
+    [825] = tpz.mod.WIND_ABSORB,  -- wind_blade2
+    [826] = tpz.mod.EARTH_ABSORB, -- earth_blade
+    [827] = tpz.mod.LTNG_ABSORB,  -- lightning_blade
+    [828] = tpz.mod.WATER_ABSORB, -- water_blade
+}
+
+function onMobWeaponSkill(target, mob, skill)
+    -- when uses an en-spell weapon skill, absorb damage of that element type
+    local absorbId = skillToAbsorb[skill:getID()]
+
+    if absorbId then
+        -- remove previous absorb mod, if set
+        local previousAbsorb = mob:getLocalVar("currentAbsorb")
+
+        if previousAbsorb > 0 then
+            mob:setMod(previousAbsorb, 0)
+        end
+
+        -- add new absorb mod
+        mob:setLocalVar("currentAbsorb", absorbId)
+        mob:setMod(absorbId, 100)
+    end
+end
 
 function onMobDeath(mob, player, isKiller)
 end

--- a/scripts/zones/Empyreal_Paradox/mobs/Kamlanaut.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Kamlanaut.lua
@@ -3,7 +3,6 @@
 --  Mob: Kam'lanaut
 -- Apocalypse Nigh Final Fight
 -- TODO:
---   Initially facing the wrong direction.
 --   Can perform three TP attacks upon reaching 100%+ TP, giving very little rest for healers.
 --   He can do 3 Great Wheels in a row, devastating any melee jobs in range.
 --   When using enspell TP moves, nukes of the matching element heal him.

--- a/scripts/zones/Empyreal_Paradox/mobs/Kamlanaut.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Kamlanaut.lua
@@ -16,6 +16,19 @@ local skillToAbsorb =
     [828] = tpz.mod.WATER_ABSORB, -- water_blade
 }
 
+function onMobEngaged(mob, target)
+    mob:setLocalVar("nextEnSkill", os.time() + 10)
+end
+
+function onMobFight(mob, target)
+    if os.time() > mob:getLocalVar("nextEnSkill") then
+        local skill = math.random(823, 828)
+        mob:setLocalVar("currentTP", mob:getTP())
+        mob:useMobAbility(skill)
+        mob:setLocalVar("nextEnSkill", os.time() + 30)
+    end
+end
+
 function onMobWeaponSkill(target, mob, skill)
     local skillId = skill:getID()
     local absorbId = skillToAbsorb[skillId]
@@ -36,6 +49,9 @@ function onMobWeaponSkill(target, mob, skill)
         mob:setLocalVar("currentAbsorb", absorbId)
         mob:setMod(absorbId, 100)
 
+        -- return TP
+        mob:setTP(mob:getLocalVar("currentTP"))
+
     else
         -- ----------------------------------------------------------------------
         -- when using Light Blade or Great Wheel, can do up to three WS in a row
@@ -51,7 +67,7 @@ function onMobWeaponSkill(target, mob, skill)
 
         if wsCount < wsMax then
             mob:setLocalVar("wsCount", wsCount + 1)
-            mob:useMobAbility(skillId)
+            mob:setTP(1000)
         else
             mob:setLocalVar("wsCount", 0)
         end

--- a/scripts/zones/Empyreal_Paradox/mobs/Kamlanaut.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Kamlanaut.lua
@@ -2,9 +2,6 @@
 -- Area: Emperial Paradox
 --  Mob: Kam'lanaut
 -- Apocalypse Nigh Final Fight
--- TODO:
---   Can perform three TP attacks upon reaching 100%+ TP, giving very little rest for healers.
---   He can do 3 Great Wheels in a row, devastating any melee jobs in range.
 -----------------------------------
 require("scripts/globals/status")
 -----------------------------------
@@ -20,10 +17,14 @@ local skillToAbsorb =
 }
 
 function onMobWeaponSkill(target, mob, skill)
-    -- when uses an en-spell weapon skill, absorb damage of that element type
-    local absorbId = skillToAbsorb[skill:getID()]
+    local skillId = skill:getID()
+    local absorbId = skillToAbsorb[skillId]
 
     if absorbId then
+        -- ----------------------------------------------------------------------
+        -- when using en-spell weapon skill, absorb damage of that element type
+        -- ----------------------------------------------------------------------
+
         -- remove previous absorb mod, if set
         local previousAbsorb = mob:getLocalVar("currentAbsorb")
 
@@ -34,6 +35,26 @@ function onMobWeaponSkill(target, mob, skill)
         -- add new absorb mod
         mob:setLocalVar("currentAbsorb", absorbId)
         mob:setMod(absorbId, 100)
+
+    else
+        -- ----------------------------------------------------------------------
+        -- when using Light Blade or Great Wheel, can do up to three WS in a row
+        -- ----------------------------------------------------------------------
+
+        local wsCount = mob:getLocalVar("wsCount")
+        local wsMax = mob:getLocalVar("wsMax")
+
+        if wsCount == 0 then
+            wsMax = math.random(0, 2)
+            mob:setLocalVar("wsMax", wsMax)
+        end
+
+        if wsCount < wsMax then
+            mob:setLocalVar("wsCount", wsCount + 1)
+            mob:useMobAbility(skillId)
+        else
+            mob:setLocalVar("wsCount", 0)
+        end
     end
 end
 

--- a/scripts/zones/Stellar_Fulcrum/mobs/Kamlanaut.lua
+++ b/scripts/zones/Stellar_Fulcrum/mobs/Kamlanaut.lua
@@ -3,34 +3,55 @@
 --  Mob: Kam'lanaut
 -- Zilart Mission 8 BCNM Fight
 -----------------------------------
-require("scripts/globals/titles")
 require("scripts/globals/status")
-require("scripts/globals/magic")
-
-local blades = {823, 826, 828, 825, 824, 827}
+require("scripts/globals/titles")
 -----------------------------------
 
+local skillToAbsorb =
+{
+    [823] = tpz.mod.FIRE_ABSORB,  -- fire_blade
+    [824] = tpz.mod.ICE_ABSORB,   -- frost_blade
+    [825] = tpz.mod.WIND_ABSORB,  -- wind_blade2
+    [826] = tpz.mod.EARTH_ABSORB, -- earth_blade
+    [827] = tpz.mod.LTNG_ABSORB,  -- lightning_blade
+    [828] = tpz.mod.WATER_ABSORB, -- water_blade
+}
+
+function onMobEngaged(mob, target)
+    mob:setLocalVar("nextEnSkill", os.time() + 10)
+end
+
 function onMobFight(mob, target)
-
-    local changeTime = mob:getLocalVar("changeTime")
-    local element = mob:getLocalVar("element")
-
-    if (changeTime == 0) then
-        mob:setLocalVar("changeTime", math.random(1, 3)*15)
-        return
+    if os.time() > mob:getLocalVar("nextEnSkill") then
+        local skill = math.random(823, 828)
+        mob:setLocalVar("currentTP", mob:getTP())
+        mob:useMobAbility(skill)
+        mob:setLocalVar("nextEnSkill", os.time() + 20)
     end
-    if (mob:getBattleTime() >= changeTime) then
-        local newelement = element
-        while (newelement == element) do
-            newelement = math.random(1, 6)
+end
+
+function onMobWeaponSkill(target, mob, skill)
+    local skillId = skill:getID()
+    local absorbId = skillToAbsorb[skillId]
+
+    if absorbId then
+        -- ----------------------------------------------------------------------
+        -- when using en-spell weapon skill, absorb damage of that element type
+        -- ----------------------------------------------------------------------
+
+        -- remove previous absorb mod, if set
+        local previousAbsorb = mob:getLocalVar("currentAbsorb")
+
+        if previousAbsorb > 0 then
+            mob:setMod(previousAbsorb, 0)
         end
-        if (element ~= 0) then
-            mob:delMod(tpz.magic.absorbMod[element], 100)
-        end
-        mob:useMobAbility(blades[newelement])
-        mob:addMod(tpz.magic.absorbMod[newelement], 100)
-        mob:setLocalVar("changeTime", mob:getBattleTime() + math.random(1, 3)*15)
-        mob:setLocalVar("element", newelement)
+
+        -- add new absorb mod
+        mob:setLocalVar("currentAbsorb", absorbId)
+        mob:setMod(absorbId, 100)
+
+        -- return TP
+        mob:setTP(mob:getLocalVar("currentTP"))
     end
 end
 

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -1594,14 +1594,8 @@ INSERT INTO `mob_skill_lists` VALUES ('Iron_Giant',350,2624);
 INSERT INTO `mob_skill_lists` VALUES ('Iron_Giant',350,2625);
 INSERT INTO `mob_skill_lists` VALUES ('Iron_Giant',350,2626);
 INSERT INTO `mob_skill_lists` VALUES ('Iron_Giant',350,2627);
-INSERT INTO `mob_skill_lists` VALUES ('Kam_lanaut',351,823);
-INSERT INTO `mob_skill_lists` VALUES ('Kam_lanaut',351,824);
-INSERT INTO `mob_skill_lists` VALUES ('Kam_lanaut',351,825);
-INSERT INTO `mob_skill_lists` VALUES ('Kam_lanaut',351,826);
-INSERT INTO `mob_skill_lists` VALUES ('Kam_lanaut',351,827);
-INSERT INTO `mob_skill_lists` VALUES ('Kam_lanaut',351,828);
-INSERT INTO `mob_skill_lists` VALUES ('Kam_lanaut',351,829);
-INSERT INTO `mob_skill_lists` VALUES ('Kam_lanaut',351,830);
+INSERT INTO `mob_skill_lists` VALUES ('Kamlanaut (Return to Delkfutt Tower)',351,829);
+INSERT INTO `mob_skill_lists` VALUES ('Kamlanaut (Return to Delkfutt Tower)',351,830);
 INSERT INTO `mob_skill_lists` VALUES ('ArkAngel-EV',352,933);
 INSERT INTO `mob_skill_lists` VALUES ('ArkAngel-EV',352,934);
 INSERT INTO `mob_skill_lists` VALUES ('ArkAngel-EV',352,942);
@@ -3596,12 +3590,6 @@ INSERT INTO `mob_skill_lists` VALUES ('Luopan',1141,3045); -- Concentric Pulse
 INSERT INTO `mob_skill_lists` VALUES ('Luopan',1141,3051); -- Mending Halation
 INSERT INTO `mob_skill_lists` VALUES ('Luopan',1141,3052); -- Radial Arcana
 INSERT INTO `mob_skill_lists` VALUES ('Bashe',1142,370); -- Baleful Gaze
-INSERT INTO `mob_skill_lists` VALUES ('Kamlanaut (Apoc Nigh)',1143,823); -- Fire Blade
-INSERT INTO `mob_skill_lists` VALUES ('Kamlanaut (Apoc Nigh)',1143,824); -- Frost Blade
-INSERT INTO `mob_skill_lists` VALUES ('Kamlanaut (Apoc Nigh)',1143,825); -- Wind Blade
-INSERT INTO `mob_skill_lists` VALUES ('Kamlanaut (Apoc Nigh)',1143,826); -- Earth Blade
-INSERT INTO `mob_skill_lists` VALUES ('Kamlanaut (Apoc Nigh)',1143,827); -- Lightning Blade
-INSERT INTO `mob_skill_lists` VALUES ('Kamlanaut (Apoc Nigh)',1143,828); -- Water Blade
 INSERT INTO `mob_skill_lists` VALUES ('Kamlanaut (Apoc Nigh)',1143,829); -- Great Wheel
 INSERT INTO `mob_skill_lists` VALUES ('Kamlanaut (Apoc Nigh)',1143,830); -- Light Blade
 INSERT INTO `mob_skill_lists` VALUES ('Ealdnarche (Apoc Nigh)',1144,985); -- Stellar Burst


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Closes #179

Follow up to #459.  Implements all remaining items I am aware of:

* Kam'lanaut and Eald'narch are now facing the battlefield entrance.
* When using an en-spell TP move, Kam'lanaut will thereafter absorb elemental damage of that element.
* When using a non-en-spell TP move, Kam'lanaut can chain up to three attacks.
* Give Eald'narch bonus EVA and MDEF.

Per convo below,

* Uses en-skills on a timer, which doesn't consume TP.
* When using TP, does not select en-skills.  Instead, can use up to three skills from its remaining list of two moves.

With these items done, I'm turning on the battlefield in bcnm.lua.  I believe this branch can now merge into release.

~~edit: Hold this PR, per additional work in conversation below~~ Ready!