### PR TITLE
Thunder Hawk and npcUtil key item option

### DIFF
--- a/scripts/globals/homepoint.lua
+++ b/scripts/globals/homepoint.lua
@@ -194,7 +194,7 @@ tpz.homepoint.onTrigger = function(player, csid, index)
         params = bit.bor(params, 0x10000) -- OR in New HP Bit Flag
     end
 
-    if player:hasKeyItem(tpz.keyItem.RHAPSODY_IN_WHITE) then
+    if player:hasKeyItem(tpz.ki.RHAPSODY_IN_WHITE) then
         -- "Rhapsody in White" key item reduces teleport fee by 80%
         params = bit.bor(params, 0x20000)
     end

--- a/scripts/globals/npc_util.lua
+++ b/scripts/globals/npc_util.lua
@@ -325,8 +325,8 @@ end
 
     Example of usage with params (all params are optional):
         npcUtil.completeQuest(player, SANDORIA, ROSEL_THE_ARMORER, {
-            item = { {640, 2}, 641 },    -- see npcUtil.giveItem for formats
-            keyItem = tpz.ki.ZERUHN_REPORT,    -- see npcUtil.giveKeyItem for formats
+            item = { {640, 2}, 641 },   -- see npcUtil.giveItem for formats
+            ki = tpz.ki.ZERUHN_REPORT,  -- see npcUtil.giveKeyItem for formats
             fame = 120,                 -- fame defaults to 30 if not set
             bayld = 500,
             gil = 200,
@@ -349,8 +349,8 @@ function npcUtil.completeQuest(player, area, quest, params)
     end
 
     -- key item(s), fame, gil, bayld, xp, and title
-    if params["keyItem"] ~= nil then
-        npcUtil.giveKeyItem(player, params["keyItem"])
+    if params["ki"] ~= nil then
+        npcUtil.giveKeyItem(player, params["ki"])
     end
 
     if params["fame"] == nil then

--- a/scripts/globals/survival_guide.lua
+++ b/scripts/globals/survival_guide.lua
@@ -116,7 +116,7 @@ tpz.survivalGuide.onTrigger = function(player)
                 param = bit.bor(param, 0x0800)
             end
 
-            if player:hasKeyItem(tpz.keyItem.RHAPSODY_IN_WHITE) then
+            if player:hasKeyItem(tpz.ki.RHAPSODY_IN_WHITE) then
                 -- "Rhapsody in White" key item reduces teleport fee by 80%
                 param = bit.bor(param, 0x2000)
             end
@@ -157,7 +157,7 @@ tpz.survivalGuide.onEventFinish = function(player, eventId, option)
                 -- If the player has the rhapsody in white, the cost is 10% of original gil or 20% of original tabs.
                 -- GIL: 1000 -> 200
                 -- TABS: 100 -> 10
-                if player:hasKeyItem(tpz.keyItem.RHAPSODY_IN_WHITE) then
+                if player:hasKeyItem(tpz.ki.RHAPSODY_IN_WHITE) then
                     teleportCostGil = teleportCostGil * .2
                     teleportCostTabs = teleportCostTabs * .2
                 end

--- a/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20c.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20c.lua
@@ -9,8 +9,8 @@ local ID = require("scripts/zones/Alzadaal_Undersea_Ruins/IDs")
 -----------------------------------
 
 function onTrigger(player, npc)
-    if player:hasKeyItem(tpz.keyItem.NYZUL_ISLE_ASSAULT_ORDERS) then
-        player:messageSpecial(ID.text.CANNOT_LEAVE, tpz.keyItem.NYZUL_ISLE_ASSAULT_ORDERS)
+    if player:hasKeyItem(tpz.ki.NYZUL_ISLE_ASSAULT_ORDERS) then
+        player:messageSpecial(ID.text.CANNOT_LEAVE, tpz.ki.NYZUL_ISLE_ASSAULT_ORDERS)
     elseif player:getZPos() >= 77 and player:getZPos() <= 79 then
         player:messageSpecial(ID.text.STAGING_POINT_NYZUL)
         player:messageSpecial(ID.text.IMPERIAL_CONTROL)

--- a/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20d.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20d.lua
@@ -8,8 +8,8 @@ local ID = require("scripts/zones/Alzadaal_Undersea_Ruins/IDs")
 -----------------------------------
 
 function onTrigger(player, npc)
-    if player:hasKeyItem(tpz.keyItem.NYZUL_ISLE_ASSAULT_ORDERS) then
-        player:messageSpecial(ID.text.CANNOT_LEAVE, tpz.keyItem.NYZUL_ISLE_ASSAULT_ORDERS)
+    if player:hasKeyItem(tpz.ki.NYZUL_ISLE_ASSAULT_ORDERS) then
+        player:messageSpecial(ID.text.CANNOT_LEAVE, tpz.ki.NYZUL_ISLE_ASSAULT_ORDERS)
     elseif player:getZPos() >= -39.1 and player:getZPos() <= -37 then
         player:messageSpecial(ID.text.STAGING_POINT_NYZUL)
         player:messageSpecial(ID.text.IMPERIAL_CONTROL)

--- a/scripts/zones/Bastok_Markets/npcs/Degenhard.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Degenhard.lua
@@ -35,7 +35,7 @@ function onEventFinish(player, csid, option)
     elseif csid == 256 then
         player:addQuest(BASTOK, tpz.quest.id.bastok.THE_BARE_BONES)
     elseif csid == 258 then
-        if (npcUtil.completeQuest(player, BASTOK, tpz.quest.id.bastok.THE_BARE_BONES, {keyItem = tpz.ki.MAP_OF_THE_DANGRUF_WADI, fame = 60})) then
+        if (npcUtil.completeQuest(player, BASTOK, tpz.quest.id.bastok.THE_BARE_BONES, {ki = tpz.ki.MAP_OF_THE_DANGRUF_WADI, fame = 60})) then
             player:confirmTrade()
         end
     end

--- a/scripts/zones/Batallia_Downs_[S]/npcs/Thorben.lua
+++ b/scripts/zones/Batallia_Downs_[S]/npcs/Thorben.lua
@@ -48,7 +48,7 @@ function onEventFinish(player, csid, option)
             })
         else
             npcUtil.completeQuest(player, CRYSTAL_WAR, tpz.quest.id.crystalWar.LOST_IN_TRANSLOCATION, {
-                keyItem = tpz.ki.MAP_OF_GRAUBERG,
+                ki = tpz.ki.MAP_OF_GRAUBERG,
                 var = "lostInTranslocationCS"
             })
         end

