### PR TITLE
Add safety check for PNotoriety container

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -77,7 +77,6 @@
 #include "../packets/char_job_extra.h"
 #include "../packets/status_effects.h"
 #include "../mobskill.h"
-#include "../notoriety_container.h"
 
 CCharEntity::CCharEntity()
 {
@@ -529,8 +528,6 @@ void CCharEntity::Tick(time_point tick)
     {
         gardenutils::UpdateGardening(this, true);
     }
-
-    PNotorietyContainer->tryClear();
 }
 
 void CCharEntity::PostTick()

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -77,7 +77,7 @@
 #include "../packets/char_job_extra.h"
 #include "../packets/status_effects.h"
 #include "../mobskill.h"
-
+#include "../notoriety_container.h"
 
 CCharEntity::CCharEntity()
 {
@@ -529,6 +529,8 @@ void CCharEntity::Tick(time_point tick)
     {
         gardenutils::UpdateGardening(this, true);
     }
+
+    PNotorietyContainer->tryClear();
 }
 
 void CCharEntity::PostTick()

--- a/src/map/notoriety_container.cpp
+++ b/src/map/notoriety_container.cpp
@@ -60,3 +60,28 @@ std::size_t CNotorietyContainer::size()
 {
     return m_Lookup.size();
 }
+
+void CNotorietyContainer::tryClear()
+{
+    if (!m_POwner->GetBattleTarget() && hasEnmity())
+    {
+        std::vector<CBattleEntity*> toRemove;
+        for (CBattleEntity* entry : *this)
+        {
+            if (CMobEntity* mob = dynamic_cast<CMobEntity*>(entry))
+            {
+                auto mobEnmityList = mob->PEnmityContainer->GetEnmityList();
+                if ((mob->isAlive() && mobEnmityList->find(m_POwner->id) == mobEnmityList->end()) ||
+                    mob->isDead())
+                {
+                    toRemove.emplace_back(entry);
+                }
+            }
+        }
+
+        for (CBattleEntity* entry : toRemove)
+        {
+            remove(entry);
+        }
+    }
+}

--- a/src/map/notoriety_container.cpp
+++ b/src/map/notoriety_container.cpp
@@ -53,17 +53,8 @@ void CNotorietyContainer::remove(CBattleEntity* entity)
 
 bool CNotorietyContainer::hasEnmity()
 {
-    return !m_Lookup.empty();
-}
-
-std::size_t CNotorietyContainer::size()
-{
-    return m_Lookup.size();
-}
-
-void CNotorietyContainer::tryClear()
-{
-    if (!m_POwner->GetBattleTarget() && hasEnmity())
+    // Make sure the container is up to date before reporting
+    if (!m_Lookup.empty())
     {
         std::vector<CBattleEntity*> toRemove;
         for (CBattleEntity* entry : *this)
@@ -84,4 +75,11 @@ void CNotorietyContainer::tryClear()
             remove(entry);
         }
     }
+
+    return !m_Lookup.empty();
+}
+
+std::size_t CNotorietyContainer::size()
+{
+    return m_Lookup.size();
 }

--- a/src/map/notoriety_container.cpp
+++ b/src/map/notoriety_container.cpp
@@ -70,9 +70,9 @@ void CNotorietyContainer::tryClear()
         {
             if (CMobEntity* mob = dynamic_cast<CMobEntity*>(entry))
             {
-                auto mobEnmityList = mob->PEnmityContainer->GetEnmityList();
-                if ((mob->isAlive() && mobEnmityList->find(m_POwner->id) == mobEnmityList->end()) ||
-                    mob->isDead())
+                EnmityList_t* mobEnmityList = mob->PEnmityContainer->GetEnmityList();
+                bool notOnEnmityList = mobEnmityList->find(m_POwner->id) == mobEnmityList->end();
+                if ((mob->isAlive() && notOnEnmityList) || mob->isDead())
                 {
                     toRemove.emplace_back(entry);
                 }

--- a/src/map/notoriety_container.h
+++ b/src/map/notoriety_container.h
@@ -39,7 +39,6 @@ public:
     void add(CBattleEntity* entity);
     void remove(CBattleEntity* entity);
     std::size_t size();
-    void tryClear();
 
     bool hasEnmity();
 

--- a/src/map/notoriety_container.h
+++ b/src/map/notoriety_container.h
@@ -39,6 +39,7 @@ public:
     void add(CBattleEntity* entity);
     void remove(CBattleEntity* entity);
     std::size_t size();
+    void tryClear();
 
     bool hasEnmity();
 


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Got a report of there being lingering entries in PNotorietyContainer, meaning you'd have to zone to clear it.
This makes player:hasEntity() wrongly return true, when the player isn't in trouble
It was in Castle O [S], so I'm guessing it has something to do with the broken giant beastmen parties.

Repro'd in canary by running around in Castle O [S] and killing Yagudos, and then trying to summon trusts -> rejected

Proven fixed by merging this branch into canary, doing the same, then being able to summon trusts when I've killed everything around me and I have no obvious aggro.

Also put a breakpoint on the `remove()` call to make sure invalid mobs were being taken out of the container