### PR TITLE
Adjust char timestamp migration for older Mariadb

### DIFF
--- a/sql/chars.sql
+++ b/sql/chars.sql
@@ -49,7 +49,7 @@ CREATE TABLE `chars` (
   `isstylelocked` tinyint(1) NOT NULL DEFAULT '0',
   `nnameflags` int(10) UNSIGNED NOT NULL DEFAULT '0',
   `moghancement` smallint(4) unsigned NOT NULL DEFAULT '0',
-  `lastupdate` timestamp ON UPDATE CURRENT_TIMESTAMP,
+  `lastupdate` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`charid`),
   FULLTEXT KEY `charname` (`charname`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;

--- a/tools/migrations/char_timestamp.py
+++ b/tools/migrations/char_timestamp.py
@@ -18,6 +18,6 @@ def needs_to_run(cur):
     return True
 
 def migrate(cur, db):
-    cur.execute("ALTER TABLE `chars` ADD COLUMN lastupdate TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;")
+    cur.execute("ALTER TABLE `chars` ADD COLUMN lastupdate TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;")
     db.commit()
 


### PR DESCRIPTION
It appears some older versions of maria require a specific default value.

Thanks to Wren + Kain for reports.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

