### PR TITLE
Fix determining relative entity positions, angles, and conal attacks

### DIFF
--- a/scripts/globals/mobskills/dragon_breath.lua
+++ b/scripts/globals/mobskills/dragon_breath.lua
@@ -15,9 +15,9 @@ require("scripts/globals/utils")
 ---------------------------------------------
 
 function onMobSkillCheck(target, mob, skill)
-    if (target:isBehind(mob, 48) == true) then
+    if not target:isInfront(mob) then
         return 1
-    elseif (mob:AnimationSub() ~= 0) then
+    elseif mob:AnimationSub() ~= 0 then
         return 1
     end
 
@@ -26,11 +26,7 @@ end
 
 function onMobWeaponSkill(target, mob, skill)
     local dmgmod = MobBreathMove(mob, target, 0.2, 1.25, tpz.magic.ele.FIRE, 1400)
-    local angle = mob:getAngle(target)
-
-    angle = mob:getRotPos() - angle
-    dmgmod = dmgmod * ((128-math.abs(angle))/128)
-    dmgmod = utils.clamp(dmgmod, 50, 1600)
+    dmgmod = utils.conalDamageAdjustment(mob, target, skill, dmgmod, 0.9)
 
     local dmg = MobFinalAdjustments(dmgmod, mob, skill, target, tpz.attackType.BREATH, tpz.damageType.FIRE, MOBPARAM_IGNORE_SHADOWS)
 

--- a/scripts/globals/mobskills/dragon_breath.lua
+++ b/scripts/globals/mobskills/dragon_breath.lua
@@ -15,7 +15,7 @@ require("scripts/globals/utils")
 ---------------------------------------------
 
 function onMobSkillCheck(target, mob, skill)
-    if not target:isInfront(mob) then
+    if not target:isInfront(mob, 128) then
         return 1
     elseif mob:AnimationSub() ~= 0 then
         return 1

--- a/scripts/globals/mobskills/fiery_breath.lua
+++ b/scripts/globals/mobskills/fiery_breath.lua
@@ -16,7 +16,7 @@ require("scripts/globals/utils")
 function onMobSkillCheck(target, mob, skill)
     if mob:hasStatusEffect(tpz.effect.MIGHTY_STRIKES) then
         return 1
-    elseif not target:isInfront(mob) then
+    elseif not target:isInfront(mob, 128) then
         return 1
     elseif mob:AnimationSub() == 1 then
         return 1

--- a/scripts/globals/mobskills/fiery_breath.lua
+++ b/scripts/globals/mobskills/fiery_breath.lua
@@ -14,11 +14,11 @@ require("scripts/globals/utils")
 ---------------------------------------------
 
 function onMobSkillCheck(target, mob, skill)
-    if (mob:hasStatusEffect(tpz.effect.MIGHTY_STRIKES)) then
+    if mob:hasStatusEffect(tpz.effect.MIGHTY_STRIKES) then
         return 1
-    elseif (target:isBehind(mob, 48) == true) then
+    elseif not target:isInfront(mob) then
         return 1
-    elseif (mob:AnimationSub() == 1) then
+    elseif mob:AnimationSub() == 1 then
         return 1
     end
 
@@ -27,11 +27,7 @@ end
 
 function onMobWeaponSkill(target, mob, skill)
     local dmgmod = MobBreathMove(mob, target, 0.2, 1.25, tpz.magic.ele.FIRE, 1400)
-    local angle = mob:getAngle(target)
-
-    angle = mob:getRotPos() - angle
-    dmgmod = dmgmod * ((128-math.abs(angle))/128)
-    dmgmod = utils.clamp(dmgmod, 50, 1600)
+    dmgmod = utils.conalDamageAdjustment(mob, target, skill, dmgmod, 0.9)
 
     local dmg = MobFinalAdjustments(dmgmod, mob, skill, target, tpz.attackType.BREATH, tpz.damageType.FIRE, MOBPARAM_IGNORE_SHADOWS)
 

--- a/scripts/globals/mobskills/geotic_breath.lua
+++ b/scripts/globals/mobskills/geotic_breath.lua
@@ -14,11 +14,11 @@ require("scripts/globals/utils")
 ---------------------------------------------
 
 function onMobSkillCheck(target, mob, skill)
-    if (mob:hasStatusEffect(tpz.effect.INVINCIBLE)) then
+    if mob:hasStatusEffect(tpz.effect.INVINCIBLE) then
         return 1
-    elseif (target:isBehind(mob, 48) == true) then
+    elseif not target:isInfront(mob) then
         return 1
-    elseif (mob:AnimationSub() ~= 0) then
+    elseif mob:AnimationSub() ~= 0 then
         return 1
     end
 
@@ -27,11 +27,7 @@ end
 
 function onMobWeaponSkill(target, mob, skill)
     local dmgmod = MobBreathMove(mob, target, 0.2, 1.25, tpz.magic.ele.EARTH, 1400)
-    local angle = mob:getAngle(target)
-
-    angle = mob:getRotPos() - angle
-    dmgmod = dmgmod * ((128-math.abs(angle))/128)
-    dmgmod = utils.clamp(dmgmod, 50, 1600)
+    dmgmod = utils.conalDamageAdjustment(mob, target, skill, dmgmod, 0.9)
 
     local dmg = MobFinalAdjustments(dmgmod, mob, skill, target, tpz.attackType.BREATH, tpz.damageType.EARTH, MOBPARAM_IGNORE_SHADOWS)
 

--- a/scripts/globals/mobskills/geotic_breath.lua
+++ b/scripts/globals/mobskills/geotic_breath.lua
@@ -16,7 +16,7 @@ require("scripts/globals/utils")
 function onMobSkillCheck(target, mob, skill)
     if mob:hasStatusEffect(tpz.effect.INVINCIBLE) then
         return 1
-    elseif not target:isInfront(mob) then
+    elseif not target:isInfront(mob, 128) then
         return 1
     elseif mob:AnimationSub() ~= 0 then
         return 1

--- a/scripts/globals/mobskills/glacial_breath.lua
+++ b/scripts/globals/mobskills/glacial_breath.lua
@@ -16,7 +16,7 @@ require("scripts/globals/utils")
 function onMobSkillCheck(target, mob, skill)
     if mob:hasStatusEffect(tpz.effect.BLOOD_WEAPON) then
         return 1
-    elseif not target:isInfront(mob) then
+    elseif not target:isInfront(mob, 128) then
         return 1
     elseif mob:AnimationSub() == 1 then
         return 1

--- a/scripts/globals/mobskills/glacial_breath.lua
+++ b/scripts/globals/mobskills/glacial_breath.lua
@@ -14,11 +14,11 @@ require("scripts/globals/utils")
 ---------------------------------------------
 
 function onMobSkillCheck(target, mob, skill)
-    if (mob:hasStatusEffect(tpz.effect.BLOOD_WEAPON)) then
+    if mob:hasStatusEffect(tpz.effect.BLOOD_WEAPON) then
         return 1
-    elseif (target:isBehind(mob, 48) == true) then
+    elseif not target:isInfront(mob) then
         return 1
-    elseif (mob:AnimationSub() == 1) then
+    elseif mob:AnimationSub() == 1 then
         return 1
     end
 
@@ -27,11 +27,7 @@ end
 
 function onMobWeaponSkill(target, mob, skill)
     local dmgmod = MobBreathMove(mob, target, 0.2, 1.25, tpz.magic.ele.ICE, 1400)
