### PR TITLE
fix typo in promathia phase 2 hp/mp

### DIFF
--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -1237,7 +1237,7 @@ INSERT INTO `mob_groups` VALUES (32,5536,35,'Ixaern_drgs_Wynav',0,128,0,0,0,78,7
 -- ------------------------------------------------------------
 
 INSERT INTO `mob_groups` VALUES (1,3205,36,'Promathia',0,128,0,8000,0,80,80,0);
-INSERT INTO `mob_groups` VALUES (2,5106,36,'Promathia',0,128,0,0,12000,80,80,0);
+INSERT INTO `mob_groups` VALUES (2,5106,36,'Promathia',0,128,0,12000,0,80,80,0);
 INSERT INTO `mob_groups` VALUES (3,6640,36,'Kamlanaut',0,128,0,10000,1500,78,78,0);
 INSERT INTO `mob_groups` VALUES (4,6641,36,'Ealdnarche',0,128,0,5000,2500,78,78,0);
 INSERT INTO `mob_groups` VALUES (5,4820,36,'Metus',0,128,0,0,20000,125,125,0);


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Phase 2 Promathia being given 12k MP instead of 12k HP.
https://www.bg-wiki.com/bg/Promathia
https://ffxiclopedia.fandom.com/wiki/Promathia

From conversation [here](https://discordapp.com/channels/639659267003252746/729967796724957244/759591581782638594)