### PR TITLE
Prefill Trust and Intermediate ROE Records

### DIFF
--- a/scripts/globals/roe_records.lua
+++ b/scripts/globals/roe_records.lua
@@ -1,4 +1,4 @@
--- This file is called by roe.lua and require()'s no file, it should not be require()'d by any 
+-- This file is called by roe.lua and require()'s no file, it should not be require()'d by any
 -- other lua scripts, which should instead require() roe.lua directly.
 
 local triggers = tpz.roe.triggers
@@ -22,7 +22,7 @@ RoeParseTimed(timedSchedule)
 local defaults = {
     check = checks.masterCheck, -- Check function should return true/false
     increment = 1,              -- Amount to increment per successful check
-    notify = 1,                 -- Progress notifications shown every X increases 
+    notify = 1,                 -- Progress notifications shown every X increases
     goal = 1,                   -- Progress goal
     flags = {},                 -- Special flags. Possible values: "timed" "repeat" "daily"
     reqs = {},                  -- Other requirements. List of function names from above, with required values.
@@ -57,6 +57,53 @@ tpz.roe.records =
 
     [  11] = { -- Undertake a GoV Training Regime
         reward =  { sparks = 100, xp = 500}
+    },
+
+    [ 932] = { -- Call Forth an Alter Ego (gives Cipher: Valaineral)
+        reward =  { sparks = 100, xp = 300, item = { 10116 } }
+    },
+
+    [ 933] = { -- Alter Ego: Valaineral (gives Cipher: Mihli)
+        reward =  { sparks = 100, xp = 300, item = { 10115 } }
+    },
+
+    [ 934] = { -- Alter Ego: Mihli Aliapoh (gives Cipher: Tenzen)
+        reward =  { sparks = 100, xp = 300, item = { 10114 } }
+    },
+
+    [ 935] = { -- Alter Ego: Tenzen (gives Cipher: Adelheid)
+        reward =  { sparks = 100, xp = 300, item = { 10153 } }
+    },
+
+    [ 936] = { -- Alter Ego: Adelheid (gives Cipher: Joachim)
+        reward =  { sparks = 100, xp = 300, item = { 10117 } }
+    },
+
+    [ 937] = { -- Alter Ego: Joachim
+        reward =  { sparks = 100, xp = 500 }
+    },
+
+  ----------------------------------------
+  -- Tutorial -> Intermediate           --
+  ----------------------------------------
+    [1045] = { -- Achieve Level 99 (gives Kupon A-PK109 x5)
+        reward =  { sparks = 200, xp = 300, item = { 8733, 5 } }
+    },
+
+    [1046] = { -- An Eminent Scholar (gives Kupon W-EMI)
+        reward =  { sparks = 200, xp = 200, item = { 9188 } }
+    },
+
+    [1047] = { -- An Eminent Scholar 2 (gives Kupon A-EMI)
+        reward =  { sparks = 200, xp = 200, item = { 9226 } }
+    },
+
+    [1048] = { -- An Eminent Scholar 3 (gives Kupon A-EMI)
+        reward =  { sparks = 200, xp = 200, item = { 9226 } }
+    },
+
+    [1049] = { -- Always Stand on 117 (gives Cipher: Koru-Moru)
+        reward =  { sparks = 200, xp = 300, item = { 10140 }  }
     },
 
   --------------------------------------------

--- a/scripts/globals/roe_records.lua
+++ b/scripts/globals/roe_records.lua
@@ -59,6 +59,7 @@ tpz.roe.records =
         reward =  { sparks = 100, xp = 500}
     },
 
+    --[[ TODO: Trusts
     [ 932] = { -- Call Forth an Alter Ego (gives Cipher: Valaineral)
         reward =  { sparks = 100, xp = 300, item = { 10116 } }
     },
@@ -82,10 +83,12 @@ tpz.roe.records =
     [ 937] = { -- Alter Ego: Joachim
         reward =  { sparks = 100, xp = 500 }
     },
+    ]]--
 
   ----------------------------------------
   -- Tutorial -> Intermediate           --
   ----------------------------------------
+    --[[ TODO
     [1045] = { -- Achieve Level 99 (gives Kupon A-PK109 x5)
         reward =  { sparks = 200, xp = 300, item = { 8733, 5 } }
     },
@@ -105,6 +108,7 @@ tpz.roe.records =
     [1049] = { -- Always Stand on 117 (gives Cipher: Koru-Moru)
         reward =  { sparks = 200, xp = 300, item = { 10140 }  }
     },
+    ]]-
 
   --------------------------------------------
   -- Combat (Wide Area) -> Combat (General) --


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Need these for my trust branch - hitting level and speaking to ROE NPC when you have x sparks aren't implemented yet (I think?)