### PR TITLE
Add step-down delays to Trust healing ticks

### DIFF
--- a/src/map/ai/controllers/trust_controller.cpp
+++ b/src/map/ai/controllers/trust_controller.cpp
@@ -34,7 +34,8 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "../../recast_container.h"
 #include "../../mob_spell_container.h"
 
-CTrustController::CTrustController(CCharEntity* PChar, CTrustEntity* PTrust) : CMobController(PTrust)
+CTrustController::CTrustController(CCharEntity* PChar, CTrustEntity* PTrust)
+: CMobController(PTrust)
 {
     m_GambitsContainer = std::make_unique<gambits::CGambitsContainer>(PTrust);
 }
@@ -178,13 +179,6 @@ void CTrustController::DoCombatTick(time_point tick)
 
         m_GambitsContainer->Tick(tick);
 
-        auto currentTopEnmity = GetTopEnmity();
-        if (m_LastTopEnmity != currentTopEnmity)
-        {
-            POwner->PAI->EventHandler.triggerListener("ENMITY_CHANGED", POwner, POwner->PMaster, PTarget);
-            m_LastTopEnmity = currentTopEnmity;
-        }
-
         POwner->PAI->EventHandler.triggerListener("COMBAT_TICK", POwner, POwner->PMaster, PTarget);
     }
 }
@@ -252,7 +246,7 @@ void CTrustController::DoRoamTick(time_point tick)
             POwner->addMP(recoverMP);
             m_LastHealTickTime = m_Tick;
             POwner->updatemask |= UPDATE_HP;
-            m_NumHealingTicks = std::clamp(++m_NumHealingTicks, static_cast<std::size_t>(0U), static_cast<std::size_t>(m_tickDelays.size() - 1U));
+            m_NumHealingTicks = std::clamp(m_NumHealingTicks + 1, static_cast<std::size_t>(0U), static_cast<std::size_t>(m_tickDelays.size() - 1U));
         }
     }
 }

--- a/src/map/ai/controllers/trust_controller.cpp
+++ b/src/map/ai/controllers/trust_controller.cpp
@@ -252,7 +252,7 @@ void CTrustController::DoRoamTick(time_point tick)
             POwner->addMP(recoverMP);
             m_LastHealTickTime = m_Tick;
             POwner->updatemask |= UPDATE_HP;
-            m_NumHealingTicks = std::clamp(++m_NumHealingTicks, 0U, m_tickDelays.size() - 1U);
+            m_NumHealingTicks = std::clamp(++m_NumHealingTicks, static_cast<std::size_t>(0U), static_cast<std::size_t>(m_tickDelays.size() - 1U));
         }
     }
 }

--- a/src/map/ai/controllers/trust_controller.cpp
+++ b/src/map/ai/controllers/trust_controller.cpp
@@ -239,8 +239,9 @@ void CTrustController::DoRoamTick(time_point tick)
     }
 
     if (POwner->CanRest() &&
-        m_Tick - m_CombatEndTime > 10s &&
-        m_Tick - m_LastHealTickTime > 10s)
+        m_Tick - POwner->LastAttacked > m_tickDelays.at(0) &&
+        m_Tick - m_CombatEndTime > m_tickDelays.at(0) &&
+        m_Tick - m_LastHealTickTime > m_tickDelays.at(m_NumHealingTicks))
     {
         if (POwner->health.hp != POwner->health.maxhp || POwner->health.mp != POwner->health.maxmp)
         {
@@ -251,6 +252,7 @@ void CTrustController::DoRoamTick(time_point tick)
             POwner->addMP(recoverMP);
             m_LastHealTickTime = m_Tick;
             POwner->updatemask |= UPDATE_HP;
+            m_NumHealingTicks = std::clamp(++m_NumHealingTicks, 0U, m_tickDelays.size() - 1);
         }
     }
 }

