### PR TITLE
Convert three quests with bitmask variables, to use utils.mask functions

### DIFF
--- a/scripts/quests/flyers_for_regine.lua
+++ b/scripts/quests/flyers_for_regine.lua
@@ -1,9 +1,10 @@
 -----------------------------------
 -- Flyers for Regine
 -----------------------------------
-require("scripts/globals/zone")
-require("scripts/globals/quests")
 require("scripts/globals/npc_util")
+require("scripts/globals/quests")
+require("scripts/globals/utils")
+require("scripts/globals/zone")
 -----------------------------------
 
 quests = quests or {}
@@ -70,7 +71,7 @@ quests.flyers_for_regine.onRegionEnter = function(player, region)
             for k, v in pairs(data) do
                 if v.region == regionId then
                     local mask = player:getCharVar('[ffr]deliveryMask')
-                    local alreadyDelivered = bit.band(mask, 2^k) ~= 0
+                    local alreadyDelivered = utils.mask.getBit(mask, k)
 
                     if not alreadyDelivered then
                         local ID = zones[zoneId]
@@ -89,7 +90,7 @@ quests.flyers_for_regine.onTrade = function(player, npc, trade, ffrId)
         local zoneId = player:getZoneID()
         local ID = zones[zoneId]
         local mask = player:getCharVar('[ffr]deliveryMask')
-        local alreadyDelivered = bit.band(mask, 2^ffrId) ~= 0
+        local alreadyDelivered = utils.mask.getBit(mask, ffrId)
 
         if alreadyDelivered then
             player:messageSpecial(ID.text.FLYER_ALREADY)
@@ -98,7 +99,7 @@ quests.flyers_for_regine.onTrade = function(player, npc, trade, ffrId)
 
             player:messageSpecial(ID.text.FLYER_ACCEPTED)
             player:showText(npc, ID.text['FFR_' .. string.upper(data.npc)])
-            player:setCharVar('[ffr]deliveryMask', bit.bor(mask, 2^ffrId))
+            player:setCharVar('[ffr]deliveryMask', utils.mask.setBit(mask, ffrId, true))
             player:confirmTrade()
         end
     end

--- a/scripts/quests/i_can_hear_a_rainbow.lua
+++ b/scripts/quests/i_can_hear_a_rainbow.lua
@@ -4,6 +4,7 @@
 require("scripts/globals/weather")
 require("scripts/globals/common")
 require("scripts/globals/quests")
+require("scripts/globals/utils")
 require("scripts/globals/zone")
 -----------------------------------
 
@@ -125,11 +126,11 @@ quests.i_can_hear_a_rainbow.onZoneIn = function(player)
 
         if data and data.zones[zone:getID()] then
             local mask = player:getCharVar('I_CAN_HEAR_A_RAINBOW')
-            local needsColor = bit.band(mask, 2^data.bit) == 0
+            local hasColor = utils.mask.getBit(mask, data.bit)
 
-            if needsColor then
+            if not hasColor then
                 trigger = true
-                player:setCharVar('I_CAN_HEAR_A_RAINBOW', bit.bor(mask, 2^data.bit))
+                player:setCharVar('I_CAN_HEAR_A_RAINBOW', utils.mask.setBit(mask, data.bit, true))
                 player:setLocalVar('[rainbow]weather', weather)
             end
         end
@@ -146,10 +147,10 @@ quests.i_can_hear_a_rainbow.onEventUpdate = function(player)
         weather = tpz.weather.NONE
     end
 
-    if player:getCharVar("I_CAN_HEAR_A_RAINBOW") < 127 then
-        player:updateEvent(0, 0, weather)
-    else
+    if utils.mask.isFull(player:getCharVar("I_CAN_HEAR_A_RAINBOW"), 7) then -- has collected all 7 colors?
         player:updateEvent(0, 0, weather, 6)
+    else
+        player:updateEvent(0, 0, weather)
     end
 end
 

--- a/scripts/zones/Balgas_Dais/bcnms/shattering_stars.lua
+++ b/scripts/zones/Balgas_Dais/bcnms/shattering_stars.lua
@@ -7,6 +7,7 @@ local ID = require("scripts/zones/Balgas_Dais/IDs")
 require("scripts/globals/battlefield")
 require("scripts/globals/quests")
 require("scripts/globals/titles")
+require("scripts/globals/utils")
 -----------------------------------
 
 function onBattlefieldTick(battlefield, tick)
@@ -40,8 +41,8 @@ function onEventFinish(player, csid, option)
         local pjob = player:getMainJob()
         player:setCharVar("maatDefeated", pjob)
         local maatsCap = player:getCharVar("maatsCap")
-        if bit.band(maatsCap, bit.lshift(1, pjob - 1)) ~= 1 then
-            player:setCharVar("maatsCap", bit.bor(maatsCap, bit.lshift(1, pjob - 1)))
+        if not utils.mask.getBit(maatsCap, pjob - 1) then
+            player:setCharVar("maatsCap", utils.mask.setBit(maatsCap, pjob - 1, true))
         end
         player:addTitle(tpz.title.MAAT_MASHER)
     end

