### PR TITLE
Fix mobskill flag 0x010 (SKILLFLAG_REPLACE_ATTACK)

### DIFF
--- a/src/map/mobskill.cpp
+++ b/src/map/mobskill.cpp
@@ -69,9 +69,14 @@ bool CMobSkill::isTwoHour() const
   return m_Flag & SKILLFLAG_TWO_HOUR;
 }
 
+bool CMobSkill::isAttackReplacement() const
+{
+  return m_Flag & SKILLFLAG_REPLACE_ATTACK;
+}
+
 bool CMobSkill::isTpSkill() const
 {
-    return !isSpecial();
+    return !isSpecial() && !isAttackReplacement();
 }
 
 bool CMobSkill::isSpecial() const

--- a/src/map/mobskill.h
+++ b/src/map/mobskill.h
@@ -50,6 +50,7 @@ public:
     bool        isSingle() const;
     bool        isTwoHour() const;
     bool        isSpecial() const;
+    bool        isAttackReplacement() const;
     bool        isTpSkill() const;
 
     uint16      getID() const;


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Adds `isAttackReplacement()` to `mobskill.cpp` to prevent mobskill flag `SKILLFLAG_REPLACE_ATTACK = 0x010` from using up TP.

Fixes https://github.com/project-topaz/topaz/issues/1406
- [x] Successfully built and tested working locally