-    local angle = mob:getAngle(target)
-
-    angle = mob:getRotPos() - angle
-    dmgmod = dmgmod * ((128-math.abs(angle))/128)
-    dmgmod = utils.clamp(dmgmod, 50, 1600)
+    dmgmod = utils.conalDamageAdjustment(mob, target, skill, dmgmod, 0.9)
 
     local dmg = MobFinalAdjustments(dmgmod, mob, skill, target, tpz.attackType.BREATH, tpz.damageType.ICE, MOBPARAM_IGNORE_SHADOWS)
 

--- a/scripts/globals/mobskills/sable_breath.lua
+++ b/scripts/globals/mobskills/sable_breath.lua
@@ -14,7 +14,7 @@ require("scripts/globals/utils")
 ---------------------------------------------
 
 function onMobSkillCheck(target, mob, skill)
-    if not target:isInfront(mob) then
+    if not target:isInfront(mob, 128) then
         return 1
     elseif mob:AnimationSub() ~= 0 then
         return 1

--- a/scripts/globals/mobskills/sable_breath.lua
+++ b/scripts/globals/mobskills/sable_breath.lua
@@ -14,9 +14,9 @@ require("scripts/globals/utils")
 ---------------------------------------------
 
 function onMobSkillCheck(target, mob, skill)
-    if (target:isBehind(mob, 48) == true) then
+    if not target:isInfront(mob) then
         return 1
-    elseif (mob:AnimationSub() ~= 0) then
+    elseif mob:AnimationSub() ~= 0 then
         return 1
     end
 
@@ -25,11 +25,7 @@ end
 
 function onMobWeaponSkill(target, mob, skill)
     local dmgmod = MobBreathMove(mob, target, 0.2, 1.25, tpz.magic.ele.DARK, 1400)
-    local angle = mob:getAngle(target)
-
-    angle = mob:getRotPos() - angle
-    dmgmod = dmgmod * ((128-math.abs(angle))/128)
-    dmgmod = utils.clamp(dmgmod, 50, 1600)
+    dmgmod = utils.conalDamageAdjustment(mob, target, skill, dmgmod, 0.9)
 
     local dmg = MobFinalAdjustments(dmgmod, mob, skill, target, tpz.attackType.BREATH, tpz.damageType.DARK, MOBPARAM_IGNORE_SHADOWS)
 

--- a/scripts/globals/utils.lua
+++ b/scripts/globals/utils.lua
@@ -98,15 +98,22 @@ end
 
 function utils.conalDamageAdjustment(attacker, target, skill, max_damage, minimum_percentage)
     local final_damage = 1
-    -- TODO: Currently all cone attacks use static 45 degree (360 scale) angles in core, when cone attacks
+    -- #TODO: Currently all cone attacks use static 45 degree (360 scale) angles in core, when cone attacks
     -- have different angles and there's a method to fetch the angle, use a line like the below
     -- local cone_angle = skill:getConalAngle()
     local cone_angle = 32 -- 256-degree based, equivalent to "45 degrees" on 360 degree scale
 
-    local conal_angle_power = cone_angle - attacker:getFacingAngle(target)
+    -- #TODO: Conal attacks hit targets in a cone with a center line of the "primary" target (the mob's
+    -- highest enmity target). These primary targets can be within 128 degrees of the mob's front. However,
+    -- there's currently no way for a conal skill to store (and later check) the primary target a mob skill
+    -- was trying to hit. Therefore the "damage drop off" here is based from an origin of the mob's rotation
+    -- instead. Should conal skills become capable of identifying their primary target, this should be changed
+    -- to be based on the degree difference from the primary target instead.
+    local conal_angle_power = cone_angle - math.abs(attacker:getFacingAngle(target))
 
     if conal_angle_power < 0 then
-        print("Error: conalDamageAdjustment - Mob TP move hit target beyond conal angle: ".. cone_angle)
+        -- #TODO The below print will be a valid print upon fixing to-do above relating to beam center orgin
+        -- print("Error: conalDamageAdjustment - Mob TP move hit target beyond conal angle: ".. cone_angle)
         conal_angle_power = 0
     end
 

--- a/scripts/globals/utils.lua
+++ b/scripts/globals/utils.lua
@@ -96,6 +96,31 @@ function utils.takeShadows(target, dmg, shadowbehav)
     return dmg
 end
 
+function utils.conalDamageAdjustment(attacker, target, skill, max_damage, minimum_percentage)
+    local final_damage = 1
+    -- TODO: Currently all cone attacks use static 45 degree (360 scale) angles in core, when cone attacks
+    -- have different angles and there's a method to fetch the angle, use a line like the below
+    -- local cone_angle = skill:getConalAngle()
+    local cone_angle = 32 -- 256-degree based, equivalent to "45 degrees" on 360 degree scale
+
+    local conal_angle_power = cone_angle - attacker:getFacingAngle(target)
+
+    if conal_angle_power < 0 then
+        print("Error: conalDamageAdjustment - Mob TP move hit target beyond conal angle: ".. cone_angle)
+        conal_angle_power = 0
+    end
+
+    -- Calculate the amount of damage to add above the minimum percentage based on how close
+    -- the target is to the center of the conal (0 degrees from the attacker's facing)
+    local minimum_damage = max_damage * minimum_percentage
+    local damage_per_angle = (max_damage - minimum_damage) / cone_angle
+    local additional_damage = damage_per_angle * conal_angle_power
+
+    final_damage = math.max(1, math.ceil(minimum_damage + additional_damage))
+
+    return final_damage
+end
+
 -- returns true if taken by third eye
 function utils.thirdeye(target)
     --third eye doesnt care how many shadows, so attempt to anticipate, but reduce

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -137,23 +137,53 @@ uint8 radianToRotation(float radian)
     return (uint8)((radian / (2 * M_PI)) * 256);
 }
 
-uint8 getangle(const position_t& A, const position_t& B)
+/****************************************************************************
+* Functions for entity-to-entity world angles, and facing differences.      *
+* Highly recommended to read Project Topaz's Wiki page to understand these. *
+*****************************************************************************/
+uint8 worldAngle(const position_t& A, const position_t& B)
 {
     uint8 angle = (uint8)(atanf((B.z - A.z) / (B.x - A.x)) * -(128.0f / M_PI));
 
     return (A.x > B.x ? angle + 128 : angle);
 }
 
-/************************************************************************
-*										       								                              *
-*  Check whether the target is in the field of view (coneAngle)	       	*
-*																		                                    *
-************************************************************************/
-
-bool isFaceing(const position_t& A, const position_t& B, uint8 coneAngle)
+int16 facingAngle(const position_t& A, const position_t& B)
 {
-    int32 angle = getangle(A, B);
-    return abs(int8(angle - A.rotation)) < (coneAngle >> 1);
+    uint8 cardinalAngle = worldAngle(A, B);
+    int16 degreeDiff = cardinalAngle - A.rotation;
+    uint8 absoluteDiff = abs(degreeDiff);
+    if (absoluteDiff > 128)
+    {
+        degreeDiff = 256 - absoluteDiff;
+    }
+    return degreeDiff;
+}
+
+bool facing(const position_t& A, const position_t& B, uint8 coneAngle)
+{
+    return infront(B, A, coneAngle); // If the target is in front of you, you're facing it!
+}
+
+bool infront(const position_t& A, const position_t& B, uint8 coneAngle)
+{
+    uint8 facingDiff = abs(facingAngle(B, A)); // Position swap intentional due to how angles are calculated
+    uint8 halfAngle = static_cast<uint8>(coneAngle / 2);
+    return (facingDiff < halfAngle);
+}
+
+bool behind(const position_t& A, const position_t& B, uint8 coneAngle)
+{
+    uint8 facingDiff = abs(facingAngle(B, A));
+    uint8 halfAngle = static_cast<uint8>(coneAngle / 2);
+    return (facingDiff > 128 - halfAngle); // Abs(Facing Angle) values are always less than 128
+}
+
+bool beside(const position_t& A, const position_t& B, uint8 coneAngle)
+{
+    uint8 facingDiff = abs(facingAngle(B, A));
+    uint8 halfAngle = static_cast<uint8>(coneAngle / 2);
+    return (facingDiff > 64 - halfAngle) && (facingDiff < 64 + halfAngle);
 }
 
 /**

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -141,6 +141,8 @@ uint8 radianToRotation(float radian)
 * Functions for entity-to-entity world angles, and facing differences.      *
 * Highly recommended to read Project Topaz's Wiki page to understand these. *
 *****************************************************************************/