--- a/scripts/zones/Chamber_of_Oracles/bcnms/shattering_stars.lua
+++ b/scripts/zones/Chamber_of_Oracles/bcnms/shattering_stars.lua
@@ -7,6 +7,7 @@ local ID = require("scripts/zones/Chamber_of_Oracles/IDs")
 require("scripts/globals/battlefield")
 require("scripts/globals/quests")
 require("scripts/globals/titles")
+require("scripts/globals/utils")
 -----------------------------------
 
 function onBattlefieldTick(battlefield, tick)
@@ -40,8 +41,8 @@ function onEventFinish(player, csid, option)
         local pjob = player:getMainJob()
         player:setCharVar("maatDefeated", pjob)
         local maatsCap = player:getCharVar("maatsCap")
-        if bit.band(maatsCap, bit.lshift(1, pjob - 1)) ~= 1 then
-            player:setCharVar("maatsCap", bit.bor(maatsCap, bit.lshift(1, pjob - 1)))
+        if not utils.mask.getBit(maatsCap, pjob - 1) then
+            player:setCharVar("maatsCap", utils.mask.setBit(maatsCap, pjob - 1, true))
         end
         player:addTitle(tpz.title.MAAT_MASHER)
     end

--- a/scripts/zones/Horlais_Peak/bcnms/shattering_stars.lua
+++ b/scripts/zones/Horlais_Peak/bcnms/shattering_stars.lua
@@ -6,6 +6,7 @@ require("scripts/globals/battlefield")
 require("scripts/globals/npc_util")
 require("scripts/globals/quests")
 require("scripts/globals/titles")
+require("scripts/globals/utils")
 -----------------------------------
 
 function onBattlefieldTick(battlefield, tick)
@@ -40,8 +41,8 @@ function onEventFinish(player, csid, option)
         local maatsCap = player:getCharVar("maatsCap")
 
         player:setCharVar("maatDefeated", pjob)
-        if bit.band(maatsCap, bit.lshift(1, pjob - 1)) ~= 1 then
-            player:setCharVar("maatsCap", bit.bor(maatsCap, bit.lshift(1, pjob - 1)))
+        if not utils.mask.getBit(maatsCap, pjob - 1) then
+            player:setCharVar("maatsCap", utils.mask.setBit(maatsCap, pjob - 1, true))
         end
 
         player:addTitle(tpz.title.MAAT_MASHER)

--- a/scripts/zones/La_Theine_Plateau/npcs/qm3.lua
+++ b/scripts/zones/La_Theine_Plateau/npcs/qm3.lua
@@ -5,17 +5,20 @@
 -----------------------------------
 local ID = require("scripts/zones/La_Theine_Plateau/IDs")
 require("scripts/globals/missions")
+require("scripts/globals/npc_util")
 require("scripts/globals/quests")
 require("scripts/globals/status")
 require("scripts/globals/titles")
+require("scripts/globals/utils")
 -----------------------------------
 
 function onTrade(player, npc, trade)
-    if (player:getQuestStatus(WINDURST, tpz.quest.id.windurst.I_CAN_HEAR_A_RAINBOW) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(1125, 1) and trade:getItemCount() == 1 and trade:getGil() == 0 and
-            player:getCharVar("I_CAN_HEAR_A_RAINBOW") == 127) then
-            player:startEvent(124)
-        end
+    if
+        player:getQuestStatus(WINDURST, tpz.quest.id.windurst.I_CAN_HEAR_A_RAINBOW) == QUEST_ACCEPTED and
+        npcUtil.tradeHas(trade, 1125) and
+        utils.mask.isFull(player:getCharVar("I_CAN_HEAR_A_RAINBOW"), 7)
+    then
+        player:startEvent(124)
     end
 end
 
@@ -30,14 +33,14 @@ end
 
 function onEventFinish(player, csid, option)
     if (csid == 124) then
-        player:tradeComplete();
-        player:completeQuest(WINDURST, tpz.quest.id.windurst.I_CAN_HEAR_A_RAINBOW);
-        player:addTitle(tpz.title.RAINBOW_WEAVER);
-        player:unlockJob(tpz.job.SMN);
-        player:addSpell(296);
-        player:messageSpecial(ID.text.UNLOCK_SUMMONER);
-        player:messageSpecial(ID.text.UNLOCK_CARBUNCLE);
-        player:setCharVar("I_CAN_HEAR_A_RAINBOW", 0);
+        player:completeQuest(WINDURST, tpz.quest.id.windurst.I_CAN_HEAR_A_RAINBOW)
+        player:addTitle(tpz.title.RAINBOW_WEAVER)
+        player:unlockJob(tpz.job.SMN)
+        player:addSpell(296)
+        player:messageSpecial(ID.text.UNLOCK_SUMMONER)
+        player:messageSpecial(ID.text.UNLOCK_CARBUNCLE)
+        player:setCharVar("I_CAN_HEAR_A_RAINBOW", 0)
+        player:confirmTrade()
 
         local rainbow = GetNPCByID(ID.npc.RAINBOW)
         rainbow:setLocalVar('setRainbow', 1)

