### PR TITLE
Validate wide scan tracking

### DIFF
--- a/src/map/entities/baseentity.cpp
+++ b/src/map/entities/baseentity.cpp
@@ -119,6 +119,16 @@ bool CBaseEntity::IsNameHidden()
 	return namevis & FLAG_HIDE_NAME;
 }
 
+bool CBaseEntity::IsTargetable()
+{
+    return (namevis & FLAG_UNTARGETABLE) == 0;
+}
+
+bool CBaseEntity::isWideScannable()
+{
+    return status != STATUS_DISAPPEAR && !IsNameHidden() && IsTargetable();
+}
+
 CBaseEntity* CBaseEntity::GetEntity(uint16 targid, uint8 filter)
 {
     if (targid == 0)

--- a/src/map/entities/baseentity.h
+++ b/src/map/entities/baseentity.h
@@ -214,7 +214,9 @@ public:
     float           GetZPos();          // позиция по координате Z
     uint8           GetRotPos();
     void            HideName(bool hide); // hide / show name
-    bool            IsNameHidden();     // checks if name is hidden
+    bool            IsNameHidden();      // checks if name is hidden
+    bool            IsTargetable();      // checks if entity is targetable
+    virtual bool    isWideScannable();   // checks if the entity should show up on wide scan
 
     CBaseEntity*    GetEntity(uint16 targid, uint8 filter = -1);
 

--- a/src/map/entities/npcentity.cpp
+++ b/src/map/entities/npcentity.cpp
@@ -91,6 +91,11 @@ bool CNpcEntity::IsUntargetable()
     return (m_flags & 0x800) == 0x800;
 }
 
