### PR TITLE
Make NM Lottery parameters configurable

### DIFF
--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -61,6 +61,13 @@ end
 -- potential lottery placeholder was killed
 tpz.mob.phOnDespawn = function(ph, phList, chance, cooldown, immediate)
     if type(immediate) ~= "boolean" then immediate = false end
+    
+    if NM_LotteryChance then
+        chance = NM_LotteryChance >= 0 and (chance * NM_LotteryChance) or 100
+    end
+    if NM_LotteryCooldown then
+        cooldown = NM_LotteryCooldown >= 0 and (cooldown * NM_LotteryCooldown) or cooldown
+    end
 
     local phId = ph:getID()
     local nmId = phList[phId]

--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -76,8 +76,9 @@ tpz.mob.phOnDespawn = function(ph, phList, chance, cooldown, immediate)
         local nm = GetMobByID(nmId)
         if nm ~= nil then
             local pop = nm:getLocalVar("pop")
-
-            if os.time() > pop and not lotteryPrimed(phList) and math.random(100) <= chance then
+            
+            chance = math.ceil(chance * 10) -- chance / 1000.
+            if os.time() > pop and not lotteryPrimed(phList) and math.random(1000) <= chance then
 
                 -- on PH death, replace PH repop with NM repop
                 DisallowRespawn(phId, true)

--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -62,11 +62,11 @@ end
 tpz.mob.phOnDespawn = function(ph, phList, chance, cooldown, immediate)
     if type(immediate) ~= "boolean" then immediate = false end
     
-    if NM_LotteryChance then
-        chance = NM_LotteryChance >= 0 and (chance * NM_LotteryChance) or 100
+    if NM_LOTTERYCHANCE then
+        chance = NM_LOTTERYCHANCE >= 0 and (chance * NM_LOTTERYCHANCE) or 100
     end
-    if NM_LotteryCooldown then
-        cooldown = NM_LotteryCooldown >= 0 and (cooldown * NM_LotteryCooldown) or cooldown
+    if NM_LOTTERYCOOLDOWN then
+        cooldown = NM_LOTTERYCOOLDOWN >= 0 and (cooldown * NM_LOTTERYCOOLDOWN) or cooldown
     end
 
     local phId = ph:getID()

--- a/scripts/globals/settings.lua
+++ b/scripts/globals/settings.lua
@@ -106,9 +106,9 @@ LandKingSystem_NQ = 1
 LandKingSystem_HQ = 1
 
 -- Multiplier to NM lottery spawn chance. (Default 1.0) eg. 0 = disable lottery spawns. -1 for always 100% chance.
-NM_LotteryChance = 1.0
+NM_LOTTERYCHANCE = 1.0
 -- Multiplier to NM lottery cooldown time (Default 1.0) eg. 2.0 = twice as long. 0 = no cooldowns.
-NM_LotteryCooldown = 1.0
+NM_LOTTERYCOOLDOWN = 1.0
 
 -- DYNAMIS SETTINGS
     BETWEEN_2DYNA_WAIT_TIME = 24       -- Hours before player can re-enter Dynamis. Default is 1 Earthday (24 hours).

--- a/scripts/globals/settings.lua
+++ b/scripts/globals/settings.lua
@@ -105,6 +105,11 @@ CHEST_MIN_ILLUSION_TIME  = 1800  -- 30 minutes
 LandKingSystem_NQ = 1
 LandKingSystem_HQ = 1
 
+-- Multiplier to NM lottery spawn chance. (Default 1.0) eg. 0 = disable lottery spawns. -1 for always 100% chance.
+NM_LotteryChance = 1.0
+-- Multiplier to NM lottery cooldown time (Default 1.0) eg. 2.0 = twice as long. 0 = no cooldowns.
+NM_LotteryCooldown = 1.0
+
 -- DYNAMIS SETTINGS
     BETWEEN_2DYNA_WAIT_TIME = 24       -- Hours before player can re-enter Dynamis. Default is 1 Earthday (24 hours).
         DYNA_MIDNIGHT_RESET = true     -- if true, makes the wait time count by number of server midnights instead of full 24 hour intervals


### PR DESCRIPTION
I'm sure there are plenty of servers who believe the lottery rates are too high or too low for their liking. This adds 2 flags to adjust the Chance and Cooldown on Lottery NMs.

This allows for some interesting options, such as turning the rates down and setting cooldowns to 0 thus having all NMs be a rare true-lottery. Or of course you could disable all Lottery spawns entirely if you want, I ain't your boss. :shrug: 

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