+// https://web.archive.org/web/https://github.com/project-topaz/topaz/wiki/Spatial-Orientation-and-Relative-Positions
+
 uint8 worldAngle(const position_t& A, const position_t& B)
 {
     uint8 angle = (uint8)(atanf((B.z - A.z) / (B.x - A.x)) * -(128.0f / M_PI));
@@ -148,16 +150,35 @@ uint8 worldAngle(const position_t& A, const position_t& B)
     return (A.x > B.x ? angle + 128 : angle);
 }
 
-int16 facingAngle(const position_t& A, const position_t& B)
+uint8 relativeAngle(uint8 world, int16 diff)
 {
-    uint8 cardinalAngle = worldAngle(A, B);
-    int16 degreeDiff = cardinalAngle - A.rotation;
+    uint8 angle = world + diff;
+    if (angle < 0)
+    {
+        angle = 256 - abs(angle);
+    }
+    else
+    {
+        angle = angle % 256;
+    }
+    return angle;
+}
+
+int16 angleDifference(uint8 worldAngleA, uint8 worldAngleB)
+{
+    int16 degreeDiff = worldAngleA - worldAngleB;
     uint8 absoluteDiff = abs(degreeDiff);
     if (absoluteDiff > 128)
     {
         degreeDiff = 256 - absoluteDiff;
     }
     return degreeDiff;
+}
+
+int16 facingAngle(const position_t& A, const position_t& B)
+{
+    uint8 cardinalAngle = worldAngle(A, B);
+    return angleDifference(cardinalAngle, A.rotation);
 }
 
 bool facing(const position_t& A, const position_t& B, uint8 coneAngle)

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -46,11 +46,13 @@ void getMSB(uint32* result,uint32 value);						// fast Most Significant Byte sea
 float rotationToRadian(uint8 rotation);
 uint8 radianToRotation(float radian);
 uint8 worldAngle(const position_t& A, const position_t& B);     // А - the main entity, B - target entity (vector projection onto the X-axis)
+uint8 relativeAngle(uint8 world, int16 diff);                   // Returns a new world angle which is diff degrees in a given (signed) direction
+int16 angleDifference(uint8 worldAngleA, uint8 aworldAngleB);   // Returns difference between two world angles (0~128), sign indicates direction
 int16 facingAngle(const position_t& A, const position_t& B);    // А - the main entity, B - target entity
-bool facing(const position_t& A, const position_t& B, uint8 coneAngle); // true if A is facing B within coneAngle degrees
-bool infront(const position_t& A, const position_t& B, uint8 coneAngle); // true if A is infront of B within coneAngle degrees
-bool behind(const position_t& A, const position_t& B, uint8 coneAngle); // true if A is behind of B within coneAngle degrees
-bool beside(const position_t& A, const position_t& B, uint8 coneAngle); // true if A is to a side of B within coneAngle degrees
+bool facing(const position_t& A, const position_t& B, uint8 coneAngle);   // true if A is facing B within coneAngle degrees
+bool infront(const position_t& A, const position_t& B, uint8 coneAngle);  // true if A is infront of B within coneAngle degrees
+bool behind(const position_t& A, const position_t& B, uint8 coneAngle);   // true if A is behind of B within coneAngle degrees
+bool beside(const position_t& A, const position_t& B, uint8 coneAngle);   // true if A is to a side of B within coneAngle degrees
 position_t nearPosition(const position_t& A, float offset, float radian); // Returns a position near the given position
 
 int32 hasBit(uint16 value, uint8* BitArray, uint32 size);		// Check for the presence of a bit in the array

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -45,8 +45,12 @@ int32 intpow32(int32 base, int32 exponent);						// Exponential power of integer
 void getMSB(uint32* result,uint32 value);						// fast Most Significant Byte search under GCC or MSVC. Fallback included.
 float rotationToRadian(uint8 rotation);
 uint8 radianToRotation(float radian);
-uint8 getangle(const position_t& A, const position_t& B);						// А - the main entity, B - target entity (vector projection onto the X-axis)
-bool  isFaceing(const position_t& A, const position_t& B, uint8 coneAngle);	// А - the main entity, B - the target entity
+uint8 worldAngle(const position_t& A, const position_t& B);     // А - the main entity, B - target entity (vector projection onto the X-axis)
+int16 facingAngle(const position_t& A, const position_t& B);    // А - the main entity, B - target entity
+bool facing(const position_t& A, const position_t& B, uint8 coneAngle); // true if A is facing B within coneAngle degrees
+bool infront(const position_t& A, const position_t& B, uint8 coneAngle); // true if A is infront of B within coneAngle degrees
+bool behind(const position_t& A, const position_t& B, uint8 coneAngle); // true if A is behind of B within coneAngle degrees
+bool beside(const position_t& A, const position_t& B, uint8 coneAngle); // true if A is to a side of B within coneAngle degrees
 position_t nearPosition(const position_t& A, float offset, float radian); // Returns a position near the given position
 
 int32 hasBit(uint16 value, uint8* BitArray, uint32 size);		// Check for the presence of a bit in the array

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -201,7 +201,7 @@ bool CMobController::CanDetectTarget(CBattleEntity* PTarget, bool forceSight)
         hasSneak = PTarget->StatusEffectContainer->HasStatusEffect(EFFECT_SNEAK);
     }
 
-    if (detectSight && !hasInvisible && currentDistance < PMob->getMobMod(MOBMOD_SIGHT_RANGE) && isFaceing(PMob->loc.p, PTarget->loc.p, 40))
+    if (detectSight && !hasInvisible && currentDistance < PMob->getMobMod(MOBMOD_SIGHT_RANGE) && facing(PMob->loc.p, PTarget->loc.p, 64))
     {
         return CanSeePoint(PTarget->loc.p);
     }
