### PR TITLE
Hourly check for Ro'Maeve full moon

### DIFF
--- a/scripts/zones/RoMaeve/Zone.lua
+++ b/scripts/zones/RoMaeve/Zone.lua
@@ -35,20 +35,38 @@ function onRegionEnter(player, region)
 end
 
 function onGameHour(zone)
-    local hour = VanadielHour()
+    local vanadielHour = VanadielHour()
+    
+    -- Make Ro'Maeve come to life between 6pm and 6am during a full moon
+    if IsMoonFull() and (vanadielHour >= 18 or vanadielHour < 6) then
+        local moongate1 = GetNPCByID(ID.npc.MOONGATE_OFFSET)
+        local moongate2 = GetNPCByID(ID.npc.MOONGATE_OFFSET + 1)
 
-    if IsMoonFull() and hour == 18 then
-        for i = ID.npc.MOONGATE_OFFSET, ID.npc.MOONGATE_OFFSET+7 do
-            GetNPCByID(i):openDoor(1728)
-            GetNPCByID(i):untargetable(true)
+        if moongate1:getLocalVar("romaeveActive") == 0 then
+            -- Loop over the affected NPCs: Moongates, bridges and fountain
+            for i = ID.npc.MOONGATE_OFFSET, ID.npc.MOONGATE_OFFSET + 7 do
+                GetNPCByID(i):setAnimation(tpz.anim.OPEN_DOOR) -- Open them
+            end
+            moongate2:untargetable(true)
+            moongate1:untargetable(true)
+            moongate1:setLocalVar("romaeveActive", 1) -- Make this loop unavailable after firing
         end
-    elseif hour == 6 then
-        for i = ID.npc.MOONGATE_OFFSET, ID.npc.MOONGATE_OFFSET+7 do
-            GetNPCByID(i):untargetable(false)
+
+    -- Clean up at 6am
+    elseif vanadielHour == 6 then
+        local moongate1 = GetNPCByID(ID.npc.MOONGATE_OFFSET)
+        local moongate2 = GetNPCByID(ID.npc.MOONGATE_OFFSET + 1)
+
+        if moongate1:getLocalVar("romaeveActive") == 1 then
+            for i = ID.npc.MOONGATE_OFFSET, ID.npc.MOONGATE_OFFSET + 7 do
+                GetNPCByID(i):setAnimation(tpz.anim.CLOSE_DOOR)
+            end
+            moongate2:untargetable(false)
+            moongate1:untargetable(false)
+            moongate1:setLocalVar("romaeveActive", 0) -- Make loop available again
         end
     end
 end
-
 
 function onEventUpdate(player, csid, option)
 end


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

This PR would successfully activate Ro'Maeve's bridges, gates and the fountain not only at exactly 6pm but at any hour that hits full moon between 6pm and (not including) 6am for the remaining amount of time until 6am. The current logic in release only once can activate the whole area at exactly 6pm not thereafter. This is not desirable.
~~It also adds the missing weather condition. The area must have no weather for the full moon to affect the mentioned objects.~~
Furthermore when cleaning up at 6am only the two Moongates should become targetable again.

This was a bummer to debug and test cause the !time command apparently throws off the sync between the in-game shown /clock and the server clock, but nonetheless:
- [x] Tested working locally at several hours, moon phases and weather conditions.