### PR TITLE
Make BLM Trusts cast more conservatively

### DIFF
--- a/scripts/globals/spells/trust/ajido-marujido.lua
+++ b/scripts/globals/spells/trust/ajido-marujido.lua
@@ -36,7 +36,7 @@ function onMobSpawn(mob)
                         ai.r.MA, ai.s.HIGHEST, tpz.magic.spellFamily.SLOW, 60)
 
     mob:addSimpleGambit(ai.t.TARGET, ai.c.NOT_SC_AVAILABLE, 0,
-                        ai.r.MA, ai.s.HIGHEST, tpz.magic.spellFamily.NONE, 30)
+                        ai.r.MA, ai.s.HIGHEST, tpz.magic.spellFamily.NONE, 60)
 end
 
 function onMobDespawn(mob)

--- a/scripts/globals/spells/trust/shantotto.lua
+++ b/scripts/globals/spells/trust/shantotto.lua
@@ -26,7 +26,7 @@ function onMobSpawn(mob)
 
     mob:addSimpleGambit(ai.t.TARGET, ai.c.MB_AVAILABLE, 0, ai.r.MA, ai.s.MB_ELEMENT, tpz.magic.spellFamily.NONE)
 
-    mob:addSimpleGambit(ai.t.TARGET, ai.c.NOT_SC_AVAILABLE, 0, ai.r.MA, ai.s.HIGHEST, tpz.magic.spellFamily.NONE, 30)
+    mob:addSimpleGambit(ai.t.TARGET, ai.c.NOT_SC_AVAILABLE, 0, ai.r.MA, ai.s.HIGHEST, tpz.magic.spellFamily.NONE, 60)
 
     mob:addFullGambit({
         ['predicates'] =
@@ -46,7 +46,7 @@ function onMobSpawn(mob)
         },
     })
 
-    local power = mob:getMainLvl() / 5
+    local power = mob:getMainLvl() / 10
     mob:addMod(tpz.mod.MATT, power)
     mob:addMod(tpz.mod.MACC, power)
     mob:addMod(tpz.mod.HASTE_MAGIC, 10)

--- a/scripts/globals/spells/trust/shantotto_ii.lua
+++ b/scripts/globals/spells/trust/shantotto_ii.lua
@@ -20,12 +20,12 @@ function onMobSpawn(mob)
     tpz.trust.message(mob, message_page_offset, tpz.trust.message_offset.SPAWN)
 
     mob:addSimpleGambit(ai.t.TARGET, ai.c.MB_AVAILABLE, 0, ai.r.MA, ai.s.MB_ELEMENT, tpz.magic.spellFamily.NONE)
-    mob:addSimpleGambit(ai.t.TARGET, ai.c.NOT_SC_AVAILABLE, 0, ai.r.MA, ai.s.HIGHEST, tpz.magic.spellFamily.NONE, 30)
+    mob:addSimpleGambit(ai.t.TARGET, ai.c.NOT_SC_AVAILABLE, 0, ai.r.MA, ai.s.HIGHEST, tpz.magic.spellFamily.NONE, 45)
 
-    local power = mob:getMainLvl()
+    local power = mob:getMainLvl() / 5
     mob:addMod(tpz.mod.MATT, power)
     mob:addMod(tpz.mod.MACC, power)
-    mob:addMod(tpz.mod.HASTE_MAGIC, 20)
+    mob:addMod(tpz.mod.HASTE_MAGIC, 10)
     mob:SetAutoAttackEnabled(false)
 end
 


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Went onto retail to do some testing, there is a much longer gap between when BLM Trusts will freely nuke. Left SCs alone.