@@ -625,7 +625,7 @@ void CMobController::Move()
                         {
                             if (PSpawnedMob.second != PMob && !PSpawnedMob.second->PAI->PathFind->IsFollowingPath() && distance(PSpawnedMob.second->loc.p, PMob->loc.p) < 1.f)
                             {
-                                auto angle = getangle(PMob->loc.p, PTarget->loc.p) + 64;
+                                auto angle = worldAngle(PMob->loc.p, PTarget->loc.p) + 64;
                                 position_t new_pos {PMob->loc.p.x - (cosf(rotationToRadian(angle)) * 1.5f),
                                     PTarget->loc.p.y, PMob->loc.p.z + (sinf(rotationToRadian(angle)) * 1.5f), 0, 0};
                                 if (PMob->PAI->PathFind->ValidPosition(new_pos))

--- a/src/map/ai/controllers/player_controller.cpp
+++ b/src/map/ai/controllers/player_controller.cpp
@@ -187,7 +187,7 @@ bool CPlayerController::WeaponSkill(uint16 targid, uint16 wsid)
 
         if (PTarget)
         {
-            if (!isFaceing(PChar->loc.p, PTarget->loc.p, 40) && PTarget != PChar)
+            if (!facing(PChar->loc.p, PTarget->loc.p, 64) && PTarget != PChar)
             {
                 PChar->pushPacket(new CMessageBasicPacket(PChar, PTarget, 0, 0, MSGBASIC_CANNOT_SEE));
                 return false;

--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -396,7 +396,7 @@ void CPathFind::LookAt(const position_t& point)
 {
     // don't look if i'm at that point
     if (!AtPoint(point)) {
-        m_PTarget->loc.p.rotation = getangle(m_PTarget->loc.p, point);
+        m_PTarget->loc.p.rotation = worldAngle(m_PTarget->loc.p, point);
         m_PTarget->updatemask |= UPDATE_POS;
     }
 }

--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -174,8 +174,10 @@ void CTargetFind::findWithinCone(CBattleEntity* PTarget, float distance, float a
 
     uint8 halfAngle = static_cast<uint8>((angle * (256.0f / 360.0f)) / 2.0f);
 
-    uint8 angleToTarget = worldAngle(m_PBattleEntity->loc.p, PTarget->loc.p);
-
+    // Confirmation on the center of cones is still needed for mob skills; player skills seem to be facing angle
+    // uint8 angleToTarget = worldAngle(m_PBattleEntity->loc.p, PTarget->loc.p);
+    uint8 angleToTarget = m_APoint->rotation;
+    
     // "Left" and "Right" are like the entity's face - "left" means "turning to the left" NOT "left when looking overhead"
     // Remember that rotation increases when turning to the right, and decreases when turning to the left
     float leftAngle = rotationToRadian(relativeAngle(angleToTarget, -halfAngle));

--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -172,10 +172,14 @@ void CTargetFind::findWithinCone(CBattleEntity* PTarget, float distance, float a
 
     m_APoint = &m_PBattleEntity->loc.p;
 
-    float halfAngle = (angle * (256.0f / 360.0f)) / 2.0f;
+    uint8 halfAngle = static_cast<uint8>((angle * (256.0f / 360.0f)) / 2.0f);
 
-    float rightAngle = rotationToRadian(m_APoint->rotation + (uint8)halfAngle);
-    float leftAngle = rotationToRadian(m_APoint->rotation - (uint8)halfAngle);
+    uint8 angleToTarget = worldAngle(m_PBattleEntity->loc.p, PTarget->loc.p);
+
+    // "Left" and "Right" are like the entity's face - "left" means "turning to the left" NOT "left when looking overhead"
+    // Remember that rotation increases when turning to the right, and decreases when turning to the left
+    float leftAngle = rotationToRadian(relativeAngle(angleToTarget, -halfAngle));
+    float rightAngle = rotationToRadian(relativeAngle(angleToTarget, halfAngle));
 
     // calculate end points for triangle
     m_BPoint.x = cosf((2 * (float)M_PI) - rightAngle) * distance + m_APoint->x;
@@ -184,7 +188,7 @@ void CTargetFind::findWithinCone(CBattleEntity* PTarget, float distance, float a
     m_CPoint.x = cosf((2 * (float)M_PI) - leftAngle) * distance + m_APoint->x;
     m_CPoint.z = sinf((2 * (float)M_PI) - leftAngle) * distance + m_APoint->z;
 
-    // ShowDebug("angle %f, rotation %f, distance %f, A (%f, %f) B (%f, %f) C (%f, %f)\n", angle, rightAngle, distance, m_APoint->x, m_APoint->z, m_BPoint.x, m_BPoint.z, m_CPoint.x, m_CPoint.z);
+    // ShowDebug("angle %f, left %f, right %f, distance %f, A (%f, %f) B (%f, %f) C (%f, %f)\n", angle, leftAngle, rightAngle, distance, m_APoint->x, m_APoint->z, m_BPoint.x, m_BPoint.z, m_CPoint.x, m_CPoint.z);
     // ShowDebug("Target: (%f, %f)\n", PTarget->loc.p.x, PTarget->loc.p.z);
 
     // precompute for next stage

--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -170,7 +170,6 @@ void CTargetFind::findWithinCone(CBattleEntity* PTarget, float distance, float a
     m_findFlags = flags;
     m_conal = true;
 
-    // TODO: a point should be based on targets position
     m_APoint = &m_PBattleEntity->loc.p;
 
     float halfAngle = (angle * (256.0f / 360.0f)) / 2.0f;

--- a/src/map/ai/states/range_state.cpp
+++ b/src/map/ai/states/range_state.cpp
@@ -174,7 +174,7 @@ bool CRangeState::CanUseRangedAttack(CBattleEntity* PTarget)
         }
     }
 
-    if (!isFaceing(m_PEntity->loc.p, PTarget->loc.p, 40))
+    if (!facing(m_PEntity->loc.p, PTarget->loc.p, 64))
     {
         m_errorMsg = std::make_unique<CMessageBasicPacket>(m_PEntity, PTarget, 0, 0, MSGBASIC_CANNOT_SEE);
         return false;

--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -432,7 +432,7 @@ bool CAttack::CheckCounter()
         seiganChance /= 4;
     }
     if ((tpzrand::GetRandomNumber(100) < std::clamp<uint16>(m_victim->getMod(Mod::COUNTER) + meritCounter, 0, 80) || tpzrand::GetRandomNumber(100) < seiganChance) &&
-        isFaceing(m_victim->loc.p, m_attacker->loc.p, 40) && tpzrand::GetRandomNumber(100) < battleutils::GetHitRate(m_victim, m_attacker))
+        facing(m_victim->loc.p, m_attacker->loc.p, 64) && tpzrand::GetRandomNumber(100) < battleutils::GetHitRate(m_victim, m_attacker))
     {
         m_isCountered = true;
         m_isCritical = (tpzrand::GetRandomNumber(100) < battleutils::GetCritHitRate(m_victim, m_attacker, false));

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -676,7 +676,7 @@ bool CCharEntity::CanAttack(CBattleEntity* PTarget, std::unique_ptr<CBasicPacket
         PAI->Disengage();
         return false;
     }
-    else if (!isFaceing(this->loc.p, PTarget->loc.p, 40))
+    else if (!facing(this->loc.p, PTarget->loc.p, 64))
     {
         errMsg = std::make_unique<CMessageBasicPacket>(this, PTarget, 0, 0, MSGBASIC_UNABLE_TO_SEE_TARG);
         return false;
@@ -704,7 +704,7 @@ bool CCharEntity::OnAttack(CAttackState& state, action_t& action)
             for (auto&& PPotentialTarget : this->SpawnMOBList)
             {
                 if (PPotentialTarget.second->animation == ANIMATION_ATTACK &&
-                    isFaceing(this->loc.p, PPotentialTarget.second->loc.p, 64) &&
+                    facing(this->loc.p, PPotentialTarget.second->loc.p, 64) &&
                     distance(this->loc.p, PPotentialTarget.second->loc.p) <= 10)
                 {
                     std::unique_ptr<CBasicPacket> errMsg;

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -287,7 +287,7 @@ bool CMobEntity::CanLink(position_t* pos, int16 superLink)
     // link only if I see him
     if (m_Detects & DETECT_SIGHT) {
 
-        if (!isFaceing(loc.p, *pos, 40))
+        if (!facing(loc.p, *pos, 64))
         {
             return false;
         }

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -194,7 +194,7 @@ inline int32 CLuaBaseEntity::showText(lua_State *L)
         if (PBaseEntity->objtype == TYPE_NPC)
         {
             PBaseEntity->m_TargID = m_PBaseEntity->targid;
-            PBaseEntity->loc.p.rotation = getangle(PBaseEntity->loc.p, m_PBaseEntity->loc.p);
+            PBaseEntity->loc.p.rotation = worldAngle(PBaseEntity->loc.p, m_PBaseEntity->loc.p);
 
             PBaseEntity->loc.zone->PushPacket(
                 PBaseEntity,
@@ -1614,7 +1614,7 @@ inline int32 CLuaBaseEntity::lookAt(lua_State* L)
     point.y = posY;
     point.z = posZ;
 
-    m_PBaseEntity->loc.p.rotation = getangle(m_PBaseEntity->loc.p, point);
+    m_PBaseEntity->loc.p.rotation = worldAngle(m_PBaseEntity->loc.p, point);
 
     m_PBaseEntity->updatemask |= UPDATE_POS;
 
@@ -2337,58 +2337,14 @@ inline int32 CLuaBaseEntity::sendEmote(lua_State* L)
 }
 
 /************************************************************************
-*  Function: isBehind()
-*  Purpose : Returns true if entity is behind another entity
-*  Example : if (attacker:isBehind(target)) then
-*  Notes   : Can specify angle for wider/narrower ranges
+*  Function: getWorldAngle()
+*  Purpose : Returns angle between two entities, relative to cardinal direction
+*  Example : player:worldAngle(target)
+*  Notes   : Target is... 0: east; 64: south; 128: west, 192: north
+*            Default angle is 255-based mob rotation value - NOT a 360 angle
 ************************************************************************/
 
-inline int32 CLuaBaseEntity::isBehind(lua_State *L)
-{
-    TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
-    TPZ_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isuserdata(L, 1));
-
-    CLuaBaseEntity* PLuaBaseEntity = Lunar<CLuaBaseEntity>::check(L, 1);
-
-    auto angle = lua_gettop(L) > 1 ? lua_tointeger(L, 2) : 42;
-
-    uint8 turn = PLuaBaseEntity->GetBaseEntity()->loc.p.rotation - getangle(PLuaBaseEntity->GetBaseEntity()->loc.p, m_PBaseEntity->loc.p);
-
-    lua_pushboolean(L, (turn > 128 - angle && turn < 128 + angle));
-
-    return 1;
-}
-
-/************************************************************************
-*  Function: isFacing()
-*  Purpose : Returns true if an entity is in front of another entity
-*  Example : if (attacker:isFacing(target)) then
-*  Notes   : Can specify angle for wider/narrower ranges
-************************************************************************/
-
-inline int32 CLuaBaseEntity::isFacing(lua_State *L)
-{
-    TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
-    TPZ_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isuserdata(L, 1));
-
-    CLuaBaseEntity* PLuaBaseEntity = Lunar<CLuaBaseEntity>::check(L, 1);
-
-    auto angle = (uint8)(lua_gettop(L) > 1 ? lua_tointeger(L, 2) : 45);
-
-    TPZ_DEBUG_BREAK_IF(PLuaBaseEntity == nullptr);
-
-    lua_pushboolean(L, isFaceing(m_PBaseEntity->loc.p, PLuaBaseEntity->GetBaseEntity()->loc.p, angle));
-    return 1;
-}
-
-/************************************************************************
-*  Function: getAngle()
-*  Purpose : Returns the angle between two entities relative to front
-*  Example : player:getAngle(target)
-*  Notes   : 0 degrees front; 180 behind
-************************************************************************/
-
-inline int32 CLuaBaseEntity::getAngle(lua_State *L)
+inline int32 CLuaBaseEntity::getWorldAngle(lua_State *L)
 {
     TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
     TPZ_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isuserdata(L, 1));
@@ -2397,7 +2353,135 @@ inline int32 CLuaBaseEntity::getAngle(lua_State *L)
 
     TPZ_DEBUG_BREAK_IF(PLuaBaseEntity == nullptr);
 
-    lua_pushnumber(L, getangle(m_PBaseEntity->loc.p, PLuaBaseEntity->GetBaseEntity()->loc.p));
+    int16 angle = worldAngle(m_PBaseEntity->loc.p, PLuaBaseEntity->GetBaseEntity()->loc.p);
+    int16 degrees = (int16)(lua_gettop(L) > 1 ? lua_tointeger(L, 2) : 256);
+    if (degrees != 256)
+    {
+        if (degrees % 4 == 0)
+        {
+            angle = static_cast<int16>(round((angle * M_PI / 128) * (degrees / (2 * M_PI))));
+            angle = angle % degrees; // If we rounded up to the "final" angle, we want the starting angle
+        }
+        else
+        {
+            ShowError(CL_RED "getWorldAngle: Called with degrees %d which isn't multiple of 4 \n" CL_RESET, degrees);
+        }
+    }
+
+    lua_pushnumber(L, angle);
+    return 1;
+}
+
+/************************************************************************
+ *  Function: getFacingAngle()
+ *  Purpose : Returns angle comparison of where entity is facing versus where
+ *            a target is. Returned value is how many degrees the
+ *            entity would need to turn to directly face the target.
+ *  Example : attacker:getFacingAngle(defender)
+ *  Notes   : 0: directly facing; 64: to a side; 128 target behind entity
+ *            Returned angle is 255-based rotation value - NOT a 360 angle
+ *            Return value is signed to indicate this shortest turn direction.
+ *            Negative: counter-clockwise (left), Positive: clockwise (right)
+ ************************************************************************/
+
+inline int32 CLuaBaseEntity::getFacingAngle(lua_State* L)
+{
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+    TPZ_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isuserdata(L, 1));
+
+    CLuaBaseEntity* PLuaBaseEntity = Lunar<CLuaBaseEntity>::check(L, 1);
+
+    TPZ_DEBUG_BREAK_IF(PLuaBaseEntity == nullptr);
+
+    lua_pushnumber(L, facingAngle(m_PBaseEntity->loc.p, PLuaBaseEntity->GetBaseEntity()->loc.p));
+    return 1;
+}
+
+/************************************************************************
+ *  Function: isFacing()
+ *  Purpose : Returns true if an entity is facing another entity
+ *  Example : if (attacker:isFacing(target)) then
+ *  Notes   : Can specify angle for wider/narrower ranges
+ ************************************************************************/
+
+inline int32 CLuaBaseEntity::isFacing(lua_State* L)
+{
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+    TPZ_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isuserdata(L, 1));
+
+    CLuaBaseEntity* PLuaBaseEntity = Lunar<CLuaBaseEntity>::check(L, 1);
+
+    auto angle = (uint8)(lua_gettop(L) > 1 ? lua_tointeger(L, 2) : 64);
+
+    TPZ_DEBUG_BREAK_IF(PLuaBaseEntity == nullptr);
+
+    lua_pushboolean(L, facing(m_PBaseEntity->loc.p, PLuaBaseEntity->GetBaseEntity()->loc.p, angle));
+    return 1;
+}
+
+/************************************************************************
+ *  Function: isInfront()
+ *  Purpose : Returns true if an entity is in front of another entity
+ *  Example : if (attacker:isInfront(target)) then
+ *  Notes   : Can specify angle for wider/narrower ranges
+ ************************************************************************/
+
+inline int32 CLuaBaseEntity::isInfront(lua_State* L)
+{
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+    TPZ_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isuserdata(L, 1));
+
+    CLuaBaseEntity* PLuaBaseEntity = Lunar<CLuaBaseEntity>::check(L, 1);
+
+    auto angle = (uint8)(lua_gettop(L) > 1 ? lua_tointeger(L, 2) : 64);
+
+    TPZ_DEBUG_BREAK_IF(PLuaBaseEntity == nullptr);
+
+    lua_pushboolean(L, infront(m_PBaseEntity->loc.p, PLuaBaseEntity->GetBaseEntity()->loc.p, angle));
+    return 1;
+}
+
+/************************************************************************
+ *  Function: isBehind()
+ *  Purpose : Returns true if an entity is behind another entity
+ *  Example : if (attacker:isBehind(target)) then
+ *  Notes   : Can specify angle for wider/narrower ranges
+ ************************************************************************/
+
+inline int32 CLuaBaseEntity::isBehind(lua_State* L)
+{
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+    TPZ_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isuserdata(L, 1));
+
+    CLuaBaseEntity* PLuaBaseEntity = Lunar<CLuaBaseEntity>::check(L, 1);
+
+    auto angle = (uint8)(lua_gettop(L) > 1 ? lua_tointeger(L, 2) : 64);
+
+    TPZ_DEBUG_BREAK_IF(PLuaBaseEntity == nullptr);
+
+    lua_pushboolean(L, behind(m_PBaseEntity->loc.p, PLuaBaseEntity->GetBaseEntity()->loc.p, angle));
+    return 1;
+}
+
+/************************************************************************
+ *  Function: isBeside()
+ *  Purpose : Returns true if an entity is to the side of another entity
+ *  Example : if (attacker:isBeside(target)) then
+ *  Notes   : Can specify angle for wider/narrower ranges
+ ************************************************************************/
+
+inline int32 CLuaBaseEntity::isBeside(lua_State* L)
+{
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+    TPZ_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isuserdata(L, 1));
+
+    CLuaBaseEntity* PLuaBaseEntity = Lunar<CLuaBaseEntity>::check(L, 1);
+
+    auto angle = (uint8)(lua_gettop(L) > 1 ? lua_tointeger(L, 2) : 64);
+
+    TPZ_DEBUG_BREAK_IF(PLuaBaseEntity == nullptr);
+
+    lua_pushboolean(L, beside(m_PBaseEntity->loc.p, PLuaBaseEntity->GetBaseEntity()->loc.p, angle));
     return 1;
 }
 
@@ -2835,7 +2919,7 @@ inline int32 CLuaBaseEntity::teleport(lua_State *L)
     else if (lua_isuserdata(L, 2))
     {
         CLuaBaseEntity* PLuaBaseEntity = Lunar<CLuaBaseEntity>::check(L, 2);
-        m_PBaseEntity->loc.p.rotation = getangle(m_PBaseEntity->loc.p, PLuaBaseEntity->GetBaseEntity()->loc.p);
+        m_PBaseEntity->loc.p.rotation = worldAngle(m_PBaseEntity->loc.p, PLuaBaseEntity->GetBaseEntity()->loc.p);
     }
 
     m_PBaseEntity->loc.zone->PushPacket(m_PBaseEntity, CHAR_INRANGE, new CPositionPacket(m_PBaseEntity));
@@ -14600,10 +14684,13 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,sendEmote),
 
     // Location and Positioning
-    LUNAR_DECLARE_METHOD(CLuaBaseEntity,isBehind),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,getWorldAngle),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,getFacingAngle),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,isFacing),
-    LUNAR_DECLARE_METHOD(CLuaBaseEntity,getAngle),
-
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,isInfront),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,isBehind),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,isBeside),
+    
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getZone),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getZoneID),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getZoneName),

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -134,9 +134,14 @@ public:
     int32 sendEmote(lua_State*);             // Character emits emote packet.
 
     // Location and Positioning
