### PR TITLE
RoE µUpdate for Merits + timed messages

### DIFF
--- a/src/common/mmo.h
+++ b/src/common/mmo.h
@@ -221,6 +221,7 @@ struct eminencecache_t
 {
     std::bitset<4096> activemap;
     uint32 lastWriteout {0};
+    bool notifyTimedRecord {false};
 };
 
 struct nameflags_t

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -6478,6 +6478,13 @@ void SmallPacket0x112(map_session_data_t* session, CCharEntity* PChar, CBasicPac
         // Current RoE quests
         PChar->pushPacket(new CRoeUpdatePacket(PChar));
 
+        // Players logging in to a new timed record get one-time message
+        if (PChar->m_eminenceCache.notifyTimedRecord)
+        {
+            PChar->m_eminenceCache.notifyTimedRecord = false;
+            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, roeutils::GetActiveTimedRecord(), 0, MSGBASIC_ROE_TIMED));
+        }
+
         // 4-part Eminence Completion bitmap
         for (int i = 0; i < 4; i++)
         {

--- a/src/map/packets/message_basic.h
+++ b/src/map/packets/message_basic.h
@@ -139,6 +139,7 @@ enum MSGBASIC_ID : uint16
     MSGBASIC_HAS_LUOPON_NO_USE      = 665, /* <player> has a pet. Unable to use ability. */
 	/* ROE */
 	MSGBASIC_ROE_START              = 704,
+	MSGBASIC_ROE_TIMED              = 705, // You have undertaken the timed record X.
 	MSGBASIC_ROE_RECORD             = 697, // Records of Eminence: <record>.
 	MSGBASIC_ROE_PROGRESS           = 698, // Progress: <amount>/<amount>.
 

--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -419,6 +419,7 @@ void onCharLoad(CCharEntity* PChar)
 
             if (lastOnline < lastJstTimedBlock || PChar->m_eminenceLog.active[30] != GetActiveTimedRecord())
             {
+                PChar->m_eminenceCache.notifyTimedRecord = true;
                 AddActiveTimedRecord(PChar);
             }
         }
@@ -444,7 +445,12 @@ void AddActiveTimedRecord(CCharEntity* PChar)
     PChar->m_eminenceCache.activemap.set(timedRecordID);
     PChar->pushPacket(new CRoeUpdatePacket(PChar));
 
-    SetEminenceRecordCompletion(PChar, timedRecordID, false);
+    if (timedRecordID)
+    {
+        PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, timedRecordID, 0, MSGBASIC_ROE_TIMED));
+        SetEminenceRecordCompletion(PChar, timedRecordID, false);
+    }
+
 }
 
 void ClearDailyRecords(CCharEntity* PChar)

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3725,10 +3725,6 @@ namespace charutils
         {
             //add normal exp
             PChar->jobs.exp[PChar->GetMJob()] += exp;
-            if (PMob != PChar) // Only mob kills count for gain EXP records
-            {
-                roeutils::event(ROE_EXPGAIN, PChar, RoeDatagram("exp", exp));
-            }
         }
 
         if (!expFromRaise)
@@ -3773,6 +3769,10 @@ namespace charutils
         }
 
         PChar->PAI->EventHandler.triggerListener("EXPERIENCE_POINTS", PChar, exp);
+        if (PMob != PChar) // Only mob kills count for gain EXP records
+        {
+            roeutils::event(ROE_EXPGAIN, PChar, RoeDatagram("exp", exp));
+        }
 
         // Player levels up
         if ((currentExp + exp) >= GetExpNEXTLevel(PChar->jobs.job[PChar->GetMJob()]) && !onLimitMode)


### PR DESCRIPTION
Microupdate adds the messages for new Timed Record blocks at login/JST-midnight as well as allowing chars at max level in Merit Mode to accumulate progress for the Gain EXP timed record.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

