### PR TITLE
Fixed "Crying over Onions" blocking Nanaa Mihgo

### DIFF
--- a/scripts/zones/Port_Windurst/npcs/Kohlo-Lakolo.lua
+++ b/scripts/zones/Port_Windurst/npcs/Kohlo-Lakolo.lua
@@ -9,6 +9,7 @@
 -- Crying Over Onions,
 -- Wild Card,
 -- The Promise
+-- !pos -26.8 -6 190 240
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/quests")
@@ -47,7 +48,7 @@ function onTrigger(player, npc)
         player:startEvent(368)
     elseif
         KnowOnesOnions == QUEST_AVAILABLE and TruthJusticeOnionWay == QUEST_COMPLETED and
-        player:getMainLvl() >= 5 and player:getLocalVar('TruthZone') == 0  and Fame >=1
+        player:getMainLvl() >= 5 and player:getLocalVar('TruthZone') == 0 and Fame >=1
     then
         player:startEvent(391, 0, 4387)
     elseif KnowOnesOnions == QUEST_ACCEPTED and Level >= 5 and player:getCharVar("KnowOnesOnions") == 2 then
@@ -57,18 +58,18 @@ function onTrigger(player, npc)
         player:getLocalVar("KnowOneOnionZone") == 0 and Fame >=2
     then
         player:startEvent(413)
-    elseif InspectorsGadget == QUEST_ACCEPTED  and player:hasKeyItem(tpz.ki.FAKE_MOUSTACHE) then
+    elseif InspectorsGadget == QUEST_ACCEPTED and player:hasKeyItem(tpz.ki.FAKE_MOUSTACHE) then
         player:startEvent(421)
     elseif
         OnionRings == QUEST_AVAILABLE and InspectorsGadget == QUEST_COMPLETED and
         player:getLocalVar('InspectorsGadgetZone') == 0 and Fame >=3 and not player:hasKeyItem(tpz.ki.OLD_RING)
     then
         player:startEvent(429)
-    elseif  (OnionRings == QUEST_ACCEPTED or OnionRings == QUEST_AVAILABLE) and player:hasKeyItem(tpz.ki.OLD_RING) then
+    elseif (OnionRings == QUEST_ACCEPTED or OnionRings == QUEST_AVAILABLE) and player:hasKeyItem(tpz.ki.OLD_RING) then
         player:startEvent(430, 0, tpz.ki.OLD_RING) --TODO get correct time for quest to expire.
-    elseif  CryingOverOnions == QUEST_AVAILABLE and OnionRings == QUEST_COMPLETED and Fame >=3 then
+    elseif CryingOverOnions == QUEST_AVAILABLE and OnionRings == QUEST_COMPLETED and Fame >=3 then
         player:startEvent(496)
-    elseif CryingOverOnions == QUEST_ACCEPTED and player:getCharVar("CryingOverOnions") ==2 then
+    elseif CryingOverOnions == QUEST_ACCEPTED and player:getCharVar("CryingOverOnions") == 3 then
         player:startEvent(497)
     elseif WildCard == QUEST_ACCEPTED then
         player:startEvent(505)
@@ -78,7 +79,7 @@ function onTrigger(player, npc)
         player:startEvent(522, 0, tpz.ki.INVISIBLE_MAN_STICKER)
     elseif ThePromise == QUEST_COMPLETED then
         player:startEvent(544)
-    elseif  KnowOnesOnions == QUEST_COMPLETED then
+    elseif KnowOnesOnions == QUEST_COMPLETED then
         player:startEvent(401)
     elseif TruthJusticeOnionWay == QUEST_COMPLETED then
         player:startEvent(379)
@@ -139,7 +140,7 @@ function onEventFinish(player, csid, option)
     elseif csid == 496 then
         player:addQuest(WINDURST, tpz.quest.id.windurst.CRYING_OVER_ONIONS)
     elseif csid == 497 then
