### PR TITLE
Adds Glanzfaust Latents, Guard Percent MOD

### DIFF
--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1542,6 +1542,7 @@ tpz.mod =
     SAVETP                          = 880, -- SAVETP Effect for Miser's Roll / ATMA / Hagakure.
     SMITE                           = 898, -- Att increase with H2H or 2H weapons
     TACTICAL_GUARD                  = 899, -- Tp gain increase when guarding
+    GUARD_PERCENT                   = 976, -- Guard Percent
     FENCER_TP_BONUS                 = 903, -- TP Bonus to weapon skills from Fencer Trait
     FENCER_CRITHITRATE              = 904, -- Increased Crit chance from Fencer Trait
     SHIELD_DEF_BONUS                = 905, -- Shield Defense Bonus
@@ -1567,9 +1568,9 @@ tpz.mod =
 
     -- The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     -- 570 - 825 used by WS DMG mods these are not spares.
-    -- SPARE = 976, -- stuff
     -- SPARE = 977, -- stuff
     -- SPARE = 978, -- stuff
+    -- SPARE = 979, -- stuff
 }
 
 tpz.latent =

--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -3003,16 +3003,43 @@ INSERT INTO `item_latents` VALUES(18991, 165, 5, 13, 56);   -- Crit Rate +5% if 
 INSERT INTO `item_latents` VALUES(18991, 288, 3, 13, 56);   -- Double Attack +3% if Berserk Active
 
 -- -------------------------------------------------------
+-- Glanzfaust 75
+-- -------------------------------------------------------
+INSERT INTO `item_latents` VALUES(18992, 62, 5, 13, 59);    -- Attack +5% if Focus is Active
+INSERT INTO `item_latents` VALUES(18992, 165, 3, 13, 59);   -- Crit rate +3% if Focus Active
+INSERT INTO `item_latents` VALUES(18992, 25, 5, 13, 59);    -- ACC +5 if Focus Active
+INSERT INTO `item_latents` VALUES(18992, 68, 5, 13, 60);    -- EVA +5 if Dodge Active
+INSERT INTO `item_latents` VALUES(18992, 976, 5, 13, 60);   -- Guard +5% if Dodge Active
+
+-- -------------------------------------------------------
 -- Conqueror 80
 -- -------------------------------------------------------
 INSERT INTO `item_latents` VALUES(19060, 165, 7, 13, 56);   -- Crit Rate +7% if Berserk Active
 INSERT INTO `item_latents` VALUES(19060, 288, 3, 13, 56);   -- Double Attack +3% if Berserk Active
 
 -- -------------------------------------------------------
+-- Glanzfaust 80
+-- -------------------------------------------------------
+INSERT INTO `item_latents` VALUES(19061, 62, 5, 13, 59);    -- Attack +5% if Focus is Active
+INSERT INTO `item_latents` VALUES(19061, 165, 3, 13, 59);   -- Crit rate +3% if Focus Active
+INSERT INTO `item_latents` VALUES(19061, 25, 10, 13, 59);   -- ACC +10 if Focus Active
+INSERT INTO `item_latents` VALUES(19061, 68, 10, 13, 60);   -- EVA +10 if Dodge Active
+INSERT INTO `item_latents` VALUES(19061, 976, 5, 13, 60);   -- Guard +5% if Dodge Active
+
+-- -------------------------------------------------------
 -- Conqueror 85
 -- -------------------------------------------------------
 INSERT INTO `item_latents` VALUES(19080, 165, 9, 13, 56);   -- Crit Rate +9% if Berserk Active
 INSERT INTO `item_latents` VALUES(19080, 288, 3, 13, 56);   -- Double Attack +3% if Berserk Active
+
+-- -------------------------------------------------------
+-- Glanzfaust 85
+-- -------------------------------------------------------
+INSERT INTO `item_latents` VALUES(19081, 62, 5, 13, 59);    -- Attack +5% if Focus is Active
+INSERT INTO `item_latents` VALUES(19081, 165, 3, 13, 59);   -- Crit rate +3% if Focus Active
+INSERT INTO `item_latents` VALUES(19081, 25, 20, 13, 59);   -- ACC +20 if Focus Active
+INSERT INTO `item_latents` VALUES(19081, 68, 20, 13, 60);   -- EVA +20 if Dodge Active
+INSERT INTO `item_latents` VALUES(19081, 976, 5, 13, 60);   -- Guard +5% if Dodge Active
 
 -- -------------------------------------------------------
 -- Zareehkl Jambiya
@@ -3101,10 +3128,28 @@ INSERT INTO `item_latents` VALUES(19612, 165, 11, 13, 56);  -- Crit Rate +11% if
 INSERT INTO `item_latents` VALUES(19612, 288, 3, 13, 56);   -- Double Attack +3% if Berserk Active
 
 -- -------------------------------------------------------