+bool CNpcEntity::isWideScannable()
+{
+    return widescan == 1 && status == STATUS_NORMAL && CBaseEntity::isWideScannable();
+}
+
 void CNpcEntity::PostTick()
 {
     if (loc.zone && updatemask)

--- a/src/map/entities/npcentity.h
+++ b/src/map/entities/npcentity.h
@@ -39,6 +39,7 @@ public:
     bool        IsHPHidden();
     void        Untargetable(bool untargetable);
     bool        IsUntargetable();
+    virtual bool isWideScannable() override;
     virtual void PostTick() override;
     virtual void Tick(time_point) override {}
 

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -5288,167 +5288,7 @@ void SmallPacket0x0F2(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0F4(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
-    // Set Widescan range
-    // Distances need verified, based current values off what we had in traits.sql and data at http://wiki.ffxiclopedia.org/wiki/Wide_Scan
-    // NOTE: Widescan was formerly piggy backed onto traits (resist slow) but is not a real trait, any attempt to give it a trait will place a dot on characters trait menu.
-    if (map_config.all_jobs_widescan == 0)
-    {
-        // Limit to BST and RNG, and try to use old distance values for tiers
-        if (PChar->GetMJob() == JOB_RNG)
-        {
-            if (PChar->GetMLevel() >= 60)
-            {
-                PChar->loc.zone->WideScan(PChar, 300);
-            }
-            else if (PChar->GetMLevel() >= 40)
-            {
-                PChar->loc.zone->WideScan(PChar, 250);
-            }
-            else if (PChar->GetMLevel() >= 20)
-            {
-                PChar->loc.zone->WideScan(PChar, 200);
-            }
-            else
-            {
-                PChar->loc.zone->WideScan(PChar, 150);
-            }
-        }
-        else if (PChar->GetMJob() == JOB_BST)
-        {
-            if (PChar->GetMLevel() >= 60)
-            {
-                PChar->loc.zone->WideScan(PChar, 250);
-            }
-            else if (PChar->GetMLevel() >= 40)
-            {
-                PChar->loc.zone->WideScan(PChar, 200);
-            }
-            else if (PChar->GetMLevel() >= 20)
-            {
-                PChar->loc.zone->WideScan(PChar, 150);
-            }
-            else
-            {
-                PChar->loc.zone->WideScan(PChar, 50);
-            }
-        }
-        else if (PChar->GetSJob() == JOB_RNG)
-        {
-            if (PChar->GetSLevel() >= 40)
-            {
-                PChar->loc.zone->WideScan(PChar, 250);
-            }
-            else if (PChar->GetSLevel() >= 20)
-            {
-                PChar->loc.zone->WideScan(PChar, 200);
-            }
-            else
-            {
-                PChar->loc.zone->WideScan(PChar, 150);
-            }
-        }
-        else if (PChar->GetSJob() == JOB_BST)
-        {
-            if (PChar->GetSLevel() >= 40)
-            {
-                PChar->loc.zone->WideScan(PChar, 200);
-            }
-            else if (PChar->GetSLevel() >= 20)
-            {
-                PChar->loc.zone->WideScan(PChar, 150);
-            }
-            else
-            {
-                PChar->loc.zone->WideScan(PChar, 50);
-            }
-        }
-        else
-        {
-            // Not BST or RNG, get nothing!
-            PChar->loc.zone->WideScan(PChar, 0);
-            // The zero needs set or client will lag on map screen saying downloading data.
-        }
-    }
-    else if (map_config.all_jobs_widescan == 1)
-    {
-        // All jobs have 1st tier, and use current retail distance values for tiers
-        if (PChar->GetMJob() == JOB_RNG)
-        {
-            // Need verification
-            // if (PChar->GetMLevel() >= 80)
-            // {
-            //     PChar->loc.zone->WideScan(PChar,350);
-            // }
-            // else if (PChar->GetMLevel() >= 60)
-            if (PChar->GetMLevel() >= 60)
-            {
-                PChar->loc.zone->WideScan(PChar, 300);
-            }
-            else if (PChar->GetMLevel() >= 40)
-            {
-                PChar->loc.zone->WideScan(PChar, 250);
-            }
-            else if (PChar->GetMLevel() >= 20)
-            {
-                PChar->loc.zone->WideScan(PChar, 200);
-            }
-            else
-            {
-                PChar->loc.zone->WideScan(PChar, 150);
-            }
-        }
-        else if (PChar->GetMJob() == JOB_BST)
-        {
-            if (PChar->GetMLevel() >= 80)
-            {
-                PChar->loc.zone->WideScan(PChar, 300);
-            }
-            else if (PChar->GetMLevel() >= 60)
-            {
-                PChar->loc.zone->WideScan(PChar, 250);
-            }
-            else if (PChar->GetMLevel() >= 40)
-            {
-                PChar->loc.zone->WideScan(PChar, 200);
-            }
-            else
-            {
-                PChar->loc.zone->WideScan(PChar, 150);
-            }
-        }
-        else if (PChar->GetSJob() == JOB_RNG)
-        {
-            if (PChar->GetSLevel() >= 40)
-            {
-                PChar->loc.zone->WideScan(PChar, 250);
-            }
-            else if (PChar->GetSLevel() >= 20)
-            {
-                PChar->loc.zone->WideScan(PChar, 200);
-            }
-            else
-            {
-                PChar->loc.zone->WideScan(PChar, 150);
-            }
-        }
-        else if (PChar->GetSJob() == JOB_BST)
-        {
-            if (PChar->GetSLevel() >= 40)
-            {
-                PChar->loc.zone->WideScan(PChar, 200);
-            }
-            else
-            {
-                PChar->loc.zone->WideScan(PChar, 150);
-            }
-        }
-        else
-        {
-            // Not BST or RNG, get base scan radius only!
-            PChar->loc.zone->WideScan(PChar, 150);
-        }
-    }
-    return;
+    PChar->loc.zone->WideScan(PChar, charutils::getWideScanRange(PChar));
 }
 
 /************************************************************************
@@ -5461,7 +5301,23 @@ void SmallPacket0x0F5(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 {
     uint16 TargID = data.ref<uint16>(0x04);
 
-    PChar->PWideScanTarget = PChar->GetEntity(TargID, TYPE_MOB | TYPE_NPC);
+    CBaseEntity* target = PChar->GetEntity(TargID, TYPE_MOB | TYPE_NPC);
+    if (target == nullptr)
+    {
+        // Target not found
+        PChar->PWideScanTarget = nullptr;
+        return;
+    }
+
+    uint16 widescanRange = charutils::getWideScanRange(PChar);
+    float dist = distance(PChar->loc.p, target->loc.p);
+
+    // Only allow players to track targets that are actually scannable, and within their wide scan range
+    if (target->isWideScannable() && dist <= widescanRange)
+    {
+        PChar->PWideScanTarget = target;
+    }
+
     return;
 }
 

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -5174,7 +5174,12 @@ namespace charutils
         // Limit to BST and RNG, and try to use old distance values for tiers
         if (job == JOB_RNG)
         {
-            if (level >= 60)
+            // Range for RNG >=80 needs verification.
+            if (level >= 80)
+            {
+                return 350;
+            }
+            else if (level >= 60)
             {
                 return 300;
             }

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -5193,7 +5193,11 @@ namespace charutils
         }
         else if (job == JOB_BST)
         {
-            if (level >= 60)
+            if (level >= 80)
+            {
+                return 300;
+            }
+            else if (level >= 60)
             {
                 return 250;
             }
@@ -5201,7 +5205,7 @@ namespace charutils
             {
                 return 200;
             }
-            else if (level >= 20)
+            else if (level >= 20 || map_config.all_jobs_widescan == 1)
             {
                 return 150;
             }

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -5164,4 +5164,68 @@ namespace charutils
         return 0;
     }
 
+    uint16 getWideScanRange(JOBTYPE job, uint8 level)
+    {
+        // Set Widescan range
+        // Distances need verified, based current values off what we had in traits.sql and data at http://wiki.ffxiclopedia.org/wiki/Wide_Scan
+        // NOTE: Widescan was formerly piggy backed onto traits (resist slow) but is not a real trait, any attempt to give it a trait will place a dot on
+        // characters trait menu.
+
+        // Limit to BST and RNG, and try to use old distance values for tiers
+        if (job == JOB_RNG)
+        {
+            if (level >= 60)
+            {
+                return 300;
+            }
+            else if (level >= 40)
+            {
+                return 250;
+            }
+            else if (level >= 20)
+            {
+                return 200;
+            }
+            else
+            {
+                return 150;
+            }
+        }
+        else if (job == JOB_BST)
+        {
+            if (level >= 60)
+            {
+                return 250;
+            }
+            else if (level >= 40)
+            {
+                return 200;
+            }
+            else if (level >= 20)
+            {
+                return 150;
+            }
+            else
+            {
+                return 50;
+            }
+        }
+
+        // Default to base widescan if not RNG or BST
+        if (map_config.all_jobs_widescan == 1)
+        {
+            return 150;
+        }
+        else
+        {
+            return 0;
+        }
+    }
+
+    uint16 getWideScanRange(CCharEntity* PChar)
+    {
+        // Get maximum widescan range from main job or sub job
+        return std::max(getWideScanRange(PChar->GetMJob(), PChar->GetMLevel()), getWideScanRange(PChar->GetSJob(), PChar->GetSLevel()));
+    }
+
 }; // namespace charutils

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -203,6 +203,9 @@ namespace charutils
     bool    AddWeaponSkillPoints(CCharEntity*, SLOTTYPE, int);
 
     int32   GetCharVar(CCharEntity* PChar, const char* var);
+
+    uint16 getWideScanRange(JOBTYPE job, uint8 level);
+    uint16 getWideScanRange(CCharEntity* PChar);
 };
 
 #endif

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -896,23 +896,17 @@ void CZoneEntities::WideScan(CCharEntity* PChar, uint16 radius)
     for (EntityList_t::const_iterator it = m_npcList.begin(); it != m_npcList.end(); ++it)
     {
         CNpcEntity* PNpc = (CNpcEntity*)it->second;
-        if (PNpc->status == STATUS_NORMAL && !PNpc->IsNameHidden() && !PNpc->IsUntargetable() && PNpc->widescan == 1)
+        if (PNpc->isWideScannable() && distance(PChar->loc.p, PNpc->loc.p) < radius)
         {
-            if (distance(PChar->loc.p, PNpc->loc.p) < radius)
-            {
-                PChar->pushPacket(new CWideScanPacket(PChar, PNpc));
-            }
+            PChar->pushPacket(new CWideScanPacket(PChar, PNpc));
         }
     }
     for (EntityList_t::const_iterator it = m_mobList.begin(); it != m_mobList.end(); ++it)
     {
         CMobEntity* PMob = (CMobEntity*)it->second;
-        if (PMob->status != STATUS_DISAPPEAR && !PMob->IsUntargetable())
+        if (PMob->isWideScannable() && distance(PChar->loc.p, PMob->loc.p) < radius)
         {
-            if (distance(PChar->loc.p, PMob->loc.p) < radius)
-            {
-                PChar->pushPacket(new CWideScanPacket(PChar, PMob));
-            }
+            PChar->pushPacket(new CWideScanPacket(PChar, PMob));
         }
     }
     PChar->pushPacket(new CWideScanPacket(WIDESCAN_END));


### PR DESCRIPTION
Adds validation to wide scan tracking, such that only characters with an appropriate range can track entities, and only entities that show up on wide scan can be tracked.

**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