-        player:setCharVar("CryingOverOnions", 3)
+        player:setCharVar("CryingOverOnions", 4)
     elseif csid == 505 then
         player:setCharVar("WildCard", 1)
     elseif csid == 513 then

--- a/scripts/zones/Windurst_Waters/npcs/Honoi-Gomoi.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Honoi-Gomoi.lua
@@ -12,7 +12,12 @@ require("scripts/globals/titles")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if player:getCharVar("CryingOverOnions") == 1 and npcUtil.tradeHas(trade, 1149) then
+    -- Trade "Star Spinel" for "Crying over Onions" after having talked to this NPC once
+    -- and optionally talked to Nanaa Mihgo (CryingOverOnions == 2)
+    if
+        (player:getCharVar("CryingOverOnions") == 1 or player:getCharVar("CryingOverOnions") == 2) and
+        npcUtil.tradeHas(trade, 1149)
+    then
         player:startEvent(775, 0, 1149)
     end
 end
@@ -26,9 +31,15 @@ function onTrigger(player, npc)
     local wildCard          = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.WILD_CARD)
     local hatInHand         = player:getQuestStatus(WINDURST, tpz.quest.id.windurst.HAT_IN_HAND)
 
-    if player:getCurrentMission(COP) == tpz.mission.id.cop.THE_ROAD_FORKS and player:getCharVar("MEMORIES_OF_A_MAIDEN_Status") == 5 then
+    if
+        player:getCurrentMission(COP) == tpz.mission.id.cop.THE_ROAD_FORKS and
+        player:getCharVar("MEMORIES_OF_A_MAIDEN_Status") == 5
+    then
         player:startEvent(874) -- COP event
-    elseif (hatInHand == QUEST_ACCEPTED or player:getCharVar("QuestHatInHand_var2") == 1) and not testflag(player:getCharVar("QuestHatInHand_var"), 2) then
+    elseif
+        (hatInHand == QUEST_ACCEPTED or player:getCharVar("QuestHatInHand_var2") == 1) and
+        not testflag(player:getCharVar("QuestHatInHand_var"), 2)
+    then
         player:startEvent(59) -- Show Off Hat
     elseif wildCard == QUEST_COMPLETED then
         player:startEvent(783)
@@ -46,11 +57,11 @@ function onTrigger(player, npc)
         end
     elseif cryingOverOnions == QUEST_ACCEPTED then
         local cryingOverOnionsVar = player:getCharVar("CryingOverOnions")
-        if cryingOverOnionsVar == 3 then
+        if cryingOverOnionsVar == 4 then
             player:startEvent(776)
-        elseif cryingOverOnionsVar == 2 then
+        elseif cryingOverOnionsVar == 3 then
             player:startEvent(778)
-        elseif cryingOverOnionsVar == 1 then
+        elseif cryingOverOnionsVar >= 1 then
             player:startEvent(777)
         else
             player:startEvent(774, 0, 1149)
@@ -68,12 +79,17 @@ function onEventFinish(player, csid, option)
         player:setCharVar("CryingOverOnions", 1)
     elseif csid == 775 and npcUtil.giveItem(player, 13136) then
         player:confirmTrade()
-        player:setCharVar("CryingOverOnions", 2)
-    elseif csid == 776 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.CRYING_OVER_ONIONS, {fame=120, var="CryingOverOnions"}) then
+        player:setCharVar("CryingOverOnions", 3)
+    elseif csid == 776 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.CRYING_OVER_ONIONS, {
+        fame=120,
+        var="CryingOverOnions"
+    }) then
         player:needToZone(true)
     elseif csid == 780 then
         player:addQuest(WINDURST, tpz.quest.id.windurst.WILD_CARD)