+-- Glanzfaust 90
+-- -------------------------------------------------------
+INSERT INTO `item_latents` VALUES(19613, 62, 5, 13, 59);    -- Attack +5% if Focus is Active
+INSERT INTO `item_latents` VALUES(19613, 165, 3, 13, 59);   -- Crit rate +3% if Focus Active
+INSERT INTO `item_latents` VALUES(19613, 25, 25, 13, 59);   -- ACC +25 if Focus Active
+INSERT INTO `item_latents` VALUES(19613, 68, 25, 13, 60);   -- EVA +25 if Dodge Active
+INSERT INTO `item_latents` VALUES(19613, 976, 5, 13, 60);   -- Guard +5% if Dodge Active
+
+-- -------------------------------------------------------
 -- Conqueror 95
 -- -------------------------------------------------------
 INSERT INTO `item_latents` VALUES(19710, 165, 11, 13, 56);  -- Crit Rate +11% if Berserk Active
 INSERT INTO `item_latents` VALUES(19710, 288, 3, 13, 56);   -- Double Attack +3% if Berserk Active
+
+-- -------------------------------------------------------
+-- Glanzfaust 95
+-- -------------------------------------------------------
+INSERT INTO `item_latents` VALUES(19711, 62, 5, 13, 59);    -- Attack +5% if Focus is Active
+INSERT INTO `item_latents` VALUES(19711, 165, 3, 13, 59);   -- Crit rate +3% if Focus Active
+INSERT INTO `item_latents` VALUES(19711, 25, 25, 13, 59);   -- ACC +25 if Focus Active
+INSERT INTO `item_latents` VALUES(19711, 68, 25, 13, 60);   -- EVA +25 if Dodge Active
+INSERT INTO `item_latents` VALUES(19711, 976, 5, 13, 60);   -- Guard +5% if Dodge Active
 
 -- -------------------------------------------------------
 -- Conqueror 99
@@ -3113,10 +3158,28 @@ INSERT INTO `item_latents` VALUES(19819, 165, 14, 13, 56);  -- Crit Rate +14% if
 INSERT INTO `item_latents` VALUES(19819, 288, 3, 13, 56);   -- Double Attack +3% if Berserk Active
 
 -- -------------------------------------------------------
+-- Glanzfaust 99
+-- -------------------------------------------------------
+INSERT INTO `item_latents` VALUES(19820, 62, 5, 13, 59);    -- Attack +5% if Focus is Active
+INSERT INTO `item_latents` VALUES(19820, 165, 3, 13, 59);   -- Crit rate +3% if Focus Active
+INSERT INTO `item_latents` VALUES(19820, 25, 30, 13, 59);   -- ACC +30 if Focus Active
+INSERT INTO `item_latents` VALUES(19820, 68, 30, 13, 60);   -- EVA +30 if Dodge Active
+INSERT INTO `item_latents` VALUES(19820, 976, 5, 13, 60);   -- Guard +5% if Dodge Active
+
+-- -------------------------------------------------------
 -- Conqueror 99 AG
 -- -------------------------------------------------------
 INSERT INTO `item_latents` VALUES(19948, 165, 14, 13, 56);  -- Crit Rate +14% if Berserk Active
 INSERT INTO `item_latents` VALUES(19948, 288, 3, 13, 56);   -- Double Attack +3% if Berserk Active
+
+-- -------------------------------------------------------
+-- Glanzfaust 99 AG
+-- -------------------------------------------------------
+INSERT INTO `item_latents` VALUES(19949, 62, 5, 13, 59);    -- Attack +5% if Focus is Active
+INSERT INTO `item_latents` VALUES(19949, 165, 3, 13, 59);   -- Crit rate +3% if Focus Active
+INSERT INTO `item_latents` VALUES(19949, 25, 30, 13, 59);   -- ACC +30 if Focus Active
+INSERT INTO `item_latents` VALUES(19949, 68, 30, 13, 60);   -- EVA +30 if Dodge Active
+INSERT INTO `item_latents` VALUES(19949, 976, 5, 13, 60);   -- Guard +5% if Dodge Active
 
 -- -------------------------------------------------------
 -- Eminent Baghnakhs
@@ -3140,10 +3203,28 @@ INSERT INTO `item_latents` VALUES(20837, 165, 14, 13, 56);  -- Crit Rate +14% if
 INSERT INTO `item_latents` VALUES(20837, 288, 3, 13, 56);   -- Double Attack +3% if Berserk Active
 
 -- -------------------------------------------------------
+-- Glanzfaust 119
+-- -------------------------------------------------------
+INSERT INTO `item_latents` VALUES(20482, 62, 5, 13, 59);    -- Attack +5% if Focus is Active
+INSERT INTO `item_latents` VALUES(20482, 165, 3, 13, 59);   -- Crit rate +3% if Focus Active
+INSERT INTO `item_latents` VALUES(20482, 25, 30, 13, 59);   -- ACC +30 if Focus Active
+INSERT INTO `item_latents` VALUES(20482, 68, 30, 13, 60);   -- EVA +30 if Dodge Active
+INSERT INTO `item_latents` VALUES(20482, 976, 5, 13, 60);   -- Guard +5% if Dodge Active
+
+-- -------------------------------------------------------
 -- Conqueror 119 AG
 -- -------------------------------------------------------
 INSERT INTO `item_latents` VALUES(20838, 165, 14, 13, 56);  -- Crit Rate +14% if Berserk Active
 INSERT INTO `item_latents` VALUES(20838, 288, 3, 13, 56);   -- Double Attack +3% if Berserk Active