-    int32 isBehind(lua_State*);              // true if you're behind the input target
+
+    int32 getWorldAngle(lua_State* L);       // return angle (rot) between two points (vector from a to b), aligned to absolute cardinal degree
+    int32 getFacingAngle(lua_State* L);      // return angle between entity rot and target pos, aligned to number of degrees of difference
     int32 isFacing(lua_State*);              // true if you are facing the target
-    int32 getAngle(lua_State* L);            // return angle (rot) between two points (vector from a to b)
+    int32 isInfront(lua_State*);             // true if you're infront of the input target
+    int32 isBehind(lua_State*);              // true if you're behind the input target
+    int32 isBeside(lua_State*);              // true if you're to the side of the input target
+
     int32 getZone(lua_State*);               // Get Entity zone
     int32 getZoneID(lua_State*);             // Get Entity zone ID
     int32 getZoneName(lua_State*);           // Get Entity zone name

--- a/src/map/utils/attackutils.cpp
+++ b/src/map/utils/attackutils.cpp
@@ -103,7 +103,7 @@ namespace attackutils
     ************************************************************************/
     bool IsParried(CBattleEntity* PAttacker, CBattleEntity* PDefender)
     {
-        if (isFaceing(PDefender->loc.p, PAttacker->loc.p, 40))
+        if (facing(PDefender->loc.p, PAttacker->loc.p, 64))
         {
             return (tpzrand::GetRandomNumber(100) < battleutils::GetParryRate(PAttacker, PDefender));
         }
@@ -117,7 +117,7 @@ namespace attackutils
     ************************************************************************/
     bool IsGuarded(CBattleEntity* PAttacker, CBattleEntity* PDefender)
     {
-        if (isFaceing(PDefender->loc.p, PAttacker->loc.p, 40))
+        if (facing(PDefender->loc.p, PAttacker->loc.p, 64))
         {
             return(tpzrand::GetRandomNumber(100) < battleutils::GetGuardRate(PAttacker, PDefender));
         }
@@ -131,7 +131,7 @@ namespace attackutils
     ************************************************************************/
     bool IsBlocked(CBattleEntity* PAttacker, CBattleEntity* PDefender)
     {
-        if (isFaceing(PDefender->loc.p, PAttacker->loc.p, 40) && !PDefender->StatusEffectContainer->HasPreventActionEffect())
+        if (facing(PDefender->loc.p, PAttacker->loc.p, 64) && !PDefender->StatusEffectContainer->HasPreventActionEffect())
         {
             return(tpzrand::GetRandomNumber(100) < battleutils::GetBlockRate(PAttacker, PDefender));
         }

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -578,7 +578,7 @@ namespace battleutils
         // Handle Retaliation
         if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_RETALIATION) && PDefender->PAI->IsEngaged()
             && battleutils::GetHitRate(PDefender, PAttacker) / 2 > tpzrand::GetRandomNumber(100)
-            && isFaceing(PDefender->loc.p, PAttacker->loc.p, 40))
+            && facing(PDefender->loc.p, PAttacker->loc.p, 64))
         {
             // Retaliation rate is based on player acc vs mob evasion. Missed retaliations do not even display in log.
             // Other theories exist but were not proven or reliably tested (I have to assume too many things to even consider JP translations about weapon delay), this at least has data to back it up.
@@ -1376,7 +1376,7 @@ namespace battleutils
             }
 
             //Check For Ambush Merit - Ranged
