### PR TITLE
fix(ability): Increase duration and add accuracy bonus to Shiva's Sleepga

### DIFF
--- a/scripts/globals/abilities/pets/sleepga.lua
+++ b/scripts/globals/abilities/pets/sleepga.lua
@@ -5,6 +5,7 @@ require("scripts/globals/monstertpmoves")
 require("scripts/globals/status")
 require("scripts/globals/magic")
 require("scripts/globals/msg")
+require("scripts/globals/spell_data")
 require("scripts/globals/summon")
 -----------------------------------------
 
@@ -16,7 +17,7 @@ function onPetAbility(target, pet, skill)
     local duration = 90
     local dINT = pet:getStat(tpz.mod.INT) - target:getStat(tpz.mod.INT)
     local bonus = getSummoningSkillOverCap(pet)
-    local resm = applyPlayerResistance(pet, -1, target, dINT, bonus, 5)
+    local resm = applyPlayerResistance(pet, -1, target, dINT, bonus, tpz.magic.element.ICE)
     if (resm < 0.5) then
         skill:setMsg(tpz.msg.basic.JA_MISS_2) -- resist message
         return tpz.effect.SLEEP_I

--- a/scripts/globals/abilities/pets/sleepga.lua
+++ b/scripts/globals/abilities/pets/sleepga.lua
@@ -5,6 +5,7 @@ require("scripts/globals/monstertpmoves")
 require("scripts/globals/status")
 require("scripts/globals/magic")
 require("scripts/globals/msg")
+require("scripts/globals/summon")
 -----------------------------------------
 
 function onAbilityCheck(player, target, ability)
@@ -12,8 +13,10 @@ function onAbilityCheck(player, target, ability)
 end
 
 function onPetAbility(target, pet, skill)
-    local duration = 60
-    local resm = applyPlayerResistance(pet, -1, target, pet:getStat(tpz.mod.INT)-target:getStat(tpz.mod.INT), tpz.skill.ELEMENTAL_MAGIC, 5)
+    local duration = 90
+    local dINT = pet:getStat(tpz.mod.INT) - target:getStat(tpz.mod.INT)
+    local bonus = getSummoningSkillOverCap(pet)
+    local resm = applyPlayerResistance(pet, -1, target, dINT, bonus, 5)
     if (resm < 0.5) then
         skill:setMsg(tpz.msg.basic.JA_MISS_2) -- resist message
         return tpz.effect.SLEEP_I


### PR DESCRIPTION
Duration was 60, should be 90 according to all sources.

The `applyPlayerResistance` method in monstertpmoves.lua had its signature updated a long time ago, changing the 5th argument from the spell school to the accuracy bonus. Sleepga was not updated and so was receiving a flat accuracy bonus of tpz.skill.ELEMENTAL_MAGIC (38, I think). I've removed that.

Accordiong to ffxiclopedia, Sleepga was supposed to receive an unknown accuracy bonus based on summoning skill. These generally are some factor of summoning magic skill over cap. I've added that bonus with a factor of 1.0.

Sources
- https://www.bg-wiki.com/bg/Sleepga_(Blood_Pact)
- https://ffxiclopedia.fandom.com/wiki/Sleepga_(Blood_Pact)
- http://wiki.ffo.jp/html/2230.html

Closes #257

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [ ] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

