### PR TITLE
Rewrite application of GoV prowess bonus effects

### DIFF
--- a/scripts/globals/regimes.lua
+++ b/scripts/globals/regimes.lua
@@ -976,6 +976,64 @@ local function getFinishOpts(regimeType)
     end
     return out
 end
+
+-- first time an effect is applied, use basePower
+-- each additional time an effect is applied, use addPower
+-- can stack each effect up to maxStack times, per https://ffxiclopedia.fandom.com/wiki/Grounds_of_Valor#Prowesses
+local prowessData =
+{
+    {effect = tpz.effect.PROWESS_CASKET_RATE,   basePower = 4,   addPower = 4,   maxStack = 5  },
+    {effect = tpz.effect.PROWESS_SKILL_RATE,    basePower = 4,   addPower = 4,   maxStack = 11 },
+    {effect = tpz.effect.PROWESS_CRYSTAL_YIELD, basePower = 4,   addPower = 4,   maxStack = 5  },
+    {effect = tpz.effect.PROWESS_TH,            basePower = 1,   addPower = 1,   maxStack = 3  },
+    {effect = tpz.effect.PROWESS_ATTACK_SPEED,  basePower = 400, addPower = 400, maxStack = 4  },
+    {effect = tpz.effect.PROWESS_HP_MP,         basePower = 3,   addPower = 1,   maxStack = 11 },
+    {effect = tpz.effect.PROWESS_ACC_RACC,      basePower = 4,   addPower = 4,   maxStack = 11 },
+    {effect = tpz.effect.PROWESS_ATT_RATT,      basePower = 4,   addPower = 4,   maxStack = 11 },
+    {effect = tpz.effect.PROWESS_MACC_MATK,     basePower = 4,   addPower = 4,   maxStack = 10 },
+    {effect = tpz.effect.PROWESS_CURE_POTENCY,  basePower = 4,   addPower = 4,   maxStack = 5  },
+    {effect = tpz.effect.PROWESS_WS_DMG,        basePower = 2,   addPower = 2,   maxStack = 5  },
+    {effect = tpz.effect.PROWESS_KILLER,        basePower = 4,   addPower = 4,   maxStack = 2  },
+}
+
+local function addGovProwessBonusEffect(player)
+    -- make a table of prowesses that are not yet maxed
+    local availableProwesses = {}
+
+    for i = 1, #prowessData do
+        local p = prowessData[i]
+        local e = player:getStatusEffect(p.effect)
+
+        if not e or e:getPower() < (p.basePower + p.addPower * (p.maxStack - 1)) then
+            table.insert(availableProwesses, p)
+        end
+    end
+
+    -- pick one and apply
+    if #availableProwesses > 0 then
+        local p = availableProwesses[math.random(#availableProwesses)]
+        local e = player:getStatusEffect(p.effect)
+
+        -- get current power
+        local power = 0
+        if e then
+            power = e:getPower()
+            player:delStatusEffectSilent(p.effect)
+        end
+
+        -- add either basePower or addPower
+        if power == 0 then
+            power = p.basePower
+        else
+            power = power + p.addPower
+        end
+
+        -- set effect
+        player:addStatusEffectEx(p.effect, 0, power, 0, 0)
+        player:messageBasic(p.effect - 168)
+    end
+end
+
 -- function made global to be called by hunts.lua
 tpz.regime.clearRegimeVars = function(player)
     player:setCharVar("[regime]type", 0)
@@ -1297,52 +1355,7 @@ tpz.regime.checkRegime = function(player, mob, regimeId, index, regimeType)
 
     -- prowess buffs from completing Grounds regimes
     if regimeType == tpz.regime.type.GROUNDS then
-        local prowess = math.random(tpz.effect.PROWESS_CASKET_RATE, tpz.effect.PROWESS_KILLER)
-        local power = 0
-
-        -- existing buff
-        if player:hasStatusEffect(prowess) then
-
-            -- stack up to 11 times
-            if prowess == tpz.effect.PROWESS_TH then
-                power = utils.clamp(player:getStatusEffect(prowess):getPower() + 1, 0, 11)
-            elseif prowess == tpz.effect.PROWESS_ATTACK_SPEED then
-                power = 400
-            elseif prowess == tpz.effect.PROWESS_HP_MP then
-                power = utils.clamp(player:getStatusEffect(prowess):getPower() + 1, 0, 14)
-            elseif prowess == tpz.effect.PROWESS_WS_DMG then
-                power = utils.clamp(player:getStatusEffect(prowess):getPower() + 2, 0, 22)
-            else
-                power = utils.clamp(player:getStatusEffect(prowess):getPower() + 4, 0, 44)
-            end
-
-            -- reapply buff
-            player:delStatusEffectSilent(prowess)
-            player:addStatusEffectEx(prowess, 0, power, 0, 0)
-
-            -- message (prowess boosted)
-            player:messageBasic(prowess - 152)
-
-        -- new buff
-        else
-            if prowess == tpz.effect.PROWESS_TH then
-                power = 1
-            elseif prowess == tpz.effect.PROWESS_ATTACK_SPEED then
-                power = 400
-            elseif prowess == tpz.effect.PROWESS_HP_MP then
-                power = 3
-            elseif prowess == tpz.effect.PROWESS_WS_DMG then
-                power = 2
-            else
-                power = 4
-            end
-
-            -- apply buff
-            player:addStatusEffectEx(prowess, 0, power, 0, 0)
-
-            -- message (prowess attained)
-            player:messageBasic(prowess - 168)
-        end
+        addGovProwessBonusEffect(player)
 
         -- repeat clears bonus
         if player:hasStatusEffect(tpz.effect.PROWESS) then
@@ -1360,9 +1373,7 @@ tpz.regime.checkRegime = function(player, mob, regimeId, index, regimeType)
             -- keep track of number of clears
             player:addStatusEffect(tpz.effect.PROWESS, 1, 0, 0)
         end
-
     end
-    -- done with prowess buffs
 
     -- award gil and tabs once per day, or at every page completion if REGIME_WAIT is 0 in settings.lua
     local vanadielEpoch = vanaDay()

--- a/scripts/globals/regimes.lua
+++ b/scripts/globals/regimes.lua
@@ -982,18 +982,18 @@ end
 -- can stack each effect up to maxStack times, per https://ffxiclopedia.fandom.com/wiki/Grounds_of_Valor#Prowesses
 local prowessData =
 {
-    {effect = tpz.effect.PROWESS_CASKET_RATE,   basePower = 4,   addPower = 4,   maxStack = 5  },
-    {effect = tpz.effect.PROWESS_SKILL_RATE,    basePower = 4,   addPower = 4,   maxStack = 11 },
-    {effect = tpz.effect.PROWESS_CRYSTAL_YIELD, basePower = 4,   addPower = 4,   maxStack = 5  },
-    {effect = tpz.effect.PROWESS_TH,            basePower = 1,   addPower = 1,   maxStack = 3  },
-    {effect = tpz.effect.PROWESS_ATTACK_SPEED,  basePower = 400, addPower = 400, maxStack = 4  },
-    {effect = tpz.effect.PROWESS_HP_MP,         basePower = 3,   addPower = 1,   maxStack = 11 },
-    {effect = tpz.effect.PROWESS_ACC_RACC,      basePower = 4,   addPower = 4,   maxStack = 11 },
-    {effect = tpz.effect.PROWESS_ATT_RATT,      basePower = 4,   addPower = 4,   maxStack = 11 },
-    {effect = tpz.effect.PROWESS_MACC_MATK,     basePower = 4,   addPower = 4,   maxStack = 10 },
-    {effect = tpz.effect.PROWESS_CURE_POTENCY,  basePower = 4,   addPower = 4,   maxStack = 5  },
-    {effect = tpz.effect.PROWESS_WS_DMG,        basePower = 2,   addPower = 2,   maxStack = 5  },
-    {effect = tpz.effect.PROWESS_KILLER,        basePower = 4,   addPower = 4,   maxStack = 2  },
+    { effect = tpz.effect.PROWESS_CASKET_RATE,   basePower = 4,   addPower = 4,   maxStack = 5  },
+    { effect = tpz.effect.PROWESS_SKILL_RATE,    basePower = 4,   addPower = 4,   maxStack = 11 },
+    { effect = tpz.effect.PROWESS_CRYSTAL_YIELD, basePower = 4,   addPower = 4,   maxStack = 5  },
+    { effect = tpz.effect.PROWESS_TH,            basePower = 1,   addPower = 1,   maxStack = 3  },
+    { effect = tpz.effect.PROWESS_ATTACK_SPEED,  basePower = 400, addPower = 400, maxStack = 4  },
+    { effect = tpz.effect.PROWESS_HP_MP,         basePower = 3,   addPower = 1,   maxStack = 11 },
+    { effect = tpz.effect.PROWESS_ACC_RACC,      basePower = 4,   addPower = 4,   maxStack = 11 },
+    { effect = tpz.effect.PROWESS_ATT_RATT,      basePower = 4,   addPower = 4,   maxStack = 11 },
+    { effect = tpz.effect.PROWESS_MACC_MATK,     basePower = 4,   addPower = 4,   maxStack = 10 },
+    { effect = tpz.effect.PROWESS_CURE_POTENCY,  basePower = 4,   addPower = 4,   maxStack = 5  },
+    { effect = tpz.effect.PROWESS_WS_DMG,        basePower = 2,   addPower = 2,   maxStack = 5  },
+    { effect = tpz.effect.PROWESS_KILLER,        basePower = 4,   addPower = 4,   maxStack = 2  },
 }
 
 local function addGovProwessBonusEffect(player)

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -791,7 +791,7 @@ tpz.effect =
     -- GoV Prowess bonus effects, real effect at ID 474
     PROWESS_CASKET_RATE      = 777, -- (Unimplemented)
     PROWESS_SKILL_RATE       = 778, -- (Unimplemented)
-    PROWESS_CRYSTAL_YEILD    = 779, -- (Unimplemented)
+    PROWESS_CRYSTAL_YIELD    = 779, -- (Unimplemented)
     PROWESS_TH               = 780, -- +1 per tier
     PROWESS_ATTACK_SPEED     = 781, -- *flat 4% for now
     PROWESS_HP_MP            = 782, -- Base 3% and another 1% per tier.

--- a/src/map/status_effect.h
+++ b/src/map/status_effect.h
@@ -696,7 +696,7 @@ enum EFFECT
     // GoV Prowess bonus effects, real effect at ID 474
     EFFECT_PROWESS_CASKET_RATE      = 777, // (Unimplemented)
     EFFECT_PROWESS_SKILL_RATE       = 778, // (Unimplemented)
-    EFFECT_PROWESS_CRYSTAL_YEILD    = 779, // (Unimplemented)
+    EFFECT_PROWESS_CRYSTAL_YIELD    = 779, // (Unimplemented)
     EFFECT_PROWESS_TH               = 780, // +1 per tier
     EFFECT_PROWESS_ATTACK_SPEED     = 781, // *flat 4% for now
     EFFECT_PROWESS_HP_MP            = 782, // Base 3% and another 1% per tier.
@@ -721,7 +721,7 @@ enum EFFECT
     EFFECT_DYNAMIS                  = 800,
     EFFECT_MEDITATE                 = 801, // Dummy effect for SAM Meditate JA
     EFFECT_ELEMENTALRES_DOWN        = 802, // Elemental resistance down
-    EFFECT_FULL_SPEED_AHEAD         = 803, // Used to track Full Speed Ahead quest minigame 
+    EFFECT_FULL_SPEED_AHEAD         = 803, // Used to track Full Speed Ahead quest minigame
     // EFFECT_PLACEHOLDER           = 804  // Description
     // 804-1022
     // EFFECT_PLACEHOLDER           = 1023 // The client dat file seems to have only this many "slots", results of exceeding that are untested.


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

* Correct a misspelling in EFFECT_PROWESS_CRYSTAL_YIELD
* Table prowess buffs.  Each buff has its own maximum stack size. [Fixes #640]

I tested this by:
1. Going to Korroloka tunnel, taking page 2 (Seeker and Combats), and putting the page on repeat.
2. Adding in some temporary code so that I'd complete the page on every kill.
3. Killing bats, and getting a prowess buff on each completion, until I stopped getting buffed.
4. Checking actual power of each prowess effects, against expected max power. All values matched.
5. Removing the temporary code from step 2.
