### PR TITLE
Fix cutscene in COP 2-5 "Ancient Vows"

### DIFF
--- a/scripts/zones/Misareaux_Coast/npcs/Spatial_Displacement.lua
+++ b/scripts/zones/Misareaux_Coast/npcs/Spatial_Displacement.lua
@@ -16,7 +16,7 @@ function onTrigger(player, npc)
     if player:getCurrentMission(COP) == tpz.mission.id.cop.THE_SAVAGE and player:getCharVar("PromathiaStatus") == 0 then
         player:startEvent(8)
     -- COP 4-1
-    elseif (player:hasCompletedMission(COP, tpz.mission.id.cop.SHELTERING_DOUBT)) then
+    elseif player:hasCompletedMission(COP, tpz.mission.id.cop.SHELTERING_DOUBT) then
         player:startEvent(551) -- Access to Sites A & B
     else
         player:startEvent(550) -- Access to Site A Only

--- a/scripts/zones/Misareaux_Coast/npcs/Spatial_Displacement.lua
+++ b/scripts/zones/Misareaux_Coast/npcs/Spatial_Displacement.lua
@@ -1,7 +1,8 @@
 -----------------------------------
 -- Area: Misareaux Coast
 --  NPC: Spacial Displacement
---  Entrance to Riverne Site #A01 and #B01
+-- Entrance to Riverne Site #A01 and #B01
+-- !pos -540 -30 360 25
 -----------------------------------
 require("scripts/globals/missions")
 -----------------------------------
@@ -11,10 +12,12 @@ end
 
 function onTrigger(player, npc)
 
-    if (player:hasCompletedMission(COP, tpz.mission.id.cop.SHELTERING_DOUBT)) then
-        player:startEvent(551) -- Access to Sites A & B
-    elseif (player:getCurrentMission(COP) == tpz.mission.id.cop.ANCIENT_VOWS and player:getCharVar("PromathiaStatus") == 1) then
+    -- COP 4-2
+    if player:getCurrentMission(COP) == tpz.mission.id.cop.THE_SAVAGE and player:getCharVar("PromathiaStatus") == 0 then
         player:startEvent(8)
+    -- COP 4-1
+    elseif (player:hasCompletedMission(COP, tpz.mission.id.cop.SHELTERING_DOUBT)) then
+        player:startEvent(551) -- Access to Sites A & B
     else
         player:startEvent(550) -- Access to Site A Only
     end
@@ -26,12 +29,12 @@ end
 
 function onEventFinish(player, csid, option)
 
-    if (csid == 8) then
-        player:setCharVar("PromathiaStatus", 2)
+    if csid == 8 then
+        player:setCharVar("PromathiaStatus", 1)
         player:setPos(732.55, -32.5, -506.544, 90, 30) -- Go to Riverne #A01 {R}
-    elseif ((csid == 551 or csid == 550) and option == 1) then
+    elseif (csid == 551 or csid == 550) and option == 1 then
         player:setPos(732.55, -32.5, -506.544, 90, 30) -- Go to Riverne #A01 {R}
-    elseif (csid == 551 and option == 2) then
+    elseif csid == 551 and option == 2 then
         player:setPos(729.749, -20.319, 407.153, 90, 29) -- Go to Riverne #B01 {R}
     end
 

--- a/scripts/zones/Misareaux_Coast/npcs/_0p2.lua
+++ b/scripts/zones/Misareaux_Coast/npcs/_0p2.lua
@@ -12,15 +12,24 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-    if (player:getCurrentMission(COP) == tpz.mission.id.cop.THE_SAVAGE and player:getCharVar("PromathiaStatus") == 0) then
-        player:startEvent(8)
-    elseif (player:getCurrentMission(COP) == tpz.mission.id.cop.ANCIENT_VOWS and player:getCharVar("PromathiaStatus") == 0) then
-        player:startEvent(6)
-    elseif (player:getCurrentMission(COP) == tpz.mission.id.cop.FLAMES_IN_THE_DARKNESS and player:getCharVar("PromathiaStatus") == 0) then
-        player:startEvent(12)
-    elseif (player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.STORMS_OF_FATE) == QUEST_ACCEPTED and player:getCharVar('StormsOfFate') == 0) then
+    local copCurrentMission = player:getCurrentMission(COP)
+    local copMissions = tpz.mission.id.cop
+    local copMissionStatus = player:getCharVar("PromathiaStatus")
+
+    -- Bahamut Battle (requires COP to be completed)
+    if player:getQuestStatus(JEUNO, tpz.quest.id.jeuno.STORMS_OF_FATE) == QUEST_ACCEPTED and player:getCharVar('StormsOfFate') == 0 then
         player:startEvent(559)