-    elseif csid == 782 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.WILD_CARD, {title=tpz.title.DREAM_DWELLER, fame=135, var="WildCard"}) then
+    elseif csid == 782 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.WILD_CARD, {
+        title=tpz.title.DREAM_DWELLER, fame=135, var="WildCard"
+    }) then
         player:needToZone(true)
     elseif csid == 59 then -- Show Off Hat
         player:addCharVar("QuestHatInHand_var", 2)

--- a/scripts/zones/Windurst_Waters/npcs/Honoi-Gomoi.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Honoi-Gomoi.lua
@@ -75,25 +75,41 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
+    
+    -- "Crying over Onions"
     if csid == 774 then
         player:setCharVar("CryingOverOnions", 1)
     elseif csid == 775 and npcUtil.giveItem(player, 13136) then
         player:confirmTrade()
         player:setCharVar("CryingOverOnions", 3)
-    elseif csid == 776 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.CRYING_OVER_ONIONS, {
-        fame=120,
-        var="CryingOverOnions"
-    }) then
+    elseif
+        csid == 776 and
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.CRYING_OVER_ONIONS, {
+            fame=120,
+            var="CryingOverOnions",
+        })
+    then
         player:needToZone(true)
+
+    -- "Wild Card"
     elseif csid == 780 then
         player:addQuest(WINDURST, tpz.quest.id.windurst.WILD_CARD)
-    elseif csid == 782 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.WILD_CARD, {
-        title=tpz.title.DREAM_DWELLER, fame=135, var="WildCard"
-    }) then
+    elseif
+        csid == 782 and
+        npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.WILD_CARD, {
+            title=tpz.title.DREAM_DWELLER,
+            fame=135,
+            var="WildCard",
+        })
+    then
         player:needToZone(true)
+
+    -- "Hat in Hand"
     elseif csid == 59 then -- Show Off Hat
         player:addCharVar("QuestHatInHand_var", 2)
         player:addCharVar("QuestHatInHand_count", 1)
+
+    -- COP Misson 3-3B "Memories of a Maiden"
     elseif csid == 874 then
         player:setCharVar("MEMORIES_OF_A_MAIDEN_Status", 6)
         npcUtil.giveKeyItem(player, tpz.ki.CRACKED_MIMEO_MIRROR)

--- a/scripts/zones/Windurst_Woods/npcs/Nanaa_Mihgo.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Nanaa_Mihgo.lua
@@ -44,9 +44,24 @@ function onTrigger(player, npc)
     local job = player:getMainJob()
     local lvl = player:getMainLvl()
 
+    -- LURE OF THE WILDCAT (WINDURST 2-1)
+    -- Simply checks this NPC as talked to for the PC, should be highest priority
+    if
+        player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
+        not utils.mask.getBit(wildcatWindurst, 4)
+    then
+        player:startEvent(732)
+
+    -- CRYING OVER ONIONS (Optional dialogue)
+    -- Should be available at all times, variable gets increased to remove it from her logic to not block anything
+    elseif player:getCharVar("CryingOverOnions") == 1 then
+        player:startEvent(598)
+
     -- WINDURST 2-1: LOST FOR WORDS
-    if player:getCurrentMission(WINDURST) == tpz.mission.id.windurst.LOST_FOR_WORDS and missionStatus > 0 and
-        missionStatus < 5 then
+    elseif
+        player:getCurrentMission(WINDURST) == tpz.mission.id.windurst.LOST_FOR_WORDS and
+        missionStatus > 0 and missionStatus < 5
+    then
         if missionStatus == 1 then
             player:startEvent(165, 0, tpz.ki.LAPIS_CORAL, tpz.ki.LAPIS_MONOCLE)
         elseif missionStatus == 2 then
@@ -57,16 +72,7 @@ function onTrigger(player, npc)
             player:startEvent(170)
         end
 