--- a/scripts/zones/Caedarva_Mire/npcs/_270.lua
+++ b/scripts/zones/Caedarva_Mire/npcs/_270.lua
@@ -11,8 +11,8 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-    if player:hasKeyItem(tpz.keyItem.LEUJAOAM_ASSAULT_ORDERS) then
-        player:messageSpecial(ID.text.CANNOT_LEAVE, tpz.keyItem.LEUJAOAM_ASSAULT_ORDERS)
+    if player:hasKeyItem(tpz.ki.LEUJAOAM_ASSAULT_ORDERS) then
+        player:messageSpecial(ID.text.CANNOT_LEAVE, tpz.ki.LEUJAOAM_ASSAULT_ORDERS)
     elseif player:getZPos() <= -438 and player:getZPos() >= -440 then
         player:messageSpecial(ID.text.STAGING_POINT_AZOUPH)
         player:messageSpecial(ID.text.IMPERIAL_CONTROL)

--- a/scripts/zones/Caedarva_Mire/npcs/_271.lua
+++ b/scripts/zones/Caedarva_Mire/npcs/_271.lua
@@ -11,8 +11,8 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-    if player:hasKeyItem(tpz.keyItem.PERIQIA_ASSAULT_ORDERS) then
-        player:messageSpecial(ID.text.CANNOT_LEAVE, tpz.keyItem.PERIQIA_ASSAULT_ORDERS)
+    if player:hasKeyItem(tpz.ki.PERIQIA_ASSAULT_ORDERS) then
+        player:messageSpecial(ID.text.CANNOT_LEAVE, tpz.ki.PERIQIA_ASSAULT_ORDERS)
     elseif player:getZPos() <= -79.1 and player:getZPos() >= -82 then
         player:messageSpecial(ID.text.STAGING_POINT_DVUCCA)
         player:messageSpecial(ID.text.IMPERIAL_CONTROL)

--- a/scripts/zones/Lower_Jeuno/npcs/Ghebi_Damomohe.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Ghebi_Damomohe.lua
@@ -62,12 +62,12 @@ function onEventFinish(player, csid, option)
         player:addQuest(JEUNO, tpz.quest.id.jeuno.TENSHODO_MEMBERSHIP)
     elseif csid == 107 then
         -- Finish Quest: Tenshodo Membership (Application Form)
-        if npcUtil.completeQuest(player, JEUNO, tpz.quest.id.jeuno.TENSHODO_MEMBERSHIP, { item=548, title=tpz.title.TENSHODO_MEMBER, keyItem=tpz.ki.TENSHODO_MEMBERS_CARD }) then
+        if npcUtil.completeQuest(player, JEUNO, tpz.quest.id.jeuno.TENSHODO_MEMBERSHIP, { item=548, title=tpz.title.TENSHODO_MEMBER, ki=tpz.ki.TENSHODO_MEMBERS_CARD }) then
             player:delKeyItem(tpz.ki.TENSHODO_APPLICATION_FORM)
         end
     elseif csid == 108 then
         -- Finish Quest: Tenshodo Membership (Invitation)
-        if npcUtil.completeQuest(player, JEUNO, tpz.quest.id.jeuno.TENSHODO_MEMBERSHIP, { item=548, title=tpz.title.TENSHODO_MEMBER, keyItem=tpz.ki.TENSHODO_MEMBERS_CARD }) then
+        if npcUtil.completeQuest(player, JEUNO, tpz.quest.id.jeuno.TENSHODO_MEMBERSHIP, { item=548, title=tpz.title.TENSHODO_MEMBER, ki=tpz.ki.TENSHODO_MEMBERS_CARD }) then
             player:confirmTrade()
             player:delKeyItem(tpz.ki.TENSHODO_APPLICATION_FORM)
         end

