### PR TITLE
Fix: legacy of the lost

### DIFF
--- a/scripts/zones/Talacca_Cove/bcnms/legacy_of_the_lost.lua
+++ b/scripts/zones/Talacca_Cove/bcnms/legacy_of_the_lost.lua
@@ -31,7 +31,7 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-    if csid == 32001 and not player:hasCompletedMission(TOAU, tpz.mission.id.toau.LEGACY_OF_THE_LOST) then
+    if csid == 32001 and player:getCurrentMission(TOAU) == tpz.mission.id.toau.LEGACY_OF_THE_LOST then
         player:completeMission(TOAU, tpz.mission.id.toau.LEGACY_OF_THE_LOST)
         player:setTitle(tpz.title.GESSHOS_MERCY)
         player:addMission(TOAU, tpz.mission.id.toau.GAZE_OF_THE_SABOTEUR)

--- a/scripts/zones/Talacca_Cove/bcnms/legacy_of_the_lost.lua
+++ b/scripts/zones/Talacca_Cove/bcnms/legacy_of_the_lost.lua
@@ -31,9 +31,11 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-    if csid == 32001 and player:getCurrentMission(TOAU) == tpz.mission.id.toau.LEGACY_OF_THE_LOST then
-        player:completeMission(TOAU, tpz.mission.id.toau.LEGACY_OF_THE_LOST)
+    if csid == 32001 then
         player:setTitle(tpz.title.GESSHOS_MERCY)
-        player:addMission(TOAU, tpz.mission.id.toau.GAZE_OF_THE_SABOTEUR)
+        if player:getCurrentMission(TOAU) == tpz.mission.id.toau.LEGACY_OF_THE_LOST then
+            player:completeMission(TOAU, tpz.mission.id.toau.LEGACY_OF_THE_LOST)
+            player:addMission(TOAU, tpz.mission.id.toau.GAZE_OF_THE_SABOTEUR)
+        end
     end
 end


### PR DESCRIPTION
Currently the legacy of the lost bcnm can be entered with anyone who is currently on the mission and anyone who is in the party will be skipped ahead to the next mission on a win. This at least puts a check on battlefield win for the credit, but does not address people being able to join on a lesser mission.
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