-            if ((charutils::hasTrait((CCharEntity*)PAttacker, TRAIT_AMBUSH)) && ((abs(PDefender->loc.p.rotation - PAttacker->loc.p.rotation) < 23))) {
+            if ((charutils::hasTrait((CCharEntity*)PAttacker, TRAIT_AMBUSH)) && behind(PAttacker->loc.p, PDefender->loc.p, 64)) {
                 acc += ((CCharEntity*)PAttacker)->PMeritPoints->GetMeritValue(MERIT_AMBUSH, (CCharEntity*)PAttacker);
             }
 
@@ -1386,7 +1386,7 @@ namespace battleutils
             acc = PAttacker->RACC(SKILL_AUTOMATON_RANGED);
         }
         // Check for Yonin evasion bonus while in front of target
-        if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_YONIN) && ((abs(abs(PAttacker->loc.p.rotation - PDefender->loc.p.rotation) - 128) < 23)))
+        if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_YONIN) && infront(PDefender->loc.p, PAttacker->loc.p, 64))
         {
             acc -= PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_YONIN)->GetPower();
         }
@@ -2193,7 +2193,7 @@ namespace battleutils
     {
         int32 hitrate = 75;
 
-        if (PAttacker->objtype == TYPE_PC && ((PAttacker->StatusEffectContainer->HasStatusEffect(EFFECT_SNEAK_ATTACK) && (abs(PDefender->loc.p.rotation - PAttacker->loc.p.rotation) < 23 || PAttacker->StatusEffectContainer->HasStatusEffect(EFFECT_HIDE))) ||
+        if (PAttacker->objtype == TYPE_PC && ((PAttacker->StatusEffectContainer->HasStatusEffect(EFFECT_SNEAK_ATTACK) && (behind(PAttacker->loc.p, PDefender->loc.p, 64) || PAttacker->StatusEffectContainer->HasStatusEffect(EFFECT_HIDE))) ||
             (charutils::hasTrait((CCharEntity*)PAttacker, TRAIT_ASSASSIN) && PAttacker->StatusEffectContainer->HasStatusEffect(EFFECT_TRICK_ATTACK) && battleutils::getAvailableTrickAttackChar(PAttacker, PDefender))))
         {
             hitrate = 100; //attack with SA active or TA/Assassin cannot miss
@@ -2202,27 +2202,27 @@ namespace battleutils
         {
             //ShowDebug("Accuracy mod before direction checks: %d\n", offsetAccuracy);
             //Check For Ambush Merit - Melee
-            if (PAttacker->objtype == TYPE_PC && (charutils::hasTrait((CCharEntity*)PAttacker, TRAIT_AMBUSH)) && ((abs(PDefender->loc.p.rotation - PAttacker->loc.p.rotation) < 23)))
+            if (PAttacker->objtype == TYPE_PC && (charutils::hasTrait((CCharEntity*)PAttacker, TRAIT_AMBUSH)) && behind(PAttacker->loc.p, PDefender->loc.p, 64))
             {
                 offsetAccuracy += ((CCharEntity*)PAttacker)->PMeritPoints->GetMeritValue(MERIT_AMBUSH, (CCharEntity*)PAttacker);
             }
-            // Check for Closed Position merit on attacker and that attacker and defender are facing each other (within ~20 degrees from straight on)
-            if (PAttacker->objtype == TYPE_PC && (charutils::hasTrait((CCharEntity*)PAttacker, TRAIT_CLOSED_POSITION)) && ((abs(abs(PDefender->loc.p.rotation - PAttacker->loc.p.rotation) - 128) < 15)))
+            // Check for Closed Position merit on attacker for additional accuracy and that attacker and defender are facing each other
+            if (PAttacker->objtype == TYPE_PC && (charutils::hasTrait((CCharEntity*)PAttacker, TRAIT_CLOSED_POSITION)) && (infront(PAttacker->loc.p, PDefender->loc.p, 64) && facing(PAttacker->loc.p, PDefender->loc.p, 64)))
             {
                 offsetAccuracy += ((CCharEntity*)PAttacker)->PMeritPoints->GetMeritValue(MERIT_CLOSED_POSITION, (CCharEntity*)PAttacker);
             }
-            // Check for Closed Position merit on defender that attacker and defender are facing each other (within ~20 degrees from straight on)
-            if (PDefender->objtype == TYPE_PC && (charutils::hasTrait((CCharEntity*)PDefender, TRAIT_CLOSED_POSITION)) && ((abs(abs(PDefender->loc.p.rotation - PAttacker->loc.p.rotation) - 128) < 15)))
+            // Check for Closed Position merit on defender for additional evasion and that attacker and defender are facing each other
+            if (PDefender->objtype == TYPE_PC && (charutils::hasTrait((CCharEntity*)PDefender, TRAIT_CLOSED_POSITION)) && (infront(PDefender->loc.p, PAttacker->loc.p, 64) && facing(PDefender->loc.p, PAttacker->loc.p, 64)))
             {
                 offsetAccuracy -= ((CCharEntity*)PDefender)->PMeritPoints->GetMeritValue(MERIT_CLOSED_POSITION, (CCharEntity*)PDefender);
             }
             // Check for Innin accuracy bonus from behind target
-            if (PAttacker->StatusEffectContainer->HasStatusEffect(EFFECT_INNIN) && ((abs(PDefender->loc.p.rotation - PAttacker->loc.p.rotation) < 23)))
+            if (PAttacker->StatusEffectContainer->HasStatusEffect(EFFECT_INNIN) && behind(PAttacker->loc.p, PDefender->loc.p, 64))
             {
                 offsetAccuracy += PAttacker->StatusEffectContainer->GetStatusEffect(EFFECT_INNIN)->GetPower();
             }
             // Check for Yonin evasion bonus while in front of target
-            if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_YONIN) && ((abs(abs(PAttacker->loc.p.rotation - PDefender->loc.p.rotation) - 128) < 23)))
+            if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_YONIN) && infront(PDefender->loc.p, PAttacker->loc.p, 64))
             {
                 offsetAccuracy -= PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_YONIN)->GetPower();
             }
