### PR TITLE
fix(Newton Movalpolis): Link Furnace Hatch to all gates

### DIFF
--- a/scripts/zones/Newton_Movalpolos/npcs/Furnace_Hatch.lua
+++ b/scripts/zones/Newton_Movalpolos/npcs/Furnace_Hatch.lua
@@ -13,9 +13,9 @@ function onTrade(player, npc, trade)
         player:confirmTrade()
         player:startEvent(21 + offset) -- THUD!
 
-        -- toggle open/closed the four doors related to this hatch
-        local doorOffset = ID.npc.DOOR_OFFSET + math.min(offset, 2) * 4
-        for i = doorOffset, doorOffset + 3 do
+        -- trading to any hatch toggles all doors zone-wide
+        local doorOffset = ID.npc.DOOR_OFFSET
+        for i = doorOffset, doorOffset + 11 do
             local door = GetNPCByID(i)
             door:setAnimation((door:getAnimation() == tpz.anim.OPEN_DOOR) and tpz.anim.CLOSE_DOOR or tpz.anim.OPEN_DOOR)
         end


### PR DESCRIPTION
Each furnace hatch was only tied to its closest gate. This is not how the hatch works and it makes it impossible to traverse Newton Movalpolis to get to the Mine Shaft. Each furnace hatch should toggle all gates. This commit enforces that behavior.

Sources:
- https://web.archive.org/web/20070218171240/http://users.adelphia.net/~mithrankittycat/ffxi/movalpolos.png
- https://ffxi.allakhazam.com/db/areas.html?farea=147#m121595200841715177

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [ ] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