-        -- LURE OF THE WILDCAT (WINDURST)
-    elseif player:getQuestStatus(WINDURST, tpz.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
-        not utils.mask.getBit(wildcatWindurst, 4) then
-        player:startEvent(732)
-
-        -- CRYING OVER ONIONS
-    elseif player:getCharVar("CryingOverOnions") == 1 then
-        player:startEvent(598)
-
-        -- THE TENSHODO SHOWDOWN
+    -- THE TENSHODO SHOWDOWN (THF AF Weapon)
     elseif job == tpz.job.THF and lvl >= AF1_QUEST_LEVEL and tenshodoShowdown == QUEST_AVAILABLE then
         player:startEvent(496) -- start quest
     elseif tenshodoShowdownCS == 1 then
@@ -76,9 +82,11 @@ function onTrigger(player, npc)
     elseif job == tpz.job.THF and lvl < AF2_QUEST_LEVEL and tenshodoShowdown == QUEST_COMPLETED then
         player:startEvent(503) -- standard dialog after
 
-        -- THICK AS THIEVES
-    elseif job == tpz.job.THF and lvl >= AF2_QUEST_LEVEL and thickAsThieves == QUEST_AVAILABLE and tenshodoShowdown ==
-        QUEST_COMPLETED then
+    -- THICK AS THIEVES (THF AF Head)
+    elseif
+        job == tpz.job.THF and lvl >= AF2_QUEST_LEVEL and
+        thickAsThieves == QUEST_AVAILABLE and tenshodoShowdown == QUEST_COMPLETED
+    then
         player:startEvent(504) -- start quest
     elseif thickAsThieves == QUEST_ACCEPTED then
         if player:hasKeyItem(tpz.ki.FIRST_SIGNED_FORGED_ENVELOPE) and
@@ -88,17 +96,20 @@ function onTrigger(player, npc)
             player:startEvent(505, 0, tpz.ki.GANG_WHEREABOUTS_NOTE) -- before completing grappling and gambling sidequests
         end
 
-        -- HITTING THE MARQUISATE
-    elseif job == tpz.job.THF and lvl >= AF3_QUEST_LEVEL and thickAsThieves == QUEST_COMPLETED and hittingTheMarquisate ==
-        QUEST_AVAILABLE then
+    -- HITTING THE MARQUISATE (THF AF Feet)
+    elseif job == tpz.job.THF and lvl >= AF3_QUEST_LEVEL and
+        thickAsThieves == QUEST_COMPLETED and hittingTheMarquisate == QUEST_AVAILABLE
+    then
         player:startEvent(512) -- start quest
     elseif hittingTheMarquisateYatnielCS == 3 and hittingTheMarquisateHagainCS == 9 then
         player:startEvent(516) -- finish first part
     elseif hittingTheMarquisateNanaaCS == 1 then
         player:startEvent(517) -- second part
 
-        -- ROCK RACKETEER
-    elseif mihgosAmigo == QUEST_COMPLETED and rockRacketeer == QUEST_AVAILABLE and player:getFameLevel(WINDURST) >= 3 then
+    -- ROCK RACKETEER (Mihgo's Amigo follow-up)
+    elseif mihgosAmigo == QUEST_COMPLETED and rockRacketeer == QUEST_AVAILABLE and
+        player:getFameLevel(WINDURST) >= 3
+    then
         if player:needToZone() then
             player:startEvent(89) -- complete
         else
@@ -111,7 +122,7 @@ function onTrigger(player, npc)
     elseif rockRacketeer == QUEST_ACCEPTED then
         player:startEvent(94) -- quest reminder
 
-        -- MIHGO'S AMIGO
+    -- MIHGO'S AMIGO
     elseif mihgosAmigo == QUEST_AVAILABLE then
         if player:getQuestStatus(WINDURST, tpz.quest.id.windurst.CRYING_OVER_ONIONS) == QUEST_AVAILABLE then
             player:startEvent(81) -- Start Quest "Mihgo's Amigo" with quest "Crying Over Onions" Activated
@@ -121,7 +132,7 @@ function onTrigger(player, npc)
     elseif mihgosAmigo == QUEST_ACCEPTED then
         player:startEvent(82)
 
-        -- STANDARD DIALOG
+    -- STANDARD DIALOG
     elseif rockRacketeer == QUEST_COMPLETED then
         player:startEvent(99) -- new dialog after Rock Racketeer
     elseif mihgosAmigo == QUEST_COMPLETED then
@@ -146,17 +157,21 @@ function onEventFinish(player, csid, option)
         player:delKeyItem(tpz.ki.LAPIS_CORAL)
         npcUtil.giveKeyItem(player, tpz.ki.HIDEOUT_KEY)
 
-        -- LURE OF THE WILDCAT (WINDURST)
+    -- LURE OF THE WILDCAT (WINDURST)
     elseif csid == 732 then
         player:setCharVar("WildcatWindurst", utils.mask.setBit(player:getCharVar("WildcatWindurst"), 4, true))
 
-        -- THE TENSHODO SHOWDOWN
+    -- CRYING OVER ONIONS
+    elseif csid == 598 then
+        player:setCharVar("CryingOverOnions", 2)
+
+    -- THE TENSHODO SHOWDOWN
     elseif (csid == 496) then
         player:addQuest(WINDURST, tpz.quest.id.windurst.THE_TENSHODO_SHOWDOWN)
         player:setCharVar("theTenshodoShowdownCS", 1)
         npcUtil.giveKeyItem(player, tpz.ki.LETTER_FROM_THE_TENSHODO)
 
-        -- THICK AS THIEVES
+    -- THICK AS THIEVES
     elseif (csid == 504 and option == 1) then -- start quest "as thick as thieves"
         player:addQuest(WINDURST, tpz.quest.id.windurst.AS_THICK_AS_THIEVES)
         player:setCharVar("thickAsThievesGamblingCS", 1)
@@ -170,7 +185,7 @@ function onEventFinish(player, csid, option)
         player:delKeyItem(tpz.ki.FIRST_SIGNED_FORGED_ENVELOPE)
         player:delKeyItem(tpz.ki.SECOND_SIGNED_FORGED_ENVELOPE)
 
-        -- HITTING THE MARQUISATE
+    -- HITTING THE MARQUISATE
     elseif csid == 512 then
         player:addQuest(WINDURST, tpz.quest.id.windurst.HITTING_THE_MARQUISATE)
         player:setCharVar("hittingTheMarquisateYatnielCS", 1)
@@ -181,7 +196,7 @@ function onEventFinish(player, csid, option)
         player:setCharVar("hittingTheMarquisateYatnielCS", 0)
         player:setCharVar("hittingTheMarquisateHagainCS", 0)
 
-        -- ROCK RACKETEER
+    -- ROCK RACKETEER
     elseif csid == 93 then
         player:addQuest(WINDURST, tpz.quest.id.windurst.ROCK_RACKETEER)
         npcUtil.giveKeyItem(player, tpz.ki.SHARP_GRAY_STONE)
@@ -189,7 +204,7 @@ function onEventFinish(player, csid, option)
         player:delGil(10 * GIL_RATE)
         player:setCharVar("rockracketeer_sold", 3)
 
-        -- MIHGO'S AMIGO
+    -- MIHGO'S AMIGO
     elseif csid == 80 or csid == 81 then
         player:addQuest(WINDURST, tpz.quest.id.windurst.MIHGO_S_AMIGO)
     elseif csid == 88 and npcUtil.completeQuest(player, WINDURST, tpz.quest.id.windurst.MIHGO_S_AMIGO, {


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Nanaa Mihgo now increases the charVar bit responsible for this to not make her repeat the dialogue regarding this quest. The remaining NPCs involved in "Crying for Onions" got their bit increased accordingly. Tested working locally and extensively by talking to every NPC before the quest, in every step during the quest, and after the quest.
Closes #880