-    elseif (player:getCurrentMission(COP) > tpz.mission.id.cop.AN_ETERNAL_MELODY or player:hasCompletedMission(COP, tpz.mission.id.cop.THE_LAST_VERSE)) then
+    -- COP 7-2
+    elseif copCurrentMission == copMissions.FLAMES_IN_THE_DARKNESS and copMissionStatus == 0 then
+        player:startEvent(12)
+    -- COP 4-2
+    elseif copCurrentMission == copMissions.THE_SAVAGE and copMissionStatus == 0 then
+        player:startEvent(8)
+    -- COP 2-5
+    elseif copCurrentMission == copMissions.ANCIENT_VOWS and copMissionStatus == 0 then
+        player:startEvent(6)
+    -- Can pass after completing COP 2-4
+    elseif copCurrentMission > copMissions.AN_ETERNAL_MELODY or player:hasCompletedMission(COP, copMissions.THE_LAST_VERSE) then
         player:startEvent(552)
     else
         player:messageSpecial(ID.text.DOOR_CLOSED)
@@ -31,11 +40,11 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-    if (csid == 6 or csid == 12) then
+    if csid == 6 or csid == 12 then
         player:setCharVar("PromathiaStatus", 1)
-    elseif (csid == 559) then
+    elseif csid == 559 then
         player:setCharVar('StormsOfFate', 1)
-    elseif (csid == 8 and option == 1) then
+    elseif csid == 8 and option == 1 then
         player:setCharVar("PromathiaStatus", 1)
         player:setPos(729, -20, 410, 88, 29) -- Go to Riverne #B01
     end

--- a/scripts/zones/Riverne-Site_A01/Zone.lua
+++ b/scripts/zones/Riverne-Site_A01/Zone.lua
@@ -19,6 +19,10 @@ end
 function onZoneIn(player, prevZone)
     local cs = -1
 
+    if player:getCurrentMission(COP) == tpz.mission.id.cop.ANCIENT_VOWS and player:getCharVar("PromathiaStatus") == 1 then
+        cs = 100
+    end
+    
     if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
         player:setPos(732.55, -32.5, -506.544, 90) -- {R}
     end
@@ -39,4 +43,7 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
+    if csid == 100 then
+        player:setCharVar("PromathiaStatus", 2)
+    end
 end

--- a/scripts/zones/Tavnazian_Safehold/npcs/Despachiaire.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/Despachiaire.lua
@@ -5,6 +5,7 @@
 -----------------------------------
 require("scripts/globals/missions")
 -----------------------------------
+-- TO DO: Quest giver for "X Marks the Spot" which requires COP 2-5 Ancient Vows completed
 
 function onTrade(player, npc, trade)
 end
@@ -23,6 +24,8 @@ function onTrigger(player, npc)
         player:startEvent(118)
     elseif (currentCOPMission  == tpz.mission.id.cop.THREE_PATHS and LouverancePathStatut == 1 ) then
         player:startEvent(134)
+    elseif player:getCurrentMission(COP) > tpz.mission.id.cop.DARKNESS_NAMED then
+        player:startEvent(315) -- new default dialogue "Jeuno offered its help"; might be earlier 
     else
         player:startEvent(106)
     end

--- a/scripts/zones/Tavnazian_Safehold/npcs/Despachiaire.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/Despachiaire.lua
@@ -5,32 +5,68 @@
 -----------------------------------
 require("scripts/globals/missions")
 -----------------------------------
--- TO DO: Quest giver for "X Marks the Spot" which requires COP 2-5 Ancient Vows completed
+-- TODO:
+-- Starts quests: "X Marks the Spot"
+--                "Elderly Pursuits"
+--                "Tango with a Tracker"
+--                "Requiem of Sin"
+-- Involved in:   "Secrets of Ovens Lost"
+-- https://github.com/project-topaz/topaz/issues/1481
 
 function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-    local currentCOPMission = player:getCurrentMission(COP)
-    local LouverancePathStatut = player:getCharVar("COP_Louverance_s_Path")
+    local copCurrentMission = player:getCurrentMission(COP)
+    local copMissionStatus = player:getCharVar("PromathiaStatus")
+    local copMissions = tpz.mission.id.cop
 
-    if (currentCOPMission  == tpz.mission.id.cop.THE_LOST_CITY and player:getCharVar("PromathiaStatus") == 0) then
+    -- COP 2-2 "The Lost City"
+    if copCurrentMission == copMissions.THE_LOST_CITY and copMissionStatus == 0 then
         player:startEvent(102)
-    elseif (currentCOPMission  == tpz.mission.id.cop.SHELTERING_DOUBT and player:getCharVar("PromathiaStatus") == 1) then
+    -- COP 4-1 "Sheltering Doubt"
+    elseif copCurrentMission == copMissions.SHELTERING_DOUBT and copMissionStatus == 1 then
         player:startEvent(108)
