### PR TITLE
CMake: Stop using 3.12 features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ include(CompilerWarnings)
 include(Sanitizers)
 include(ClangTidy)
 
+message(STATUS "CMAKE_VERSION: ${CMAKE_VERSION}")
 message(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 message(STATUS "CMAKE_C_COMPILER: ${CMAKE_C_COMPILER}")
 message(STATUS "CMAKE_CXX_COMPILER: ${CMAKE_CXX_COMPILER}")

--- a/src/map/CMakeLists.txt
+++ b/src/map/CMakeLists.txt
@@ -119,11 +119,6 @@ endif()
 
 add_executable(topaz_game
     ${SOURCES}
-    $<TARGET_OBJECTS:entities>
-    $<TARGET_OBJECTS:items>
-    $<TARGET_OBJECTS:lua>
-    $<TARGET_OBJECTS:packets>
-    $<TARGET_OBJECTS:utils>
     ${resource})
 
 if(WIN32)
@@ -141,6 +136,11 @@ target_link_libraries(topaz_game
     PUBLIC
     common
     ai
+    entities
+    items
+    lua
+    packets
+    utils
     project_options
     #project_warnings
 )

--- a/src/map/ai/CMakeLists.txt
+++ b/src/map/ai/CMakeLists.txt
@@ -12,6 +12,11 @@ add_library(ai STATIC
 target_link_libraries(ai
     PUBLIC
     common
+    entities
+    items
+    lua
+    packets
+    utils
     ai_controllers
     ai_helpers
     ai_states

--- a/src/map/entities/CMakeLists.txt
+++ b/src/map/entities/CMakeLists.txt
@@ -16,7 +16,7 @@ set(SOURCES
     trustentity.cpp
     trustentity.h)
 
-add_library(entities OBJECT ${SOURCES})
+add_library(entities STATIC ${SOURCES})
 
 target_link_libraries(entities
     PUBLIC

--- a/src/map/items/CMakeLists.txt
+++ b/src/map/items/CMakeLists.txt
@@ -24,7 +24,7 @@ set(SOURCES
     item.cpp
     item.h)
 
-add_library(items OBJECT ${SOURCES})
+add_library(items STATIC ${SOURCES})
 
 target_link_libraries(items
     PUBLIC

--- a/src/map/lua/CMakeLists.txt
+++ b/src/map/lua/CMakeLists.txt
@@ -26,7 +26,7 @@ set(SOURCES
     luautils.cpp
     luautils.h)
 
-add_library(lua OBJECT ${SOURCES})
+add_library(lua STATIC ${SOURCES})
 
 target_link_libraries(lua
     PUBLIC

--- a/src/map/packets/CMakeLists.txt
+++ b/src/map/packets/CMakeLists.txt
@@ -231,7 +231,7 @@ set(SOURCES
     zone_visited.cpp
     zone_visited.h)
 
-add_library(packets OBJECT ${SOURCES})
+add_library(packets STATIC ${SOURCES})
 
 target_link_libraries(packets
     PUBLIC

--- a/src/map/utils/CMakeLists.txt
+++ b/src/map/utils/CMakeLists.txt
@@ -34,11 +34,16 @@ set(SOURCES
     zoneutils.cpp
     zoneutils.h)
 
-add_library(utils OBJECT ${SOURCES})
+add_library(utils STATIC ${SOURCES})
 
 target_link_libraries(utils
     PUBLIC
     common
+    ai
+    entities
+    items
+    lua
+    packets
     project_options
     #project_warnings
 )

--- a/src/search/CMakeLists.txt
+++ b/src/search/CMakeLists.txt
@@ -16,7 +16,6 @@ endif()
 
 add_executable(topaz_search
     ${SOURCES}
-    $<TARGET_OBJECTS:search_packets>
     ${resource})
 
 if(WIN32)
@@ -34,6 +33,7 @@ target_compile_definitions(topaz_search PUBLIC DEFINE_OWN_MAIN)
 
 target_link_libraries(topaz_search
     common
+    search_packets
     project_options
     #project_warnings
 )

--- a/src/search/packets/CMakeLists.txt
+++ b/src/search/packets/CMakeLists.txt
@@ -12,4 +12,4 @@ set(SOURCES
     search_list.cpp
     search_list.h)
 
-add_library(search_packets OBJECT ${SOURCES})
+add_library(search_packets STATIC ${SOURCES})


### PR DESCRIPTION
CMake: Stop using 3.12 features -> we specify using 3.10 (and that is what's bundled in Ubuntu 18.04 LTS).
Strange that the CI (which is 18.04 LTS) never complained...

**Further reading**
OBJECT libraries are bags of compiled objects, that don't have their dependencies figured out. They are great for splitting out sections of the build into their own steps that can be cached and then brought together at link time. 

However, they can't have dependencies added to them until 3.12 :(

So we have to use STATIC libs, which need to have their dependencies linked correctly at every stage, not just final link time.

I always thought you couldn't have a chain of static lib dependencies in cmake
```
A (static) -> B (static) -> C (executable)
```
I was under the assumption that C wouldn't get the symbols from A. I'm sure I encountered this issue at work a few years ago, which is why I had to use OBJECT libs. 

Though... that might have been a quirk of cross-compiling for iOS....

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