--- a/scripts/zones/Lower_Jeuno/npcs/Zauko.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Zauko.lua
@@ -109,7 +109,7 @@ function onEventFinish(player, csid, option)
             -- repeat victory. offer membership card.
             params.fame = 15
             if (option == 1) then
-                params.keyItem = tpz.ki.LAMP_LIGHTERS_MEMBERSHIP_CARD
+                params.ki = tpz.ki.LAMP_LIGHTERS_MEMBERSHIP_CARD
             end
         end
         npcUtil.completeQuest(player, JEUNO, tpz.quest.id.jeuno.COMMUNITY_SERVICE, params)

--- a/scripts/zones/Mhaura/npcs/Celestina.lua
+++ b/scripts/zones/Mhaura/npcs/Celestina.lua
@@ -51,7 +51,7 @@ function onEventFinish(player, csid, option)
     elseif (csid == 127) then
         player:confirmTrade()
         npcUtil.completeQuest(player, OTHER_AREAS_LOG, tpz.quest.id.otherAreas.THE_SAND_CHARM, {
-            keyItem = tpz.ki.MAP_OF_BOSTAUNIEUX_OUBLIETTE,
+            ki = tpz.ki.MAP_OF_BOSTAUNIEUX_OUBLIETTE,
             fame_area = MHAURA,
             var = "theSandCharmVar"
         })

--- a/scripts/zones/Northern_San_dOria/npcs/Aurege.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Aurege.lua
@@ -40,6 +40,6 @@ function onEventFinish(player, csid, option)
     if csid == 521 and player:getQuestStatus(SANDORIA, tpz.quest.id.sandoria.EXIT_THE_GAMBLER) == QUEST_AVAILABLE then
         player:addQuest(SANDORIA, tpz.quest.id.sandoria.EXIT_THE_GAMBLER)
     elseif csid == 516 then
-        npcUtil.completeQuest(player, SANDORIA, tpz.quest.id.sandoria.EXIT_THE_GAMBLER, {keyItem = tpz.ki.MAP_OF_KING_RANPERRES_TOMB, title = tpz.title.DAYBREAK_GAMBLER, xp = 2000})
+        npcUtil.completeQuest(player, SANDORIA, tpz.quest.id.sandoria.EXIT_THE_GAMBLER, {ki = tpz.ki.MAP_OF_KING_RANPERRES_TOMB, title = tpz.title.DAYBREAK_GAMBLER, xp = 2000})
     end
 end

--- a/scripts/zones/Windurst_Walls/npcs/Shantotto.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Shantotto.lua
@@ -21,7 +21,7 @@ function onTrade(player, npc, trade)
 
     if wsQuestEvent ~= nil then
         if wsQuestEvent == 448 then
-            player:startEvent(wsQuestEvent, nil, nil, tpz.keyItem.ANNALS_OF_TRUTH)
+            player:startEvent(wsQuestEvent, nil, nil, tpz.ki.ANNALS_OF_TRUTH)
         else
             player:startEvent(wsQuestEvent)
         end

--- a/scripts/zones/Windurst_Waters/npcs/Angelica.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Angelica.lua
@@ -104,7 +104,7 @@ function onEventFinish(player, csid, option)
     -- complete quest
     elseif csid == 96 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.A_POSE_BY_ANY_OTHER_NAME, {
         item = 206, -- copy_of_ancient_blood
-        keyItem = tpz.ki.ANGELICAS_AUTOGRAPH,
+        ki = tpz.ki.ANGELICAS_AUTOGRAPH,
         fame = 75,
         title = tpz.title.SUPER_MODEL,
         var = {"QuestAPoseByOtherName_time", "QuestAPoseByOtherName_equip", "QuestAPoseByOtherName_prog"},

--- a/scripts/zones/Windurst_Woods/npcs/Ibwam.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Ibwam.lua
@@ -83,7 +83,7 @@ function onEventFinish(player, csid, option)
         player:addQuest(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT)
         player:setCharVar("WildcatWindurst", 0)
         npcUtil.giveKeyItem(player, tpz.ki.GREEN_SENTINEL_BADGE)
-    elseif csid == 739 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT, {fame=150, keyItem=tpz.ki.GREEN_INVITATION_CARD, var="WildcatWindurst"}) then
+    elseif csid == 739 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT, {fame=150, ki=tpz.ki.GREEN_INVITATION_CARD, var="WildcatWindurst"}) then
         player:delKeyItem(tpz.ki.GREEN_SENTINEL_BADGE)
         player:messageSpecial(ID.text.KEYITEM_LOST, tpz.ki.GREEN_SENTINEL_BADGE)
     elseif csid == 794 then


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Fixes #1292 

Rather than fixing Thunder Hawk's npcUtil option from **ki** to **keyItem** (See #1292), I decided to go the other way with the fix, and rename the option to **ki** for consistency.  Updated all references in codebase.

Also switched some references to the short-hand **tpz.ki**