@@ -2268,7 +2268,7 @@ namespace battleutils
         else if (PAttacker->objtype == TYPE_PC && (!ignoreSneakTrickAttack) && PAttacker->StatusEffectContainer->HasStatusEffect(EFFECT_SNEAK_ATTACK))
         {
 
-            if (abs(PDefender->loc.p.rotation - PAttacker->loc.p.rotation) < 23 || PAttacker->StatusEffectContainer->HasStatusEffect(EFFECT_HIDE))
+            if (behind(PAttacker->loc.p, PDefender->loc.p, 64) || PAttacker->StatusEffectContainer->HasStatusEffect(EFFECT_HIDE))
             {
                 crithitrate = 100;
             }
@@ -2297,19 +2297,20 @@ namespace battleutils
                 }
             }
 
-            if (PDefender->objtype == TYPE_PC) crithitrate -= ((CCharEntity*)PDefender)->PMeritPoints->GetMeritValue(MERIT_ENEMY_CRIT_RATE, (CCharEntity*)PDefender);
-            //ShowDebug("Crit rate mod before Innin/Yonin: %d\n", crithitrate);
+            if (PDefender->objtype == TYPE_PC)
+            {
+                crithitrate -= ((CCharEntity*)PDefender)->PMeritPoints->GetMeritValue(MERIT_ENEMY_CRIT_RATE, (CCharEntity*)PDefender);
+            }
             // Check for Innin crit rate bonus from behind target
-            if (PAttacker->StatusEffectContainer->HasStatusEffect(EFFECT_INNIN) && ((abs(PDefender->loc.p.rotation - PAttacker->loc.p.rotation) < 23)))
+            if (PAttacker->StatusEffectContainer->HasStatusEffect(EFFECT_INNIN) && behind(PAttacker->loc.p, PDefender->loc.p, 64))
             {
                 crithitrate += PAttacker->StatusEffectContainer->GetStatusEffect(EFFECT_INNIN)->GetPower();
             }
-            // Check for Yonin crit rate bonus while in front of target
-            if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_YONIN) && ((abs(abs(PAttacker->loc.p.rotation - PDefender->loc.p.rotation) - 128) < 23)))
+            // Check for Yonin enemy crit rate reduction while in front of target
+            if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_YONIN) && infront(PDefender->loc.p, PAttacker->loc.p, 64))
             {
                 crithitrate -= PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_YONIN)->GetPower();
             }