--- a/scripts/zones/Port_San_dOria/npcs/Regine.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Regine.lua
@@ -7,6 +7,7 @@
 local ID = require("scripts/zones/Port_San_dOria/IDs")
 require("scripts/globals/npc_util")
 require("scripts/globals/quests")
+require("scripts/globals/utils")
 require("scripts/globals/shop")
 -----------------------------------
 
@@ -32,7 +33,7 @@ function onTrigger(player, npc)
     -- FLYERS FOR REGINE
     if ffr == QUEST_AVAILABLE then -- ready to accept quest
         player:startEvent(510, 2)
-    elseif ffr == QUEST_ACCEPTED and player:getCharVar('[ffr]deliveryMask') == 32767 then -- all flyers delivered
+    elseif ffr == QUEST_ACCEPTED and utils.mask.isFull(player:getCharVar('[ffr]deliveryMask'), 15) then -- all 15 flyers delivered
         player:startEvent(603)
     elseif ffr == QUEST_ACCEPTED and not player:hasItem(532) then -- on quest but out of flyers
         player:startEvent(510, 3)

--- a/scripts/zones/QuBia_Arena/bcnms/shattering_stars.lua
+++ b/scripts/zones/QuBia_Arena/bcnms/shattering_stars.lua
@@ -6,6 +6,7 @@ require("scripts/globals/battlefield")
 require("scripts/globals/npc_util")
 require("scripts/globals/quests")
 require("scripts/globals/titles")
+require("scripts/globals/utils")
 -----------------------------------
 
 function onBattlefieldTick(battlefield, tick)
@@ -41,8 +42,8 @@ function onEventFinish(player, csid, option)
         local maatsCap = player:getCharVar("maatsCap")
         local pjob = player:getMainJob()
         player:setCharVar("maatDefeated", pjob)
-        if bit.band(maatsCap, bit.lshift(1, pjob - 1)) ~= 1 then
-            player:setCharVar("maatsCap", bit.bor(maatsCap, bit.lshift(1, pjob - 1)))
+        if not utils.mask.getBit(maatsCap, pjob - 1) then
+            player:setCharVar("maatsCap", utils.mask.setBit(maatsCap, pjob - 1, true))
         end
     end
 end

--- a/scripts/zones/RuLude_Gardens/npcs/Maat.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Maat.lua
@@ -11,6 +11,7 @@ require("scripts/globals/settings")
 require("scripts/globals/quests")
 require("scripts/globals/status")
 require("scripts/globals/titles")
+require("scripts/globals/utils")
 -----------------------------------
 
 function onTrade(player, npc, trade)
@@ -87,7 +88,11 @@ function onTrigger(player, npc)
         player:startEvent(91, player:getMainJob()) -- During Quest "Shattering Stars"
     elseif (shatteringStars == QUEST_ACCEPTED and LvL >= 66 and mJob <= 15 and player:getCharVar("maatDefeated") >= 1) then
         player:startEvent(93) -- Finish Quest "Shattering Stars"
-    elseif (player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.BEYOND_THE_SUN) == QUEST_AVAILABLE and mJob <= 15 and player:getCharVar("maatsCap") == 32767) then
+    elseif
+        player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.BEYOND_THE_SUN) == QUEST_AVAILABLE and
+        mJob <= 15 and
+        utils.mask.isFull(player:getCharVar("maatsCap"), 15) -- defeated maat on 15 jobs
+    then
         player:startEvent(74) -- Finish Quest "Beyond The Sun"
     else
         player:showText(npc, ID.text.MAAT_DIALOG)

--- a/scripts/zones/Waughroon_Shrine/bcnms/shattering_stars.lua
+++ b/scripts/zones/Waughroon_Shrine/bcnms/shattering_stars.lua
@@ -7,6 +7,7 @@ require("scripts/globals/battlefield")
 require("scripts/globals/npc_util")
 require("scripts/globals/quests")
 require("scripts/globals/titles")
+require("scripts/globals/utils")
 -----------------------------------
 
 function onBattlefieldTick(battlefield, tick)
@@ -40,8 +41,8 @@ function onEventFinish(player, csid, option)
             npcUtil.giveItem(player, 4181)
         end
         player:setCharVar("maatDefeated", pjob)
-        if bit.band(maatsCap, bit.lshift(1, pjob - 1)) ~= 1 then
-            player:setCharVar("maatsCap", bit.bor(maatsCap, bit.lshift(1, pjob - 1)))
+        if not utils.mask.getBit(maatsCap, pjob - 1) then
+            player:setCharVar("maatsCap", utils.mask.setBit(maatsCap, pjob - 1, true))
         end
         player:addTitle(tpz.title.MAAT_MASHER)
     end


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

