### PR TITLE
"Recollections" quest missing dialogue item

### DIFF
--- a/scripts/zones/Heavens_Tower/npcs/Chumimi.lua
+++ b/scripts/zones/Heavens_Tower/npcs/Chumimi.lua
@@ -25,7 +25,7 @@ function onTrade(player, npc, trade)
         trade:hasItemQty(1105, 1) and
         trade:getItemCount() == 1
     then
-        player:startEvent(271)
+        player:startEvent(271, 0, 520)
     elseif
         player:getQuestStatus(WINDURST, tpz.quest.id.windurst.THE_ROOT_OF_THE_PROBLEM) == QUEST_ACCEPTED and
         player:getCharVar("rootProblem") == 1 and


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Passes the correct item (520: linkshell) as option to the corresponding dialogue involved in BLM AF feet quest "Recollections".