-            //ShowDebug("Crit rate mod after Innin/Yonin: %d\n", crithitrate);
 
             int32 attackerdex = PAttacker->DEX();
             int32 defenderagi = PDefender->AGI();
@@ -3098,12 +3099,9 @@ namespace battleutils
             * (100 + PAttacker->getMod(Mod::SKILLCHAINDMG)) / 100);
 
         auto PChar = dynamic_cast<CCharEntity *>(PAttacker);
-        if (PChar && PChar->StatusEffectContainer->HasStatusEffect(EFFECT_INNIN))
+        if (PChar && PChar->StatusEffectContainer->HasStatusEffect(EFFECT_INNIN) && behind(PChar->loc.p, PDefender->loc.p, 64))
         {
-            auto angle = PDefender->loc.p.rotation - getangle(PDefender->loc.p, PChar->loc.p);
-            // assuming default tolerance of 42 from lua_baseentity.cpp
-            if (angle > 86 && angle < 170)
-                damage = (int32)(damage * (1.f + PChar->PMeritPoints->GetMeritValue(MERIT_INNIN_EFFECT, PChar)/100.f));
+            damage = (int32)(damage * (1.f + PChar->PMeritPoints->GetMeritValue(MERIT_INNIN_EFFECT, PChar)/100.f));    
         }
         damage = damage * (1000 - resistance) / 1000;
         damage = MagicDmgTaken(PDefender, damage, appliedEle);
@@ -3555,8 +3553,8 @@ namespace battleutils
     {
         if (m_PChar->objtype == TYPE_PC) // Some mobskills use TakeWeaponskillDamage function, which calls upon this one.
         {
-            // must be facing mob
-            if (isFaceing(PDefender->loc.p, m_PChar->loc.p, 23))
+            // must be in front of mob
+            if (infront(m_PChar->loc.p, PDefender->loc.p, 64))
             {
                 uint8 meritCount = m_PChar->PMeritPoints->GetMeritValue(MERIT_OVERWHELM, m_PChar);
                 // ShowDebug("Merits: %u\n", meritCount);


### PR DESCRIPTION
⚠️ **Highly recommended reading: http://wiki.project-topaz.com/Spatial-Orientation-and-Relative-Positions**

^ No really, you don't stand a chance of understanding the changes in this PR until you have~!

Currently, everything relating to positions will encounter issues at Rotation 0 (due East). This all stems from one [little lie told in the documentation for `getangle`](https://github.com/project-topaz/topaz/blob/37e22e0e9f648043e55158716c52631dde4f376a/src/map/lua/lua_baseentity.cpp#L2384-L2402):
```cpp
*  Function: getAngle()
*  Purpose : Returns the angle between two entities relative to front
*  Example : player:getAngle(target)
*  Notes   : 0 degrees front; 180 behind
```
That is [not what getAngle did at all](https://github.com/project-topaz/topaz/blob/37e22e0e9f648043e55158716c52631dde4f376a/src/common/utils.cpp#L140-L145).

What `getangle` was returning was the "world angle" between two entities - _not_ a facing angle. It was also using a different scale than advertised. This leads to some problems:
![current_function](https://user-images.githubusercontent.com/13112942/96661875-a9a41380-133c-11eb-9fbd-596555d5ed20.png)

We also had places which weren't even using getangle - [but instead subtracting two raw rotations from each other - **which caused them to suffer from the "rotation overflow" problem** above](https://github.com/project-topaz/topaz/blob/37e22e0e9f648043e55158716c52631dde4f376a/src/map/utils/battleutils.cpp#L2272-L2274).
```
Entity A: Rotation 255 (East), Entity B: Rotation 1 (East)
255 - 1 = 254, which isn't less than 64
```
(**Note**: This was reported in https://github.com/DarkstarProject/darkstar/issues/6415)

Naturally, this is all very no bueno. So I made `getangle` into the more specific `getWorldAngle`, which serves the same functional purpose that `getangle` _actually did_. As a nice bonus I threw in, it now lets you optionally pass in a custom number of degrees to scale to, provided that they're a multiple of 4.

**BOLD FOR EMPHASIS: You can now get the world angle between two entities on a custom scale. 4 = NESW, 8 adds NE, SE, SW, and SE. Increase for additional cardinal axis. This means _you_, Ballista Rooks, VWNMs, and [Geomancer](https://github.com/project-topaz/topaz/pull/723#discussion_r443180935)!**

Afterwards I added `getFacingAngle` to do what the previous `getangle` _advertised_, and several positioning arc functions like `isInfront`, `isBeside`, and `isBehind`. Each of the positioning functions can take a custom angle (_always 256 scaled_), but will otherwise use a default of 64 (equivalent to 90 degrees on "360 scale").

**So then came changes to conal attacks**. Wikis claim that damage drops from the center line of the cone. So I wrote a new lua utility function to handle that. It takes a "minimum percentage" argument, which is, well, **the minimum damage you'll take if you're hit with that breath attack at its farthest end. The closer you are to the damage line of the attack, the closer you'll get to taking the passed-in max damage**.

I couldn't find any sources on how this "damage reduction if you're farther away" is calculated. I'm a skeptic, so at the moment I'm not convinced it's real. So **I set all dragon breath attacks to have a minimum percentage of 90%** because I'd rather damage be overtuned than undertuned! _Normally_ in this circumstance I'd keep it at 100%, but I wanted to illustrate that the damage adjustment function works and how. Servers can set each breath's minimum percentages to their taste.

Due to what has been ingrained in all of us - "stand on the paws" - there were some questions to how these breaths worked. _Why_ are we standing on the paws? Do we dodge damage? Do we reduce damage? Hopefully by now everyone knows the **dangers of myths**. @zach2good and @UynGH did a video test on retail, and they produced this one beautiful image which shows a lot.
![breath3](https://user-images.githubusercontent.com/13112942/96663970-53859f00-1341-11eb-8d51-7b32b38a1acf.jpg)
That's Nyu, who had hate, getting hit with Dragon Breath while almost 90 degrees ("360 scale") to Fafnir's right. You can see it targeting _him_ in Zach's log, _and_ Nyu _being on fire_ from the animation. Also notice that Zach _wasn't_ hit.

**Dragon Breath can be used on someone so long as they're within the front 180 degrees ("360 scale") of the mob.** ~~Additional targets are based on the conal fan from the _primary_ target - not the mob's face. This [matches a TODO in targetfind's findWithinCone](https://github.com/project-topaz/topaz/blob/37e22e0e9f648043e55158716c52631dde4f376a/src/map/ai/helpers/targetfind.cpp#L168-L174).~~

(There is a video of this, but I won't publicly link it here. You might be able to ask Zach on Discord if you don't believe me.)

~~With the help of a new additional utility function (`relativeAngle`), **targets are now hit based on the primary target** instead of where the mob is facing.~~

(**Edit:** See later comments; I reverted the above back to additional targets from the mob's face.)

[This presented a problem for breath damage reduction, which will need to be solved later](https://github.com/ibm2431/topaz/blob/0bd3bad899d48dfb4d2785d331bbc36d073f707f/scripts/globals/utils.lua#L106-L111). It'd require a pretty massive restructuring of how mob skills work. When targets get hit with a skill, the lua script is executed individually on each one, with no methods of storing arbitrary data about what the skill did to others - like the primary target's world angle. **So while the targets hit are correctly selected, the "center damage line" used for breath damage reduction is unfortunately still the mob's face**. Keep this in mind when adjusting minimum damage percentages.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