--- a/src/map/ai/controllers/trust_controller.cpp
+++ b/src/map/ai/controllers/trust_controller.cpp
@@ -252,7 +252,7 @@ void CTrustController::DoRoamTick(time_point tick)
             POwner->addMP(recoverMP);
             m_LastHealTickTime = m_Tick;
             POwner->updatemask |= UPDATE_HP;
-            m_NumHealingTicks = std::clamp(++m_NumHealingTicks, 0U, m_tickDelays.size() - 1);
+            m_NumHealingTicks = std::clamp(++m_NumHealingTicks, 0U, m_tickDelays.size() - 1U);
         }
     }
 }

--- a/src/map/ai/controllers/trust_controller.h
+++ b/src/map/ai/controllers/trust_controller.h
@@ -66,11 +66,15 @@ private:
     uint8 GetPartyPosition();
 
     CBattleEntity* m_LastTopEnmity;
+
+    time_point m_LastRepositionTime;
+    uint8 m_failedRepositionAttempts;
+    bool m_InTransit;
+
     time_point m_CombatEndTime;
     time_point m_LastHealTickTime;
-    time_point m_LastRepositionTime;
-    bool m_InTransit;
-    uint8 m_failedRepositionAttempts;
+    std::vector<std::chrono::seconds> m_tickDelays = { 15s, 10s, 10s, 3s };
+    std::size_t m_NumHealingTicks = 0;
 };
 
 #endif // _TRUSTCONTROLLER

--- a/src/map/ai/controllers/trust_controller.h
+++ b/src/map/ai/controllers/trust_controller.h
@@ -46,12 +46,11 @@ public:
     bool Ability(uint16 targid, uint16 abilityid) override;
     bool Cast(uint16 targid, SpellID spellid) override;
 
-    static constexpr float RoamDistance{ 2.0f };
-    static constexpr float SpawnDistance{ 3.0f };
-    static constexpr float CastingDistance { 15.0f };
-    static constexpr float WarpDistance{ 30.0f };
+    static constexpr float RoamDistance = { 2.0f };
+    static constexpr float SpawnDistance = { 3.0f };
+    static constexpr float CastingDistance = { 15.0f };
+    static constexpr float WarpDistance = { 30.0f };
 
-    // TODO: Replace with reverse enmity container
     CBattleEntity* GetTopEnmity();
 
     std::unique_ptr<gambits::CGambitsContainer> m_GambitsContainer;
@@ -74,7 +73,7 @@ private:
     time_point m_CombatEndTime;
     time_point m_LastHealTickTime;
     std::vector<std::chrono::seconds> m_tickDelays = { 15s, 10s, 10s, 3s };
-    std::size_t m_NumHealingTicks = 0;
+    std::size_t m_NumHealingTicks = { 0 };
 };
 
 #endif // _TRUSTCONTROLLER

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1792,6 +1792,7 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
     battleutils::ClaimMob(PTarget, this);
     PAI->EventHandler.triggerListener("ATTACK", this, PTarget, &action);
     PTarget->PAI->EventHandler.triggerListener("ATTACKED", PTarget, this, &action);
+    PTarget->LastAttacked = server_clock::now();
     /////////////////////////////////////////////////////////////////////////////////////////////
     // End of attack loop
     /////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -669,7 +669,8 @@ public:
     CParty*			PParty;					    // описание группы, в которой состоит сущность
     CBattleEntity*	PPet;					    // питомец сущности
     CBattleEntity*	PMaster;				    // владелец/хозяин сущности (распространяется на все боевые сущности)
-    CBattleEntity*	PLastAttacker;
+    CBattleEntity*  PLastAttacker;
+    time_point      LastAttacked;
 
     std::unique_ptr<CStatusEffectContainer> StatusEffectContainer;
     std::unique_ptr<CRecastContainer> PRecastContainer;


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Fixes #1337 

After combat, trust healing ticks will come in after 15s, 10s, 10s and then every 3s.
This counter is reset if the trust is hit, so they can't tank while being hit by stuff.

Checked against retail by counting in my head when the ticks happen, and writing down the amounts so I can work out the differences.
They're all 5% (still)