-    elseif (currentCOPMission  == tpz.mission.id.cop.THE_ENDURING_TUMULT_OF_WAR and player:getCharVar("COP_optional_CS_Despachaire") == 0) then
-        player:startEvent(117) --117
-    elseif (currentCOPMission  == tpz.mission.id.cop.THREE_PATHS and LouverancePathStatut == 0) then
-        player:startEvent(118)
-    elseif (currentCOPMission  == tpz.mission.id.cop.THREE_PATHS and LouverancePathStatut == 1 ) then
-        player:startEvent(134)
-    elseif player:getCurrentMission(COP) > tpz.mission.id.cop.DARKNESS_NAMED then
-        player:startEvent(315) -- new default dialogue "Jeuno offered its help"; might be earlier 
+    -- COP 4-4 "Slanderous Utterings" is an area approach handled in Tavnazian_Safehold/Zone.lua
+    -- COP 5-1 "Sheltering Doubt" (optional)
+    elseif
+        copCurrentMission == copMissions.THE_ENDURING_TUMULT_OF_WAR and
+        copMissionStatus == 0 and
+        player:getCharVar("COP_optional_CS_Despachaire") == 0
+    then
+        player:startEvent(117)
+    -- COP 5-3 "Three Paths"
+    elseif copCurrentMission == copMissions.THREE_PATHS then
+        if player:getCharVar("COP_Louverance_s_Path") == 0 then
+            player:startEvent(118)
+        else
+            player:startEvent(134)
+        end
+    -- COP Default dialogue change
+    elseif player:getCurrentMission(COP) > copMissions.DARKNESS_NAMED then
+        player:startEvent(315) -- "Jeuno offered its help"; TODO: might trigger as early as 5-2?
+    -- Default dialogue
     else
         player:startEvent(106)
     end
+end
+
+function onEventUpdate(player, csid, option)
+end
+
+function onEventFinish(player, csid, option)
+
+    if csid == 102 or csid == 108 then
+        player:setCharVar("PromathiaStatus", 2)
+    elseif csid == 117 then
+        player:setCharVar("COP_optional_CS_Despachaire", 1)
+    elseif csid == 118 then
+        player:setCharVar("COP_Louverance_s_Path", 1)
+    end
 
 end
+
+-- TODO: cutscenes including Despachiaire for reference
 --Despachiaire     102 ++
 --Despachiaire     104 ++
 --Despachiaire     106 ++
@@ -58,17 +94,3 @@ end
 --Despachiaire     579 chat
 --Despachiaire     617 XX
 --Despachiaire     618 XX
-function onEventUpdate(player, csid, option)
-end
-
-function onEventFinish(player, csid, option)
-
-    if (csid == 102 or csid == 108) then
-        player:setCharVar("PromathiaStatus", 2)
-    elseif (csid == 117) then
-        player:setCharVar("COP_optional_CS_Despachaire", 1)
-    elseif (csid == 118) then
-        player:setCharVar("COP_Louverance_s_Path", 1)
-    end
-
-end

--- a/scripts/zones/Tavnazian_Safehold/npcs/Justinius.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/Justinius.lua
@@ -18,14 +18,22 @@ function onTrigger(player, npc)
     local copCurrentMission = player:getCurrentMission(COP)
     local copMissionStatus = player:getCharVar("PromathiaStatus")
 
+    -- COP 2-3
     if copCurrentMission == copMissions.DISTANT_BELIEFS and copMissionStatus == 3 then
         player:startEvent(113)
+    -- COP 2-4
     elseif copCurrentMission == copMissions.AN_ETERNAL_MELODY and copMissionStatus == 1 then
         player:startEvent(127) -- optional dialogue
+    -- COP 4-1
     elseif copCurrentMission == copMissions.SHELTERING_DOUBT and copMissionStatus == 2 then
         player:startEvent(109)
-    elseif copCurrentMission == copMissions.THE_SAVAGE and copMissionStatus == 2 then
-        player:startEvent(110)
+    -- COP 4-2
+    elseif copCurrentMission == copMissions.THE_SAVAGE then
+        if copMissionStatus == 2 then
+            player:startEvent(110) -- finish mission
+        else
+            player:startEvent(130) -- optional dialogue
+        end
     else
         player:startEvent(123)
     end


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

_ Fixes a wrong cutscene ( #1420  ) after entering through the Dilapidated Gate in Misareaux Coast (F-7) and clicking the Spacial Displacement
_ This affected mission 4-2 (csid 8) so I added one optional dialogue and a new default dialogue there while at it
_ Minor style guide clean up for the Dilapidated Gate (4383c20098a31dcbfd507bd758f228c0568b1c97)

Captures used for this PR:
[Missions: COP 2-4 (An Eternal Melody) ~ COP 2-5 (Ancient Vows)](https://www.youtube.com/watch?v=xHDoAEIQ7_Y&feature=youtu.be)
[Chains of Promathia: COP 4-1 (Sheltering Doubt)](https://www.youtube.com/watch?v=TyOlnk3c_Po&feature=youtu.be)
[Chains of Promathia: COP 4-2 (The Savage)](https://www.youtube.com/watch?v=jIVHFjG1kS0&feature=youtu.be)