+
+-- -------------------------------------------------------
+-- Glanzfaust 119 AG
+-- -------------------------------------------------------
+INSERT INTO `item_latents` VALUES(20483, 62, 5, 13, 59);    -- Attack +5% if Focus is Active
+INSERT INTO `item_latents` VALUES(20483, 165, 3, 13, 59);   -- Crit rate +3% if Focus Active
+INSERT INTO `item_latents` VALUES(20483, 25, 30, 13, 59);   -- ACC +30 if Focus Active
+INSERT INTO `item_latents` VALUES(20483, 68, 30, 13, 60);   -- EVA +30 if Dodge Active
+INSERT INTO `item_latents` VALUES(20483, 976, 5, 13, 60);   -- Guard +5% if Dodge Active
 
 -- INSERT INTO `item_latents` VALUES(21521, 25, 10, ??, 0); -- Melee fists: Dynamis (D): Accuracy+10
 -- INSERT INTO `item_latents` VALUES(21521, 30, 10, ??, 0); -- Melee fists: Dynamis (D): Magic Accuracy+10
@@ -3209,6 +3290,15 @@ INSERT INTO `item_latents` VALUES(21661, 840, 1, 56, 0);    -- Rune Algol: Laten
 -- -------------------------------------------------------
 INSERT INTO `item_latents` VALUES(21757, 165, 14, 13, 56);  -- Crit Rate +14% if Berserk Active
 INSERT INTO `item_latents` VALUES(21757, 288, 3, 13, 56);   -- Double Attack +3% if Berserk Active
+
+-- -------------------------------------------------------
+-- Glanzfaust 119 AG v3
+-- -------------------------------------------------------
+INSERT INTO `item_latents` VALUES(20510, 62, 5, 13, 59);    -- Attack +5% if Focus is Active
+INSERT INTO `item_latents` VALUES(20510, 165, 3, 13, 59);   -- Crit rate +3% if Focus Active
+INSERT INTO `item_latents` VALUES(20510, 25, 30, 13, 59);   -- ACC +30 if Focus Active
+INSERT INTO `item_latents` VALUES(20510, 68, 30, 13, 60);   -- EVA +30 if Dodge Active
+INSERT INTO `item_latents` VALUES(20510, 976, 5, 13, 60);   -- Guard +5% if Dodge Active
 
 -- INSERT INTO `item_latents` VALUES(21772, 25, 10, ??, 0); -- Warrior's Chopper: (D): Accuracy+10
 -- INSERT INTO `item_latents` VALUES(21772, 30, 10, ??, 0); -- Warrior's Chopper: (D): Magic Accuracy+10

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -215,6 +215,7 @@ enum class Mod
 
     SMITE                     = 898, // Raises attack when using H2H or 2H weapons (256 scale)
     TACTICAL_GUARD            = 899, // Tp increase when guarding
+    GUARD_PERCENT             = 976, // Guard Percent
 
     HASTE_MAGIC               = 167, // Haste (and Slow) from magic - 10000 base, 375 = 3.75%
     HASTE_ABILITY             = 383, // Haste (and Slow) from abilities - 10000 base, 375 = 3.75%
@@ -810,9 +811,9 @@ enum class Mod
 
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     // 570 through 825 used by WS DMG mods these are not spares.
-    // SPARE = 976, // stuff
     // SPARE = 977, // stuff
     // SPARE = 978, // stuff
+    // SPARE = 979, // stuff
 };
 
 //temporary workaround for using enum class as unordered_map key until compilers support it

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1753,7 +1753,8 @@ namespace battleutils
         if (validWeapon && hasGuardSkillRank && PDefender->PAI->IsEngaged())
         {
             // assuming this is like parry
-            float skill = (float)PDefender->GetSkill(SKILL_GUARD) + PDefender->getMod(Mod::GUARD);
+            float gbase = (float)PDefender->GetSkill(SKILL_GUARD) + PDefender->getMod(Mod::GUARD);
+            float skill = (float)gbase + ((float)gbase * (PDefender->getMod(Mod::GUARD_PERCENT) / 100));
 
             if (PWeapon)
                 skill += PWeapon->getILvlParry(); //no weapon will ever have ilvl guard and parry


### PR DESCRIPTION
Adds latents for Focus and Dodge for all Glanzfaust variants.
Adds MOD for Guard Percentage (needed for Glanzfaust Latent).
Adds math check in battleutils to account for Guard Percent.

All Glanzfaust bonuses for Focus/Dodge require Glanzfaust to be equipped to take effect.

https://www.bg-wiki.com/bg/Glanzfaust_(Level_75)

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

