### PR TITLE
Tracy Profiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,6 @@ cmake_install.cmake
 /conf/search_server.conf
 /conf/server_message.conf
 /conf/server_message_fr.conf
+
+# Tracy download
+tracy/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ include(StandardProjectSettings)
 include(CompilerWarnings)
 include(Sanitizers)
 include(ClangTidy)
+include(Tracy)
 
 message(STATUS "CMAKE_VERSION: ${CMAKE_VERSION}")
 message(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -47,6 +47,30 @@
       "ctestCommandArgs": "",
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "variables": []
+    },
+    {
+      "name": "x64-Debug-Tracy",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "-DMYSQL_INCLUDE_DIR=${projectDir}\\ext\\include\\mysql -DMYSQL_LIBRARY=${projectDir}\\ext\\lib64\\libmariadb64.lib -DTRACY_ENABLE=ON",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "variables": []
+    },
+    {
+      "name": "x64-Release-Tracy",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "-DMYSQL_INCLUDE_DIR=${projectDir}\\ext\\include\\mysql -DMYSQL_LIBRARY=${projectDir}\\ext\\lib64\\libmariadb64.lib -DTRACY_ENABLE=ON",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "variables": []
     }
   ]
 }

--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -66,7 +66,7 @@ if(MSVC)
 endif()
 
 if(UNIX)
-
+    link_libraries(dl)
 endif()
 
 # TODO: These should be applied on a per-target level, not globally like this!

--- a/cmake/Tracy.cmake
+++ b/cmake/Tracy.cmake
@@ -1,0 +1,27 @@
+# Enable on command-line with 'cmake -DTRACY_ENABLE=ON ..'
+
+option(TRACY_ENABLE "Enable Tracy profiling." OFF)
+message(STATUS "TRACY_ENABLE: ${TRACY_ENABLE}")
+
+if(TRACY_ENABLE)
+    set(TRACY_LINK https://github.com/wolfpld/tracy/archive/v0.7.3.tar.gz)
+    if(NOT EXISTS ${CMAKE_SOURCE_DIR}/tracy/tracy-0.7.3/TracyClient.cpp)
+        file(MAKE_DIRECTORY ${CMAKE_SOURCE_DIR}/tracy)
+        file(DOWNLOAD
+                ${TRACY_LINK}
+                ${CMAKE_SOURCE_DIR}/tracy/tracy.tar.gz
+                TIMEOUT 60
+                SHOW_PROGRESS)
+        execute_process(COMMAND "${CMAKE_COMMAND}" -E
+                tar xf "${CMAKE_SOURCE_DIR}/tracy/tracy.tar.gz"
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tracy)
+    endif()
+
+    add_library(tracy_client ${CMAKE_SOURCE_DIR}/tracy/tracy-0.7.3/TracyClient.cpp)
+    target_include_directories(tracy_client PUBLIC ${CMAKE_SOURCE_DIR}/tracy/tracy-0.7.3/)
+    target_compile_definitions(tracy_client PUBLIC TRACY_ENABLE TRACY_ON_DEMAND TRACY_NO_EXIT TRACY_NO_BROADCAST)
+
+    if(MSVC AND CMAKE_SIZEOF_VOID_P EQUAL 4)
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LARGEADDRESSAWARE")
+    endif()
+endif(TRACY_ENABLE)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -44,3 +44,6 @@ target_link_libraries(
   # project_warnings
   )
  
+if(TRACY_ENABLE)
+    target_link_libraries(common PUBLIC tracy_client)
+endif(TRACY_ENABLE)

--- a/src/common/cbasetypes.h
+++ b/src/common/cbasetypes.h
@@ -48,4 +48,6 @@ using server_clock = std::chrono::system_clock;
 using time_point = server_clock::time_point;
 using duration = server_clock::duration;
 
+#include "tracy.h"
+
 #endif /* _CBASETYPES_H_ */

--- a/src/common/showmsg.cpp
+++ b/src/common/showmsg.cpp
@@ -687,6 +687,10 @@ int _vShowMessage(MSGTYPE flag, const std::string& string)
         }
     }
 
+#ifdef TRACY_ENABLE
+    TracyMessage(string.c_str(), string.size());
+#endif
+
     return 0;
 }
 void ClearScreen(void)

--- a/src/common/tracy.h
+++ b/src/common/tracy.h
@@ -1,0 +1,46 @@
+﻿#ifndef _TRACY_H
+#define _TRACY_H
+
+#ifdef TRACY_ENABLE
+    #include "fmt/format.h"
+    #include "Tracy.hpp"
+
+    #define TracyFrameMark FrameMark
+    #define TracyZoneScoped ZoneScoped
+    #define TracyZoneScopedN(n) ZoneScopedN(n)
+    #define TracyZoneText(n, l) ZoneText(n, l)
+    #define TracyZoneScopedC(c) ZoneScopedC(c)
+    #define TracyZoneString(str) ZoneText(str.c_str(), str.size())
+    #define TracyZoneCString(cstr) ZoneText(cstr, std::strlen(cstr))
+    #define TracyZoneIString(istr) TracyZoneCString(reinterpret_cast<const char*>(istr))
+
+    inline std::string Hex8ToString(uint8 hex)
+    {
+        return fmt::format("0x{:2X}", hex);
+    }
+
+    inline std::string Hex16ToString(uint16 hex)
+    {
+        return fmt::format("0x{:4X}", hex);
+    }
+
+    #define TracyZoneHex8(num) auto str = Hex8ToString(num); TracyZoneText(str.c_str(), str.size());
+    #define TracyZoneHex16(num) auto str = Hex16ToString(num); TracyZoneText(str.c_str(), str.size());
+
+    #define TracyReportLuaMemory(L) TracyPlotConfig("Lua Memory Usage", tracy::PlotFormatType::Memory); TracyPlot("Lua Memory Usage", static_cast<double>(lua_gc(L, LUA_GCCOUNT, 0)) * 1024.0);
+
+#else // Empty stubs for regular builds
+    #define TracyFrameMark
+    #define TracyZoneScoped
+    #define TracyZoneScopedN(n)
+    #define TracyZoneText(n, l)
+    #define TracyZoneScopedC(c)
+    #define TracyZoneString(str)
+    #define TracyZoneCString(cstr)
+    #define TracyZoneIString(istr)
+    #define TracyZoneHex8(num)
+    #define TracyZoneHex16(num)
+    #define TracyReportLuaMemory(L)
+#endif
+
+#endif // _TRACY_H

--- a/src/map/CMakeLists.txt
+++ b/src/map/CMakeLists.txt
@@ -145,6 +145,10 @@ target_link_libraries(topaz_game
     #project_warnings
 )
 
+if(TRACY_ENABLE)
+    target_link_libraries(topaz_game PUBLIC tracy_client)
+endif(TRACY_ENABLE)
+
 if(APPLE)
     link_options(topaz_game PUBLIC -pagezero_size 10000 -image_base 100000000)
 endif()

--- a/src/map/ai/ai_container.cpp
+++ b/src/map/ai/ai_container.cpp
@@ -334,6 +334,7 @@ void CAIContainer::Reset()
 
 void CAIContainer::Tick(time_point _tick)
 {
+    TracyZoneScoped;
     m_PrevTick = m_Tick;
     m_Tick = _tick;
 

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -43,6 +43,9 @@ CMobController::CMobController(CMobEntity* PEntity) :
 
 void CMobController::Tick(time_point tick)
 {
+    TracyZoneScoped;
+    TracyZoneIString(PMob->GetName());
+
     m_Tick = tick;
 
     if (PMob->isAlive())
@@ -60,6 +63,7 @@ void CMobController::Tick(time_point tick)
 
 bool CMobController::TryDeaggro()
 {
+    TracyZoneScoped;
     if (PTarget == nullptr && (PMob->PEnmityContainer != nullptr && PMob->PEnmityContainer->GetHighestEnmity() == nullptr))
     {
         return true;
@@ -85,6 +89,7 @@ bool CMobController::TryDeaggro()
 
 bool CMobController::CanPursueTarget(CBattleEntity* PTarget)
 {
+    TracyZoneScoped;
     if (PMob->m_Detects & DETECT_SCENT)
     {
         // if mob is in water it will instant deaggro if target cannot be detected
@@ -99,6 +104,7 @@ bool CMobController::CanPursueTarget(CBattleEntity* PTarget)
 
 bool CMobController::CheckHide(CBattleEntity* PTarget)
 {
+    TracyZoneScoped;
     if (PTarget->GetMJob() == JOB_THF && PTarget->StatusEffectContainer->HasStatusEffect(EFFECT_HIDE))
     {
         return !CanPursueTarget(PTarget) && !PMob->m_TrueDetection;
@@ -108,6 +114,7 @@ bool CMobController::CheckHide(CBattleEntity* PTarget)
 
 bool CMobController::CheckDetection(CBattleEntity* PTarget)
 {
+    TracyZoneScoped;
     if (CanDetectTarget(PTarget) || CanPursueTarget(PTarget) ||
         PMob->StatusEffectContainer->HasStatusEffect({EFFECT_BIND, EFFECT_SLEEP, EFFECT_SLEEP_II, EFFECT_LULLABY}))
     {
@@ -119,6 +126,7 @@ bool CMobController::CheckDetection(CBattleEntity* PTarget)
 
 void CMobController::TryLink()
 {
+    TracyZoneScoped;
     if (PTarget == nullptr)
     {
         return;
@@ -179,6 +187,7 @@ void CMobController::TryLink()
 **/
 bool CMobController::CanDetectTarget(CBattleEntity* PTarget, bool forceSight)
 {
+    TracyZoneScoped;
     if (PTarget->isDead() || PTarget->isMounted()) return false;
 
     float verticalDistance = abs(PMob->loc.p.y - PTarget->loc.p.y);
@@ -248,6 +257,7 @@ bool CMobController::CanDetectTarget(CBattleEntity* PTarget, bool forceSight)
 
 bool CMobController::CanSeePoint(position_t pos)
 {
+    TracyZoneScoped;
     if (PMob->PAI->PathFind)
     {
         return PMob->PAI->PathFind->CanSeePoint(pos);
@@ -258,6 +268,7 @@ bool CMobController::CanSeePoint(position_t pos)
 
 bool CMobController::MobSkill(int wsList)
 {
+    TracyZoneScoped;
     /* #TODO: mob 2 hours, etc */
     if (!wsList) wsList = PMob->getMobMod(MOBMOD_SKILL_LIST);
     auto skillList {battleutils::GetMobSkillList(wsList)};
@@ -304,6 +315,7 @@ bool CMobController::MobSkill(int wsList)
 
 bool CMobController::TrySpecialSkill()
 {
+    TracyZoneScoped;
     // get my special skill
     CMobSkill* PSpecialSkill = battleutils::GetMobSkill(PMob->getMobMod(MOBMOD_SPECIAL_SKILL));
     CBattleEntity* PAbilityTarget = nullptr;
@@ -357,6 +369,7 @@ bool CMobController::TrySpecialSkill()
 
 bool CMobController::TryCastSpell()
 {
+    TracyZoneScoped;
     if (!CanCastSpells())
     {
         return false;
@@ -401,7 +414,7 @@ bool CMobController::TryCastSpell()
 
 bool CMobController::CanCastSpells()
 {
-
+    TracyZoneScoped;
     if (!PMob->SpellContainer->HasSpells() && !PMob->m_HasSpellScript)
     {
         return false;
@@ -428,6 +441,7 @@ bool CMobController::CanCastSpells()
 
 void CMobController::CastSpell(SpellID spellid)
 {
+    TracyZoneScoped;
     CSpell* PSpell = spell::GetSpell(spellid);
     if (PSpell == nullptr)
     {
@@ -480,6 +494,7 @@ void CMobController::CastSpell(SpellID spellid)
 
 void CMobController::DoCombatTick(time_point tick)
 {
+    TracyZoneScopedC(0xFF0000);
     if (PMob->m_OwnerID.targid != 0 && static_cast<CCharEntity*>(PMob->GetEntity(PMob->m_OwnerID.targid))->PClaimedMob != static_cast<CBattleEntity*>(PMob))
     {
         if (m_Tick >= m_DeclaimTime + 3s)
@@ -525,6 +540,7 @@ void CMobController::DoCombatTick(time_point tick)
 
 void CMobController::FaceTarget(uint16 targid)
 {
+    TracyZoneScoped;
     CBaseEntity* targ = PTarget;
     if (targid != 0 && ((targ && targid != targ->targid ) || !targ))
     {
@@ -538,6 +554,7 @@ void CMobController::FaceTarget(uint16 targid)
 
 void CMobController::Move()
 {
+    TracyZoneScoped;
     if (!PMob->PAI->CanFollowPath())
     {
         return;
@@ -652,6 +669,7 @@ void CMobController::Move()
 
 void CMobController::HandleEnmity()
 {
+    TracyZoneScoped;
     PMob->PEnmityContainer->DecayEnmity();
     if (PMob->getMobMod(MOBMOD_SHARE_TARGET) > 0 && PMob->GetEntity(PMob->getMobMod(MOBMOD_SHARE_TARGET), TYPE_MOB))
     {
@@ -672,6 +690,7 @@ void CMobController::HandleEnmity()
 
 void CMobController::DoRoamTick(time_point tick)
 {
+    TracyZoneScopedC(0x00FF00);
     // If there's someone on our enmity list, go from roaming -> engaging
     if (PMob->PEnmityContainer->GetHighestEnmity() != nullptr && !(PMob->m_roamFlags & ROAMFLAG_IGNORE))
     {
@@ -847,6 +866,7 @@ void CMobController::Wait(duration _duration)
 
 void CMobController::FollowRoamPath()
 {
+    TracyZoneScoped;
     if (PMob->PAI->CanFollowPath())
     {
         PMob->PAI->PathFind->FollowPath();
@@ -892,6 +912,7 @@ void CMobController::FollowRoamPath()
 
 void CMobController::Despawn()
 {
+    TracyZoneScoped;
     if (PMob)
     {
         PMob->PAI->Internal_Despawn();
@@ -900,6 +921,7 @@ void CMobController::Despawn()
 
 void CMobController::Reset()
 {
+    TracyZoneScoped;
     // Wait a little before roaming / casting spell / spawning pet
     m_LastActionTime = m_Tick - std::chrono::milliseconds(tpzrand::GetRandomNumber(PMob->getBigMobMod(MOBMOD_ROAM_COOL)));
 
@@ -912,6 +934,7 @@ void CMobController::Reset()
 
 bool CMobController::MobSkill(uint16 targid, uint16 wsid)
 {
+    TracyZoneScoped;
     if (POwner)
     {
         FaceTarget(targid);
@@ -923,6 +946,7 @@ bool CMobController::MobSkill(uint16 targid, uint16 wsid)
 
 bool CMobController::Disengage()
 {
+    TracyZoneScoped;
     // this will let me decide to walk home or despawn
     m_LastActionTime = m_Tick - std::chrono::milliseconds(PMob->getBigMobMod(MOBMOD_ROAM_COOL)) + 10s;
     PMob->m_neutral = true;
@@ -946,6 +970,7 @@ bool CMobController::Disengage()
 
 bool CMobController::Engage(uint16 targid)
 {
+    TracyZoneScoped;
     auto ret = CController::Engage(targid);
     if (ret)
     {
@@ -967,6 +992,10 @@ bool CMobController::Engage(uint16 targid)
 
 bool CMobController::CanAggroTarget(CBattleEntity* PTarget)
 {
+    TracyZoneScoped;
+    TracyZoneIString(PMob->GetName());
+    TracyZoneIString(PTarget->GetName());
+
     // Don't aggro I'm neutral
     if ((PMob->getMobMod(MOBMOD_ALWAYS_AGGRO) == 0 && !PMob->m_Aggro) || PMob->m_neutral || PMob->isDead())
     {
@@ -1010,12 +1039,14 @@ void CMobController::TapDeclaimTime()
 
 bool CMobController::Cast(uint16 targid, SpellID spellid)
 {
+    TracyZoneScoped;
     FaceTarget(targid);
     return CController::Cast(targid, spellid);
 }
 
 bool CMobController::CanMoveForward(float currentDistance)
 {
+    TracyZoneScoped;
     if(PMob->m_Behaviour & BEHAVIOUR_STANDBACK && currentDistance < 20)
     {
         return false;
@@ -1042,7 +1073,7 @@ bool CMobController::CanMoveForward(float currentDistance)
 
 bool CMobController::IsSpecialSkillReady(float currentDistance)
 {
-
+    TracyZoneScoped;
     if (PMob->getMobMod(MOBMOD_SPECIAL_SKILL) == 0) return false;
 
     if (PMob->StatusEffectContainer->HasStatusEffect(EFFECT_CHAINSPELL)) return false;
@@ -1064,7 +1095,7 @@ bool CMobController::IsSpecialSkillReady(float currentDistance)
 
 bool CMobController::IsSpellReady(float currentDistance)
 {
-
+    TracyZoneScoped;
     int32 bonusTime = 0;
     if (currentDistance > 5)
     {

--- a/src/map/ai/controllers/pet_controller.cpp
+++ b/src/map/ai/controllers/pet_controller.cpp
@@ -36,6 +36,9 @@ CPetController::CPetController(CPetEntity* _PPet) :
 
 void CPetController::Tick(time_point tick)
 {
+    TracyZoneScoped;
+    TracyZoneIString(PPet->GetName());
+
     if (PPet->isCharmed && tick > PPet->charmTime)
     {
         petutils::DespawnPet(PPet->PMaster);

--- a/src/map/ai/controllers/trust_controller.cpp
+++ b/src/map/ai/controllers/trust_controller.cpp
@@ -55,6 +55,9 @@ void CTrustController::Despawn()
 
 void CTrustController::Tick(time_point tick)
 {
+    TracyZoneScoped;
+    TracyZoneIString(POwner->GetName());
+
     m_Tick = tick;
 
     if (POwner->PAI->IsEngaged())
@@ -69,6 +72,7 @@ void CTrustController::Tick(time_point tick)
 
 void CTrustController::DoCombatTick(time_point tick)
 {
+    TracyZoneScoped;
     if (!POwner->PMaster->PAI->IsEngaged())
     {
         POwner->PAI->Internal_Disengage();
@@ -98,6 +102,7 @@ void CTrustController::DoCombatTick(time_point tick)
 
 void CTrustController::DoRoamTick(time_point tick)
 {
+    TracyZoneScoped;
     if (POwner->PMaster->PAI->IsEngaged())
     {
         POwner->PAI->Internal_Engage(POwner->PMaster->GetBattleTargetID());

--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -40,6 +40,7 @@ CPathFind::~CPathFind()
 
 bool CPathFind::RoamAround(const position_t& point, float maxRadius, uint8 maxTurns, uint16 roamFlags)
 {
+    TracyZoneScoped;
     Clear();
 
     m_roamFlags = roamFlags;
@@ -75,6 +76,7 @@ bool CPathFind::RoamAround(const position_t& point, float maxRadius, uint8 maxTu
 
 bool CPathFind::PathTo(const position_t& point, uint8 pathFlags, bool clear)
 {
+    TracyZoneScoped;
     // don't follow a new path if the current path has script flag and new path doesn't
     if (IsFollowingPath() && (m_pathFlags & PATHFLAG_SCRIPT) && !(pathFlags & PATHFLAG_SCRIPT))
         return false;
@@ -119,6 +121,7 @@ bool CPathFind::PathTo(const position_t& point, uint8 pathFlags, bool clear)
 
 bool CPathFind::PathInRange(const position_t& point, float range, uint8 pathFlags /*= 0*/, bool clear /*= true*/)
 {
+    TracyZoneScoped;
     if (clear)
     {
         Clear();
@@ -129,6 +132,7 @@ bool CPathFind::PathInRange(const position_t& point, float range, uint8 pathFlag
 
 bool CPathFind::PathAround(const position_t& point, float distanceFromPoint, uint8 pathFlags)
 {
+    TracyZoneScoped;
     Clear();
     //position_t* lastPoint = &point;
 
@@ -147,6 +151,7 @@ bool CPathFind::PathAround(const position_t& point, float distanceFromPoint, uin
 
 bool CPathFind::PathThrough(std::vector<position_t>&& points, uint8 pathFlags)
 {
+    TracyZoneScoped;
     Clear();
 
     m_pathFlags = pathFlags;
@@ -158,6 +163,7 @@ bool CPathFind::PathThrough(std::vector<position_t>&& points, uint8 pathFlags)
 
 bool CPathFind::WarpTo(const position_t& point, float maxDistance)
 {
+    TracyZoneScoped;
     Clear();
 
     position_t newPoint = nearPosition(point, maxDistance, (float)M_PI);
@@ -180,6 +186,7 @@ bool CPathFind::isNavMeshEnabled()
 
 bool CPathFind::ValidPosition(const position_t& pos)
 {
+    TracyZoneScoped;
     if (isNavMeshEnabled())
     {
         return m_PTarget->loc.zone->m_navMesh->validPosition(pos);
@@ -197,6 +204,7 @@ void CPathFind::LimitDistance(float maxLength)
 
 void CPathFind::StopWithin(float within)
 {
+    TracyZoneScoped;
     if (!IsFollowingPath()) return;
     // TODO: cut up path
 
@@ -239,6 +247,7 @@ void CPathFind::StopWithin(float within)
 
 void CPathFind::FollowPath()
 {
+    TracyZoneScoped;
     if (!IsFollowingPath()) return;
 
     m_onPoint = false;
@@ -271,7 +280,7 @@ void CPathFind::FollowPath()
 
 void CPathFind::StepTo(const position_t& pos, bool run)
 {
-
+    TracyZoneScoped;
     float speed = GetRealSpeed();
 
     int8 mode = 2;
@@ -332,7 +341,7 @@ void CPathFind::StepTo(const position_t& pos, bool run)
 
 bool CPathFind::FindPath(const position_t& start, const position_t& end)
 {
-
+    TracyZoneScoped;
     m_points = m_PTarget->loc.zone->m_navMesh->findPath(start, end);
     m_currentPoint = 0;
 
@@ -347,6 +356,7 @@ bool CPathFind::FindPath(const position_t& start, const position_t& end)
 
 bool CPathFind::FindRandomPath(const position_t& start, float maxRadius, uint8 maxTurns, uint16 roamFlags)
 {
+    TracyZoneScoped;
     auto m_turnLength = tpzrand::GetRandomNumber((int)maxTurns) + 1;
 
     position_t startPosition = start;
@@ -377,6 +387,7 @@ bool CPathFind::FindRandomPath(const position_t& start, float maxRadius, uint8 m
 
 bool CPathFind::FindClosestPath(const position_t& start, const position_t& end)
 {
+    TracyZoneScoped;
     m_points = m_PTarget->loc.zone->m_navMesh->findPath(start, end);
     m_currentPoint = 0;
     m_points.push_back(end);  // this prevents exploits with navmesh / impassible terrain

--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -68,6 +68,7 @@ void CTargetFind::findSingleTarget(CBattleEntity* PTarget, uint8 flags)
 
 void CTargetFind::findWithinArea(CBattleEntity* PTarget, AOERADIUS radiusType, float radius, uint8 flags)
 {
+    TracyZoneScoped;
     m_findFlags = flags;
     m_radius = radius;
     m_zone = m_PBattleEntity->getZone();
@@ -224,6 +225,7 @@ void CTargetFind::addAllInMobList(CBattleEntity* PTarget, bool withPet)
 
 void CTargetFind::addAllInZone(CBattleEntity* PTarget, bool withPet)
 {
+    TracyZoneScoped;
 	zoneutils::GetZone(PTarget->getZone())->ForEachCharInstance(PTarget, [&](CCharEntity* PChar){
 		if (PChar){
 			addEntity(PChar, withPet);

--- a/src/map/conquest_system.cpp
+++ b/src/map/conquest_system.cpp
@@ -46,6 +46,7 @@ namespace conquest
 
 	void UpdateConquestSystem()
 	{
+        TracyZoneScoped;
 		zoneutils::ForEachZone([](CZone* PZone)
 		{
             //only find chars for zones that have had conquest updated
@@ -306,6 +307,7 @@ namespace conquest
 
 	void UpdateWeekConquest()
 	{
+        TracyZoneScoped;
 		//TODO: move to lobby server
 		//launch conquest message in all zone (monday server midnight)
 

--- a/src/map/enmity_container.cpp
+++ b/src/map/enmity_container.cpp
@@ -57,6 +57,7 @@ CEnmityContainer::~CEnmityContainer()
 
 void CEnmityContainer::Clear(uint32 EntityID)
 {
+    TracyZoneScoped;
     if (EntityID == 0)
     {
         for (const auto& entry : m_EnmityList)
@@ -99,6 +100,7 @@ void CEnmityContainer::LogoutReset(uint32 EntityID)
 
 void CEnmityContainer::AddBaseEnmity(CBattleEntity* PChar)
 {
+    TracyZoneScoped;
     m_EnmityList.emplace(PChar->id, EnmityObject_t {PChar, 0, 0, false, 0});
     PChar->PNotorietyContainer->add(m_EnmityHolder);
 }
@@ -136,6 +138,7 @@ float CEnmityContainer::CalculateEnmityBonus(CBattleEntity* PEntity)
 
 void CEnmityContainer::UpdateEnmity(CBattleEntity* PEntity, int32 CE, int32 VE, bool withMaster, bool tameable)
 {
+    TracyZoneScoped;
     // you're too far away so i'm ignoring you
     if (!IsWithinEnmityRange(PEntity))
     {
@@ -218,6 +221,7 @@ bool CEnmityContainer::HasID(uint32 TargetID)
 
 void CEnmityContainer::UpdateEnmityFromCure(CBattleEntity* PEntity, uint8 level, int32 CureAmount, bool isCureV)
 {
+    TracyZoneScoped;
     if (!IsWithinEnmityRange(PEntity))
         return;
 
@@ -343,6 +347,7 @@ void CEnmityContainer::SetVE(CBattleEntity* PEntity, const int32 amount)
 
 void CEnmityContainer::UpdateEnmityFromDamage(CBattleEntity* PEntity, int32 Damage)
 {
+    TracyZoneScoped;
     Damage = (Damage < 1 ? 1 : Damage);
     int16 damageMod = battleutils::GetEnmityModDamage(m_EnmityHolder->GetMLevel());
 
@@ -363,6 +368,7 @@ void CEnmityContainer::UpdateEnmityFromDamage(CBattleEntity* PEntity, int32 Dama
 
 void CEnmityContainer::UpdateEnmityFromAttack(CBattleEntity* PEntity, int32 Damage)
 {
+    TracyZoneScoped;
     if (auto enmity_obj = m_EnmityList.find(PEntity->id); enmity_obj != m_EnmityList.end())
     {
         float reduction = (100.f - std::min<int16>(PEntity->getMod(Mod::ENMITY_LOSS_REDUCTION), 100)) / 100.f;
@@ -380,6 +386,7 @@ void CEnmityContainer::UpdateEnmityFromAttack(CBattleEntity* PEntity, int32 Dama
 
 CBattleEntity* CEnmityContainer::GetHighestEnmity()
 {
+    TracyZoneScoped;
     if (m_EnmityList.empty())
     {
         return nullptr;
@@ -471,6 +478,7 @@ bool CEnmityContainer::IsTameable()
 
 void CEnmityContainer::UpdateEnmityFromCover(CBattleEntity* PCoverAbilityTarget, CBattleEntity* PCoverAbilityUser)
 {
+    TracyZoneScoped;
     // Update Enmity if cover ability target and cover ability user are not nullptr
     if (PCoverAbilityTarget != nullptr && PCoverAbilityUser != nullptr)
     {

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -255,6 +255,10 @@ void CCharEntity::clearPacketList()
 
 void CCharEntity::pushPacket(CBasicPacket* packet)
 {
+    TracyZoneScoped;
+    TracyZoneIString(GetName());
+    TracyZoneHex16(packet->id());
+
     std::lock_guard<std::mutex> lk(m_PacketListMutex);
     PacketList.push_back(packet);
 }
@@ -516,6 +520,7 @@ void CCharEntity::ClearTrusts()
 
 void CCharEntity::Tick(time_point tick)
 {
+    TracyZoneScoped;
     CBattleEntity::Tick(tick);
     if (m_DeathTimestamp > 0 && tick >= m_deathSyncTime)
     {
@@ -532,6 +537,7 @@ void CCharEntity::Tick(time_point tick)
 
 void CCharEntity::PostTick()
 {
+    TracyZoneScoped;
     CBattleEntity::PostTick();
     if (m_EquipSwap)
     {

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -359,6 +359,7 @@ void CLatentEffectContainer::CheckLatentsDay()
 ************************************************************************/
 void CLatentEffectContainer::CheckLatentsMoonPhase()
 {
+    TracyZoneScoped;
     ProcessLatentEffects([this](CLatentEffect& latentEffect)
     {
         switch (latentEffect.GetConditionsID())
@@ -410,6 +411,7 @@ void CLatentEffectContainer::CheckLatentsWeekDay()
 ************************************************************************/
 void CLatentEffectContainer::CheckLatentsHours()
 {
+    TracyZoneScoped;
     ProcessLatentEffects([this](CLatentEffect& latentEffect)
     {
         switch (latentEffect.GetConditionsID())
@@ -688,6 +690,7 @@ void CLatentEffectContainer::ProcessLatentEffects(std::function <bool(CLatentEff
 // activation/deactivation and attempts to apply
 bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
 {
+    TracyZoneScoped;
     // Our default case un-finds our latent prevent us from toggling a latent we don't have programmed
     auto expression = false;
     auto latentFound = true;

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -99,6 +99,7 @@ namespace luautils
 
     int32 init()
     {
+        TracyZoneScoped;
         ShowStatus("luautils::init:lua initializing...");
         LuaHandle = luaL_newstate();
         luaL_openlibs(LuaHandle);
@@ -176,6 +177,8 @@ namespace luautils
 
         contentRestrictionEnabled = (GetSettingsVariable("RESTRICT_CONTENT") != 0);
 
+        TracyReportLuaMemory(LuaHandle);
+
         ShowMessage("\t\t - " CL_GREEN"[OK]" CL_RESET"\n");
         return 0;
     }
@@ -200,11 +203,15 @@ namespace luautils
 
     int32 garbageCollect()
     {
+        TracyZoneScoped;
+        TracyReportLuaMemory(LuaHandle);
 
         int32 top = lua_gettop(LuaHandle);
         ShowDebug(CL_CYAN"[Lua] Garbage Collected. Current State Top: %d\n" CL_RESET, top);
 
         lua_gc(LuaHandle, LUA_GCSTEP, 10);
+
+        TracyReportLuaMemory(LuaHandle);
 
         return 0;
     }
@@ -245,6 +252,11 @@ namespace luautils
 
     int32 prepFile(int8* File, const char* function)
     {
+        TracyZoneScoped;
+        TracyZoneCString(function);
+        TracyZoneIString(File);
+        TracyReportLuaMemory(LuaHandle);
+
         lua_pushnil(LuaHandle);
         lua_setglobal(LuaHandle, function);
 
@@ -336,6 +348,7 @@ namespace luautils
 
     int32 GetNPCByID(lua_State* L)
     {
+        TracyZoneScoped;
         if (!lua_isnil(L, 1) && lua_isnumber(L, 1))
         {
             uint32 npcid = (uint32)lua_tointeger(L, 1);
@@ -387,6 +400,7 @@ namespace luautils
 
     int32 GetMobByID(lua_State* L)
     {
+        TracyZoneScoped;
         if (!lua_isnil(L, 1) && lua_isnumber(L, 1))
         {
             uint32 mobid = (uint32)lua_tointeger(L, 1);
@@ -857,6 +871,7 @@ namespace luautils
     ************************************************************************/
     int32 SpawnMob(lua_State* L)
     {
+        TracyZoneScoped;
         if (!lua_isnil(L, 1) && lua_isnumber(L, 1))
         {
             uint32 mobid = (uint32)lua_tointeger(L, 1);
@@ -922,6 +937,7 @@ namespace luautils
 
     int32 DespawnMob(lua_State* L)
     {
+        TracyZoneScoped;
         if (!lua_isnil(L, 1) && lua_isnumber(L, 1))
         {
             uint32 mobid = (uint32)lua_tointeger(L, 1);
@@ -1459,6 +1475,7 @@ namespace luautils
 
     int32 OnTrigger(CCharEntity* PChar, CBaseEntity* PNpc)
     {
+        TracyZoneScoped;
         lua_prepscript("scripts/zones/%s/npcs/%s.lua", PChar->loc.zone->GetName(), PNpc->GetName());
 
         PChar->m_event.reset();
@@ -1517,6 +1534,7 @@ namespace luautils
 
     int32 OnEventUpdate(CCharEntity* PChar, uint16 eventID, uint32 result, uint16 extras)
     {
+        TracyZoneScoped;
         lua_gettop(LuaHandle);
         lua_pushnil(LuaHandle);
         lua_setglobal(LuaHandle, "onEventUpdate");
@@ -1558,6 +1576,7 @@ namespace luautils
 
     int32 OnEventUpdate(CCharEntity* PChar, uint16 eventID, uint32 result)
     {
+        TracyZoneScoped;
         lua_pushnil(LuaHandle);
         lua_setglobal(LuaHandle, "onEventUpdate");
 
@@ -1593,6 +1612,7 @@ namespace luautils
 
     int32 OnEventUpdate(CCharEntity* PChar, int8* string)
     {
+        TracyZoneScoped;
         lua_pushnil(LuaHandle);
         lua_setglobal(LuaHandle, "onEventUpdate");
 
@@ -1630,6 +1650,7 @@ namespace luautils
 
     int32 OnEventFinish(CCharEntity* PChar, uint16 eventID, uint32 result)
     {
+        TracyZoneScoped;
         lua_pushnil(LuaHandle);
         lua_setglobal(LuaHandle, "onEventFinish");
 
@@ -1672,6 +1693,7 @@ namespace luautils
 
     int32 OnTrade(CCharEntity* PChar, CBaseEntity* PNpc)
     {
+        TracyZoneScoped;
         lua_prepscript("scripts/zones/%s/npcs/%s.lua", PChar->loc.zone->GetName(), PNpc->GetName());
 
         PChar->m_event.reset();
@@ -2503,6 +2525,7 @@ namespace luautils
 
     int32 OnPath(CBaseEntity* PEntity)
     {
+        TracyZoneScoped;
         TPZ_DEBUG_BREAK_IF(PEntity == nullptr);
 
         if (PEntity->objtype != TYPE_PC)
@@ -2742,6 +2765,7 @@ namespace luautils
 
     int32 OnMobFight(CBaseEntity* PMob, CBaseEntity* PTarget)
     {
+        TracyZoneScoped;
         TPZ_DEBUG_BREAK_IF(PMob == nullptr);
         TPZ_DEBUG_BREAK_IF(PTarget == nullptr || PTarget->objtype == TYPE_NPC);
 
@@ -2807,6 +2831,7 @@ namespace luautils
 
     int32 OnMobDeath(CBaseEntity* PMob, CBaseEntity* PKiller)
     {
+        TracyZoneScoped;
         TPZ_DEBUG_BREAK_IF(PMob == nullptr);
 
         CCharEntity* PChar = dynamic_cast<CCharEntity*>(PKiller);
@@ -3096,6 +3121,7 @@ namespace luautils
 
     int32 OnGameHour(CZone* PZone)
     {
+        TracyZoneScoped;
         lua_prepscript("scripts/zones/%s/Zone.lua", PZone->GetName());
 
         if (prepFile(File, "onGameHour"))
@@ -3977,6 +4003,7 @@ namespace luautils
 
     int32 OnConquestUpdate(CZone* PZone, ConquestUpdate type)
     {
+        TracyZoneScoped;
         lua_prepscript("scripts/zones/%s/Zone.lua", PZone->GetName());
 
         if (prepFile(File, "onConquestUpdate"))

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -66,6 +66,20 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "packets/char_update.h"
 #include "message.h"
 
+#ifdef TRACY_ENABLE
+void* operator new(std::size_t count)
+{
+    auto ptr = malloc(count);
+    TracyAlloc(ptr, count);
+    return ptr;
+}
+
+void operator delete(void* ptr) noexcept
+{
+    TracyFree(ptr);
+    free(ptr);
+}
+#endif // TRACY_ENABLE
 
 const char* MAP_CONF_FILENAME = nullptr;
 
@@ -112,6 +126,7 @@ map_session_data_t* mapsession_getbyipp(uint64 ipp)
 
 map_session_data_t* mapsession_createsession(uint32 ip, uint16 port)
 {
+    TracyZoneScoped;
     map_session_data_t* map_session_data = new map_session_data_t;
     memset(map_session_data, 0, sizeof(map_session_data_t));
 
@@ -147,6 +162,7 @@ map_session_data_t* mapsession_createsession(uint32 ip, uint16 port)
 
 int32 do_init(int32 argc, char** argv)
 {
+    TracyZoneScoped;
     ShowStatus("do_init: begin server initialization...");
     map_ip.s_addr = 0;
 
@@ -408,6 +424,9 @@ int32 do_sockets(fd_set* rfd, duration next)
             }
         }
     }
+
+    TracyReportLuaMemory(luautils::LuaHandle);
+
     return 0;
 }
 
@@ -570,12 +589,15 @@ int32 recv_parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_da
 
 int32 parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_data_t* map_session_data)
 {
+    TracyZoneScoped;
     // начало обработки входящего пакета
 
     int8* PacketData_Begin = &buff[FFXI_HEADER_SIZE];
     int8* PacketData_End = &buff[*buffsize];
 
-    CCharEntity *PChar = map_session_data->PChar;
+    CCharEntity* PChar = map_session_data->PChar;
+
+    TracyZoneIString(PChar->GetName());
 
     uint16 SmallPD_Size = 0;
     uint16 SmallPD_Type = 0;
@@ -820,6 +842,7 @@ int32 map_close_session(time_point tick, map_session_data_t* map_session_data)
 
 int32 map_cleanup(time_point tick, CTaskMgr::CTask* PTask)
 {
+    TracyZoneScoped;
     map_session_list_t::iterator it = map_session_list.begin();
 
     while (it != map_session_list.end())
@@ -1468,6 +1491,7 @@ int32 map_config_read(const int8* cfgName)
 
 int32 map_garbage_collect(time_point tick, CTaskMgr::CTask* PTask)
 {
+    TracyZoneScoped;
     luautils::garbageCollect();
     return 0;
 }

--- a/src/map/navmesh.cpp
+++ b/src/map/navmesh.cpp
@@ -198,6 +198,7 @@ void CNavMesh::unload()
 
 std::vector<position_t> CNavMesh::findPath(const position_t& start, const position_t& end)
 {
+    TracyZoneScoped;
     std::vector<position_t> ret;
     dtStatus status;
 
@@ -297,6 +298,7 @@ std::vector<position_t> CNavMesh::findPath(const position_t& start, const positi
 
 std::pair<int16, position_t> CNavMesh::findRandomPosition(const position_t& start, float maxRadius)
 {
+    TracyZoneScoped;
     dtStatus status;
 
     float spos[3];
@@ -354,6 +356,7 @@ bool CNavMesh::inWater(const position_t& point)
 
 bool CNavMesh::validPosition(const position_t& position)
 {
+    TracyZoneScoped;
     float spos[3];
     CNavMesh::ToDetourPos(&position, spos);
 
@@ -382,6 +385,7 @@ bool CNavMesh::validPosition(const position_t& position)
 
 bool CNavMesh::raycast(const position_t& start, const position_t& end)
 {
+    TracyZoneScoped;
     if (start.x == end.x && start.y == end.y && start.z == end.z)
         return true;
     dtStatus status;

--- a/src/map/notoriety_container.cpp
+++ b/src/map/notoriety_container.cpp
@@ -53,6 +53,7 @@ void CNotorietyContainer::remove(CBattleEntity* entity)
 
 bool CNotorietyContainer::hasEnmity()
 {
+    TracyZoneScoped;
     // Make sure the container is up to date before reporting
     if (!m_Lookup.empty())
     {

--- a/src/map/packet_guard.cpp
+++ b/src/map/packet_guard.cpp
@@ -53,6 +53,7 @@ void Init()
 
 bool PacketIsValidForPlayerState(CCharEntity* PChar, uint16 SmallPD_Type)
 {
+    TracyZoneScoped;
 #if PACKETGUARD_CAP_ENABLED == 1
     regular_client_packets[PChar->m_Substate].insert(SmallPD_Type);
     for (uint8 state = SUBSTATE_IN_CS; state < SUBSTATE_LAST; ++state)
@@ -72,6 +73,7 @@ bool PacketIsValidForPlayerState(CCharEntity* PChar, uint16 SmallPD_Type)
 
 bool IsRateLimitedPacket(CCharEntity* PChar, uint16 SmallPD_Type)
 {
+    TracyZoneScoped;
     using namespace std::chrono;
     uint32 lastPacketRecievedTime = PChar->m_PacketRecievedTimestamps[SmallPD_Type];
     uint32 timeNowSeconds = static_cast<uint32>(time_point_cast<seconds>(server_clock::now()).time_since_epoch().count());

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -225,6 +225,7 @@ void SmallPacket0xFFF(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x00A(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     data.ref<uint32>(0x5C) = 0;
 
     PChar->clearPacketList();
@@ -334,6 +335,7 @@ void SmallPacket0x00A(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x00C(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     PChar->pushPacket(new CInventorySizePacket(PChar));
     PChar->pushPacket(new CMenuConfigPacket(PChar));
     PChar->pushPacket(new CCharJobsPacket(PChar));
@@ -377,7 +379,7 @@ void SmallPacket0x00C(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x00D(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
-
+    TracyZoneScoped;
     session->blowfish.status = BLOWFISH_WAITING;
 
     PChar->TradePending.clean();
@@ -474,6 +476,7 @@ void SmallPacket0x00D(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x00F(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     charutils::SendKeyItems(PChar);
     charutils::SendQuestMissionLog(PChar);
 
@@ -502,6 +505,7 @@ void SmallPacket0x00F(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x011(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     session->blowfish.status = BLOWFISH_ACCEPTED;
 
     PChar->health.tp = 0;
@@ -535,6 +539,9 @@ void SmallPacket0x011(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x015(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
+    TracyZoneCString("Player Sync");
+
     if (PChar->status != STATUS_SHUTDOWN &&
         PChar->status != STATUS_DISAPPEAR)
     {
@@ -591,6 +598,7 @@ void SmallPacket0x015(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x016(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint16 targid = data.ref<uint16>(0x04);
 
     if (targid == PChar->targid)
@@ -626,6 +634,7 @@ void SmallPacket0x016(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x017(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint16 targid = data.ref<uint16>(0x04);
     uint32 npcid = data.ref<uint32>(0x08);
     uint8  type = data.ref<uint8>(0x12);
@@ -642,6 +651,9 @@ void SmallPacket0x017(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x01A(map_session_data_t* PSession, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
+    TracyZoneCString("Player Action");
+
     // uint32 ID = data.ref<uint32>(0x04);
     uint16 TargID = data.ref<uint16>(0x08);
     uint8 action = data.ref<uint8>(0x0A);
@@ -957,6 +969,7 @@ void SmallPacket0x01A(map_session_data_t* PSession, CCharEntity* PChar, CBasicPa
 
 void SmallPacket0x01B(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     // 0 - world pass, 2 - gold world pass; +1 - purchase
 
     PChar->pushPacket(new CWorldPassPacket(data.ref<uint8>(0x04) & 1 ? (uint32)tpzrand::GetRandomNumber(9999999999) : 0));
@@ -972,6 +985,7 @@ void SmallPacket0x01B(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x01C(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     PrintPacket(data);
     return;
 }
@@ -984,6 +998,7 @@ void SmallPacket0x01C(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x028(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     int32  quantity = data.ref<uint8>(0x04);
     uint8 container = data.ref<uint8>(0x08);
     uint8    slotID = data.ref<uint8>(0x09);
@@ -1033,6 +1048,7 @@ void SmallPacket0x028(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x029(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint32 quantity = data.ref<uint8>(0x04);
     uint8  FromLocationID = data.ref<uint8>(0x08);
     uint8  ToLocationID = data.ref<uint8>(0x09);
@@ -1142,6 +1158,7 @@ void SmallPacket0x029(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x032(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint32 charid = data.ref<uint32>(0x04);
     uint16 targid = data.ref<uint16>(0x08);
 
@@ -1198,6 +1215,7 @@ void SmallPacket0x032(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x033(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     CCharEntity* PTarget = (CCharEntity*)PChar->GetEntity(PChar->TradePending.targid, TYPE_PC);
 
     if (PTarget != nullptr && PChar->TradePending.id == PTarget->id)
@@ -1300,6 +1318,7 @@ void SmallPacket0x033(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x034(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint32 quantity = data.ref<uint32>(0x04);
     uint16 itemID = data.ref<uint16>(0x08);
     uint8  invSlotID = data.ref<uint8>(0x0A);
@@ -1388,6 +1407,7 @@ void SmallPacket0x034(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x036(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint32 npcid = data.ref<uint32>(0x04);
     uint16 targid = data.ref<uint16>(0x3A);
 
@@ -1437,6 +1457,7 @@ void SmallPacket0x036(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x037(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     // uint32 EntityID = data.ref<uint32>(0x04);
     uint16 TargetID = data.ref<uint16>(0x0C);
     uint8  SlotID = data.ref<uint8>(0x0E);
@@ -1464,6 +1485,9 @@ void SmallPacket0x037(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x03A(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
+    TracyZoneCString("Sort Inventory");
+
     uint8 container = data.ref<uint8>(0x04);
 
     if (container >= MAX_CONTAINER_ID)
@@ -1540,6 +1564,7 @@ void SmallPacket0x03A(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x03C(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     ShowWarning(CL_YELLOW"SmallPacket0x03C\n" CL_RESET);
     return;
 }
@@ -1552,6 +1577,7 @@ void SmallPacket0x03C(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x03D(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     const int8* name = (const int8*)(data[0x08]);
     uint8 cmd = data.ref<uint8>(0x18);
 
@@ -1617,6 +1643,7 @@ void SmallPacket0x03D(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x041(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     PrintPacket(data);
 
     uint8 SlotID = data.ref<uint8>(0x04);
@@ -1644,6 +1671,7 @@ void SmallPacket0x041(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x042(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     PrintPacket(data);
 
     uint8 SlotID = data.ref<uint8>(0x04);
@@ -1671,6 +1699,7 @@ void SmallPacket0x042(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x04B(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     // uint8   msg_chunk = data.ref<uint8>(0x04); // The current chunk of the message to send.. (1 = start, 2 = rest of message)
     // uint8   msg_unknown1 = data.ref<uint8>(0x05); // Unknown.. always 0
     // uint8   msg_unknown2 = data.ref<uint8>(0x06); // Unknown.. always 1
@@ -1708,6 +1737,7 @@ void SmallPacket0x04B(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x04D(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint8 action = data.ref<uint8>(0x04);
     uint8 boxtype = data.ref<uint8>(0x05);
     uint8 slotID = data.ref<uint8>( 0x06);
@@ -2352,6 +2382,7 @@ void SmallPacket0x04D(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x04E(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint8  action = data.ref<uint8>(0x04);
     uint8  slotid = data.ref<uint8>(0x05);
     uint32 price = data.ref<uint32>(0x08);
@@ -2644,6 +2675,7 @@ void SmallPacket0x04E(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x050(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     if (PChar->status != STATUS_NORMAL)
         return;
 
@@ -2674,6 +2706,7 @@ void SmallPacket0x050(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x051(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     if (PChar->status != STATUS_NORMAL)
         return;
 
@@ -2702,6 +2735,7 @@ void SmallPacket0x051(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x052(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     //Im guessing this is here to check if you can use A Item, as it seems useless to have this sent to server
     //as It will check requirements when it goes to equip the items anyway
     //0x05 is slot of updated item
@@ -2721,6 +2755,7 @@ void SmallPacket0x052(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 ************************************************************************/
 void SmallPacket0x053(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint8 count = data.ref<uint8>(0x04);
     uint8 type = data.ref<uint8>(0x05);
 
@@ -2800,6 +2835,7 @@ void SmallPacket0x053(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x058(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint16 skillID    = data.ref<uint16>(0x04);
     uint16 skillLevel = data.ref<uint16>(0x06);
 
@@ -2814,6 +2850,7 @@ void SmallPacket0x058(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x059(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     if (PChar->animation == ANIMATION_SYNTH)
     {
         synthutils::sendSynthDone(PChar);
@@ -2829,6 +2866,7 @@ void SmallPacket0x059(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x05A(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     PChar->pushPacket(new CConquestPacket(PChar));
     PChar->pushPacket(new CCampaignPacket(PChar, 0));
     PChar->pushPacket(new CCampaignPacket(PChar, 1));
@@ -2847,6 +2885,7 @@ void SmallPacket0x05A(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x05B(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     //auto CharID = data.ref<uint32>(0x04);
     auto Result = data.ref<uint32>(0x08);
     //auto ZoneID = data.ref<uint16>(0x10);
@@ -2885,6 +2924,7 @@ void SmallPacket0x05B(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x05C(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     //auto CharID = data.ref<uint32>(0x10);
     auto Result = data.ref<uint32>(0x14);
     //auto ZoneID = data.ref<uint16>(0x18);
@@ -2933,6 +2973,7 @@ void SmallPacket0x05C(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x05D(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     if (jailutils::InPrison(PChar))
     {
         PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, 316));
@@ -2990,6 +3031,7 @@ void SmallPacket0x05D(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x05E(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     // handle pets on zone
     if (PChar->PPet != nullptr)
     {
@@ -3108,6 +3150,7 @@ void SmallPacket0x05E(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x060(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     // uint32 charid = data.ref<uint32>(0x04);
     int8* string = data[12];
     luautils::OnEventUpdate(PChar, string);
@@ -3126,6 +3169,7 @@ void SmallPacket0x060(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x061(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     PChar->pushPacket(new CCharUpdatePacket(PChar));
     PChar->pushPacket(new CCharHealthPacket(PChar));
     PChar->pushPacket(new CCharStatsPacket(PChar));
@@ -3147,6 +3191,7 @@ void SmallPacket0x061(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x063(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     return;
 }
 
@@ -3158,6 +3203,7 @@ void SmallPacket0x063(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x064(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint8 KeyTable = data.ref<uint8>(0x4A);
 
     if (KeyTable >= PChar->keys.tables.size())
@@ -3177,6 +3223,7 @@ void SmallPacket0x064(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x066(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     //PrintPacket(data);
 
     //uint32 charid = data.ref<uint32>(0x04);
@@ -3201,6 +3248,7 @@ void SmallPacket0x066(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x06E(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint32 charid = data.ref<uint32>(0x04);
     uint16 targid = data.ref<uint16>(0x08);
     // cannot invite yourself
@@ -3374,6 +3422,7 @@ void SmallPacket0x06E(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x06F(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     if (PChar->PParty)
         switch (data.ref<uint8>(0x04))
     {
@@ -3433,6 +3482,7 @@ void SmallPacket0x06F(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x070(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     if (PChar->PParty && PChar->PParty->GetLeader() == PChar)
         switch (data.ref<uint8>(0x04))
     {
@@ -3469,6 +3519,7 @@ void SmallPacket0x070(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x071(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     switch (data.ref<uint8>(0x0A))
     {
     case 0: // party - party leader may remove member of his own party
@@ -3620,6 +3671,7 @@ void SmallPacket0x071(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x074(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     CCharEntity* PInviter = zoneutils::GetCharFromWorld(PChar->InvitePending.id, PChar->InvitePending.targid);
 
     uint8 InviteAnswer = data.ref<uint8>(0x04);
@@ -3729,6 +3781,7 @@ void SmallPacket0x074(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x076(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     if (PChar->PParty)
     {
         PChar->PParty->ReloadPartyMembers(PChar);
@@ -3749,6 +3802,7 @@ void SmallPacket0x076(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x077(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     switch (data.ref<uint8>(0x14))
     {
     case 0: // party
@@ -3817,6 +3871,7 @@ void SmallPacket0x077(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x078(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     PChar->pushPacket(new CPartySearchPacket(PChar));
     return;
 }
@@ -3829,6 +3884,7 @@ void SmallPacket0x078(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x083(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint8  quantity = data.ref<uint8>(0x04);
     uint8  shopSlotID = data.ref<uint8>(0x0A);
 
@@ -3883,6 +3939,7 @@ void SmallPacket0x083(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x084(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     if (PChar->animation != ANIMATION_SYNTH)
     {
         uint32 quantity = data.ref<uint32>(0x04);
@@ -3912,6 +3969,7 @@ void SmallPacket0x084(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x085(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     // Retrieve item-to-sell from last slot of the shop's container
     uint32 quantity = PChar->Container->getQuantity(PChar->Container->getExSize());
     uint16 itemID = PChar->Container->getItemID(PChar->Container->getExSize());
@@ -3958,6 +4016,7 @@ void SmallPacket0x085(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x096(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     if (jailutils::InPrison(PChar))
     {
         // Prevent crafting in prison
@@ -4016,6 +4075,7 @@ void SmallPacket0x096(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0AA(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint16 itemID = data.ref<uint16>(0x04);
     uint8  quantity = data.ref<uint8>(0x07);
     uint8  shopSlotID = PChar->PGuildShop->SearchItem(itemID);
@@ -4063,6 +4123,7 @@ void SmallPacket0x0AA(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0A2(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint16 diceroll = tpzrand::GetRandomNumber(1000);
 
     PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CMessageStandardPacket(PChar, diceroll, MsgStd::DiceRoll));
@@ -4077,6 +4138,7 @@ void SmallPacket0x0A2(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0AB(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     if (PChar->PGuildShop != nullptr)
     {
         PChar->pushPacket(new CGuildMenuBuyPacket(PChar, PChar->PGuildShop));
@@ -4092,6 +4154,7 @@ void SmallPacket0x0AB(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0AC(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     if (PChar->animation != ANIMATION_SYNTH)
     {
         if (PChar->PGuildShop != nullptr)
@@ -4134,6 +4197,7 @@ void SmallPacket0x0AC(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0AD(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     if (PChar->PGuildShop != nullptr)
     {
         PChar->pushPacket(new CGuildMenuSellPacket(PChar, PChar->PGuildShop));
@@ -4149,6 +4213,7 @@ void SmallPacket0x0AD(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0B5(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     if (data.ref<uint8>(0x06) == '!' && !jailutils::InPrison(PChar) && CmdHandler.call(PChar, (const int8*)data[7]) == 0)
     {
         //this makes sure a command isn't sent to chat
@@ -4369,6 +4434,7 @@ void SmallPacket0x0B5(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0B6(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     if (jailutils::InPrison(PChar))
     {
         PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, 316));
@@ -4408,7 +4474,7 @@ void SmallPacket0x0B6(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0BE(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
-
+    TracyZoneScoped;
     uint8 operation = data.ref<uint8>(0x05);
 
     switch (data.ref<uint8>(0x04))
@@ -4475,6 +4541,7 @@ void SmallPacket0x0BE(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0C3(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint8 lsNum = data.ref<uint8>(0x05);
     CItemLinkshell* PItemLinkshell = (CItemLinkshell*)PChar->getEquip(SLOT_LINK1);
     if (lsNum == 2)
@@ -4504,6 +4571,7 @@ void SmallPacket0x0C3(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0C4(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint8 SlotID = data.ref<uint8>(0x06);
     uint8 LocationID = data.ref<uint8>(0x07);
     uint8 action = data.ref<uint8>(0x08);
@@ -4654,6 +4722,7 @@ void SmallPacket0x0C4(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0CB(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     if (data.ref<uint8>(0x04) == 1)
     {
         //open
@@ -4676,6 +4745,7 @@ void SmallPacket0x0CB(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0D2(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     PChar->ForAlliance([PChar](CBattleEntity* PPartyMember)
     {
         if (PPartyMember->getZone() == PChar->getZone() && ((CCharEntity*)PPartyMember)->m_moghouseID == PChar->m_moghouseID)
@@ -4696,6 +4766,7 @@ void SmallPacket0x0D2(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0D3(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     return;
 }
 
@@ -4707,6 +4778,7 @@ void SmallPacket0x0D3(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0DB(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     PChar->search.language = data.ref<uint8>(0x24);
     return;
 }
@@ -4719,6 +4791,7 @@ void SmallPacket0x0DB(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0DC(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     switch (data.ref<uint32>(0x04))
     {
     case NFLAG_INVITE:
@@ -4829,6 +4902,7 @@ void SmallPacket0x0DC(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0DD(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint32 id = data.ref<uint32>(0x04);
     uint16 targid = data.ref<uint16>(0x08);
     uint8 type = data.ref<uint8>(0x0C);
@@ -4981,6 +5055,7 @@ void SmallPacket0x0DD(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0DE(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     PChar->bazaar.message.clear();
     PChar->bazaar.message.insert(0, (const char*)data[4]);
 
@@ -4999,6 +5074,7 @@ void SmallPacket0x0DE(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0E0(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     PChar->search.message.clear();
     PChar->search.message.insert(0, (const char*)data[4]);
 
@@ -5058,6 +5134,7 @@ void SmallPacket0x0E0(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0E1(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint8 slot = data.ref<uint8>(0x07);
     if (slot == PChar->equip[SLOT_LINK1] && PChar->PLinkshell1)
     {
@@ -5078,6 +5155,7 @@ void SmallPacket0x0E1(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0E2(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     CItemLinkshell* PItemLinkshell = (CItemLinkshell*)PChar->getEquip(SLOT_LINK1);
 
     if (PChar->PLinkshell1 != nullptr && (PItemLinkshell != nullptr && PItemLinkshell->isType(ITEM_LINKSHELL)))
@@ -5129,6 +5207,7 @@ void SmallPacket0x0E2(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0E7(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     if (PChar->status != STATUS_NORMAL)
         return;
 
@@ -5177,6 +5256,7 @@ void SmallPacket0x0E7(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0E8(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     if (PChar->status != STATUS_NORMAL)
         return;
 
@@ -5224,6 +5304,7 @@ void SmallPacket0x0E8(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0EA(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     if (PChar->status != STATUS_NORMAL)
         return;
 
@@ -5243,6 +5324,7 @@ void SmallPacket0x0EA(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0EB(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     if (PChar->m_event.EventID == -1)
         return;
 
@@ -5258,6 +5340,7 @@ void SmallPacket0x0EB(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0F1(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint16 IconID = data.ref<uint16>(0x04);
 
     if (IconID)
@@ -5274,6 +5357,7 @@ void SmallPacket0x0F1(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0F2(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     PChar->loc.boundary = data.ref<uint16>(0x06);
 
     charutils::SaveCharPosition(PChar);
@@ -5288,6 +5372,8 @@ void SmallPacket0x0F2(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0F4(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
+    TracyZoneCString("Wide Scan");
     PChar->loc.zone->WideScan(PChar, charutils::getWideScanRange(PChar));
 }
 
@@ -5299,6 +5385,7 @@ void SmallPacket0x0F4(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0F5(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint16 TargID = data.ref<uint16>(0x04);
 
     CBaseEntity* target = PChar->GetEntity(TargID, TYPE_MOB | TYPE_NPC);
@@ -5329,6 +5416,7 @@ void SmallPacket0x0F5(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0F6(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     PChar->PWideScanTarget = nullptr;
     return;
 }
@@ -5341,6 +5429,7 @@ void SmallPacket0x0F6(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0FA(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint16 ItemID = data.ref<uint16>(0x04);
 
     if (ItemID == 0)
@@ -5449,6 +5538,7 @@ void SmallPacket0x0FA(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0FB(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint16 ItemID = data.ref<uint16>(0x04);
 
     if (ItemID == 0)
@@ -5530,6 +5620,7 @@ void SmallPacket0x0FB(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0FC(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint16 potItemID = data.ref<uint16>(0x04);
     uint16 itemID = data.ref<uint16>(0x06);
 
@@ -5601,6 +5692,7 @@ void SmallPacket0x0FC(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0FD(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint16 itemID = data.ref<uint16>(0x04);
     if (itemID == 0)
         return;
@@ -5657,6 +5749,7 @@ void SmallPacket0x0FD(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0FE(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint16 ItemID = data.ref<uint16>(0x04);
     if (ItemID == 0)
         return;
@@ -5721,6 +5814,7 @@ void SmallPacket0x0FE(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x0FF(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint16 itemID = data.ref<uint16>(0x04);
     if (itemID == 0)
         return;
@@ -5757,6 +5851,7 @@ void SmallPacket0x0FF(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x100(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     if (PChar->loc.zone->CanUseMisc(MISC_MOGMENU) || PChar->m_moghouseID)
     {
         uint8 mjob = data.ref<uint8>(0x04);
@@ -5860,6 +5955,7 @@ void SmallPacket0x100(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x102(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint8 job = data.ref<uint8>(0x08);
     if ((PChar->GetMJob() == JOB_BLU || PChar->GetSJob() == JOB_BLU) && job == JOB_BLU) {
         // This may be a request to add or remove set spells, so lets check.
@@ -5976,6 +6072,7 @@ void SmallPacket0x102(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x104(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     CCharEntity* PTarget = (CCharEntity*)PChar->GetEntity(PChar->BazaarID.targid, TYPE_PC);
 
     if (PTarget != nullptr && PTarget->id == PChar->BazaarID.id)
@@ -6001,6 +6098,7 @@ void SmallPacket0x104(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x105(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     TPZ_DEBUG_BREAK_IF(PChar->BazaarID.id != 0);
     TPZ_DEBUG_BREAK_IF(PChar->BazaarID.targid != 0);
 
@@ -6041,6 +6139,7 @@ void SmallPacket0x105(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x106(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint8 Quantity = data.ref<uint8>(0x08);
     uint8 SlotID = data.ref<uint8>(0x04);
 
@@ -6165,6 +6264,7 @@ void SmallPacket0x106(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x109(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     CItemContainer* PStorage = PChar->getStorage(LOC_INVENTORY);
 
     for (uint8 slotID = 1; slotID <= PStorage->GetSize(); ++slotID)
@@ -6189,6 +6289,7 @@ void SmallPacket0x109(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x10A(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     uint8  slotID = data.ref<uint8>(0x04);
     uint32 price = data.ref<uint32>(0x08);
 
@@ -6221,6 +6322,7 @@ void SmallPacket0x10A(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x10B(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     for (uint16 i = 0; i < PChar->BazaarCustomers.size(); ++i)
     {
         CCharEntity* PCustomer = (CCharEntity*)PChar->GetEntity(PChar->BazaarCustomers[i].targid, TYPE_PC);
@@ -6245,6 +6347,7 @@ void SmallPacket0x10B(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x10C(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     if (roeutils::RoeSystem.RoeEnabled)
     {
         roeutils::AddEminenceRecord(PChar, data.ref<uint32>(0x04));
@@ -6261,6 +6364,7 @@ void SmallPacket0x10C(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x10D(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     if (roeutils::RoeSystem.RoeEnabled)
     {
         roeutils::DelEminenceRecord(PChar, data.ref<uint32>(0x04));
@@ -6277,6 +6381,7 @@ void SmallPacket0x10D(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x10F(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     PChar->pushPacket(new CCurrencyPacket1(PChar));
     return;
 }
@@ -6289,6 +6394,7 @@ void SmallPacket0x10F(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x110(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     //PrintPacket(data);
     if (PChar->animation != ANIMATION_FISHING_START)
         return;
@@ -6313,6 +6419,7 @@ void SmallPacket0x110(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x111(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     charutils::SetStyleLock(PChar, data.ref<uint8>(0x04));
     PChar->pushPacket(new CCharAppearancePacket(PChar));
     return;
@@ -6326,6 +6433,7 @@ void SmallPacket0x111(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x112(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     // Send spark updates
     PChar->pushPacket(new CRoeSparkUpdatePacket(PChar));
 
@@ -6358,6 +6466,7 @@ void SmallPacket0x112(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 ************************************************************************/
 void SmallPacket0x113(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     PrintPacket(data);
 
     if (PChar->status != STATUS_NORMAL)
@@ -6397,6 +6506,7 @@ void SmallPacket0x113(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x114(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     PChar->pushPacket(new CMapMarkerPacket(PChar));
 }
 
@@ -6408,6 +6518,7 @@ void SmallPacket0x114(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x115(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     PChar->pushPacket(new CCurrencyPacket2(PChar));
     return;
 }
@@ -6421,6 +6532,7 @@ void SmallPacket0x115(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void SmallPacket0x117(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
+    TracyZoneScoped;
     PChar->pushPacket(new CRoeSparkUpdatePacket(PChar));
     return;
 }
@@ -6433,6 +6545,7 @@ void SmallPacket0x117(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 void PacketParserInitialize()
 {
+    TracyZoneScoped;
     for (uint16 i = 0; i < 512; ++i)
     {
         PacketSize[i] = 0;

--- a/src/map/recast_container.cpp
+++ b/src/map/recast_container.cpp
@@ -259,6 +259,7 @@ bool CRecastContainer::HasRecast(RECASTTYPE type, uint16 id, uint32 recast)
 
 void CRecastContainer::Check()
 {
+    TracyZoneScoped;
     for (auto type : {RECAST_MAGIC, RECAST_ABILITY})
     {
         RecastList_t* PRecastList = GetRecastList(type);

--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * roe.cpp
  *      Author: Kreidos | github.com/kreidos
  *
@@ -174,6 +174,7 @@ int32 ParseTimedSchedule(lua_State* L)
 
 bool event(ROE_EVENT eventID, CCharEntity* PChar, const RoeDatagramList& payload)
 {
+    TracyZoneScoped;
     if (!RoeSystem.RoeEnabled || !PChar || PChar->objtype != TYPE_PC)
     {
         return false;
@@ -481,6 +482,7 @@ void ClearDailyRecords(CCharEntity* PChar)
 
 void CycleTimedRecords()
 {
+    TracyZoneScoped;
     if (!RoeSystem.RoeEnabled)
     {
         return;
@@ -498,6 +500,7 @@ void CycleTimedRecords()
 
 void CycleDailyRecords()
 {
+    TracyZoneScoped;
     if (!RoeSystem.RoeEnabled)
     {
         return;

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -1489,6 +1489,7 @@ void CStatusEffectContainer::SaveStatusEffects(bool logout)
 void CStatusEffectContainer::CheckEffectsExpiry(time_point tick)
 {
     TPZ_DEBUG_BREAK_IF(m_POwner == nullptr);
+    TracyZoneScoped;
 
     for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
     {
@@ -1509,6 +1510,7 @@ void CStatusEffectContainer::CheckEffectsExpiry(time_point tick)
 
 void CStatusEffectContainer::HandleAura(CStatusEffect* PStatusEffect)
 {
+    TracyZoneScoped;
     CBattleEntity* PEntity = static_cast<CBattleEntity*>(m_POwner);
     AURATARGET auraTarget = static_cast<AURATARGET>(PStatusEffect->GetTier());
 
@@ -1566,6 +1568,7 @@ void CStatusEffectContainer::HandleAura(CStatusEffect* PStatusEffect)
 
 void CStatusEffectContainer::TickEffects(time_point tick)
 {
+    TracyZoneScoped;
     TPZ_DEBUG_BREAK_IF(m_POwner == nullptr);
 
     if (!m_POwner->isDead())
@@ -1596,6 +1599,7 @@ void CStatusEffectContainer::TickEffects(time_point tick)
 
 void CStatusEffectContainer::TickRegen(time_point tick)
 {
+    TracyZoneScoped;
     TPZ_DEBUG_BREAK_IF(m_POwner == nullptr);
 
     if (!m_POwner->isDead())

--- a/src/map/time_server.cpp
+++ b/src/map/time_server.cpp
@@ -34,13 +34,13 @@
 #include "entities/charentity.h"
 #include "latent_effect_container.h"
 
-
-int32 time_server(time_point tick,CTaskMgr::CTask* PTask)
+int32 time_server(time_point tick, CTaskMgr::CTask* PTask)
 {
+    TracyZoneScoped;
     TIMETYPE VanadielTOTD = CVanaTime::getInstance()->SyncTime();
     // uint8 WeekDay = (uint8)CVanaTime::getInstance()->getWeekday();
 
-    // weekly update for conquest (sunday at midnight)
+    // Weekly update for conquest (sunday at midnight)
     static time_point lastConquestTally = tick - 1h;
     static time_point lastConquestUpdate = tick - 1h;
     if (CVanaTime::getInstance()->getJstWeekDay() == 1  && CVanaTime::getInstance()->getJstHour() == 0 && CVanaTime::getInstance()->getJstMinute() == 0)
@@ -51,7 +51,7 @@ int32 time_server(time_point tick,CTaskMgr::CTask* PTask)
             lastConquestTally = tick;
         }
     }
-    // hourly conquest update
+    // Hourly conquest update
     else if (CVanaTime::getInstance()->getJstMinute() == 0)
     {
         if (tick > (lastConquestUpdate + 1h))
@@ -82,7 +82,7 @@ int32 time_server(time_point tick,CTaskMgr::CTask* PTask)
 
     }
 
-    //JST Midnight
+    // JST Midnight
     static time_point lastTickedJstMidnight = tick - 1h;
     if (CVanaTime::getInstance()->getJstHour() == 0 && CVanaTime::getInstance()->getJstMinute() == 0)
     {
@@ -94,7 +94,7 @@ int32 time_server(time_point tick,CTaskMgr::CTask* PTask)
         }
     }
 
-    //4-hour RoE Timed blocks
+    // 4-hour RoE Timed blocks
     static time_point lastTickedRoeBlock = tick - 1h;
     if (CVanaTime::getInstance()->getJstHour() % 4 == 0 && CVanaTime::getInstance()->getJstMinute() == 0)
     {
@@ -109,6 +109,7 @@ int32 time_server(time_point tick,CTaskMgr::CTask* PTask)
     static time_point lastVDailyUpdate = tick - 4800ms;
     if (CVanaTime::getInstance()->getHour() == 0 && CVanaTime::getInstance()->getMinute() == 0)
     {
+        TracyZoneScoped;
         if (tick > (lastVDailyUpdate + 4800ms))
         {
 			zoneutils::ForEachZone([](CZone* PZone)
@@ -129,6 +130,7 @@ int32 time_server(time_point tick,CTaskMgr::CTask* PTask)
 
     if (VanadielTOTD != TIME_NONE)
     {
+        TracyZoneScoped;
         zoneutils::TOTDChange(VanadielTOTD);
 
         if ((VanadielTOTD == TIME_DAY) || (VanadielTOTD == TIME_DUSK) || (VanadielTOTD == TIME_NIGHT))
@@ -147,6 +149,8 @@ int32 time_server(time_point tick,CTaskMgr::CTask* PTask)
     CTriggerHandler::getInstance()->triggerTimer();
     CTransportHandler::getInstance()->TransportTimer();
 
-	instanceutils::CheckInstance();
+    instanceutils::CheckInstance();
+
+    TracyFrameMark;
     return 0;
 }

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4068,6 +4068,7 @@ namespace battleutils
 
     void ClaimMob(CBattleEntity* PDefender, CBattleEntity* PAttacker, bool passing)
     {
+        TracyZoneScoped;
         if (PDefender->objtype == TYPE_MOB)
         {
             CBattleEntity* original = PAttacker;

--- a/src/map/utils/gardenutils.cpp
+++ b/src/map/utils/gardenutils.cpp
@@ -82,6 +82,7 @@ namespace gardenutils
 
     void UpdateGardening(CCharEntity* PChar, bool sendPacket)
     {
+        TracyZoneScoped;
         uint32 vanatime = CVanaTime::getInstance()->getVanaTime();
         for (auto containerID : { LOC_MOGSAFE, LOC_MOGSAFE2 })
         {

--- a/src/map/utils/guildutils.cpp
+++ b/src/map/utils/guildutils.cpp
@@ -144,6 +144,7 @@ void UpdateGuildsStock()
 
 void UpdateGuildPointsPattern()
 {
+    TracyZoneScoped;
     uint8 pattern = tpzrand::GetRandomNumber(8);
 
     const char* query = "SELECT value FROM server_variables WHERE name = '[GUILD]pattern_update';";

--- a/src/map/utils/itemutils.cpp
+++ b/src/map/utils/itemutils.cpp
@@ -535,6 +535,7 @@ namespace itemutils
 
     void Initialize()
     {
+        TracyZoneScoped;
         LoadItemList();
         LoadDropList();
         LoadLootList();

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -71,6 +71,7 @@ void TOTDChange(TIMETYPE TOTD)
 
 void InitializeWeather()
 {
+    TracyZoneScoped;
     for (auto PZone : g_PZoneList)
     {
         if (!PZone.second->IsWeatherStatic())
@@ -627,6 +628,7 @@ CZone* CreateZone(uint16 ZoneID)
 
 void LoadZoneList()
 {
+    TracyZoneScoped;
     g_PTrigger = new CNpcEntity();  // нужно в конструкторе CNpcEntity задавать модель по умолчанию
 
     std::vector<uint16> zones;

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -612,6 +612,7 @@ void CZone::DecreaseZoneCounter(CCharEntity* PChar)
 
 void CZone::IncreaseZoneCounter(CCharEntity* PChar)
 {
+    TracyZoneScoped;
     TPZ_DEBUG_BREAK_IF(PChar == nullptr);
     TPZ_DEBUG_BREAK_IF(PChar->loc.zone != nullptr);
     TPZ_DEBUG_BREAK_IF(PChar->PTreasurePool != nullptr);
@@ -844,6 +845,7 @@ void CZone::createZoneTimer()
 
 void CZone::CharZoneIn(CCharEntity* PChar)
 {
+    TracyZoneScoped;
     // ищем свободный targid для входящего в зону персонажа
 
     PChar->loc.zone = this;
@@ -898,6 +900,7 @@ void CZone::CharZoneIn(CCharEntity* PChar)
 
 void CZone::CharZoneOut(CCharEntity* PChar)
 {
+    TracyZoneScoped;
     for (regionList_t::const_iterator region = m_regionList.begin(); region != m_regionList.end(); ++region)
     {
         if ((*region)->GetRegionID() == PChar->m_InsideRegionID)
@@ -991,6 +994,7 @@ void CZone::CharZoneOut(CCharEntity* PChar)
 
 void CZone::CheckRegions(CCharEntity* PChar)
 {
+    TracyZoneScoped;
     uint32 RegionID = 0;
 
     for (regionList_t::const_iterator region = m_regionList.begin(); region != m_regionList.end(); ++region)

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -231,6 +231,7 @@ void CZoneEntities::TransportDepart(uint16 boundary, uint16 zone)
 
 void CZoneEntities::WeatherChange(WEATHER weather)
 {
+    TracyZoneScoped;
     auto element = zoneutils::GetWeatherElement(weather);
     for (EntityList_t::const_iterator it = m_mobList.begin(); it != m_mobList.end(); ++it)
     {
@@ -286,6 +287,7 @@ void CZoneEntities::DecreaseZoneCounter(CCharEntity* PChar)
 {
     TPZ_DEBUG_BREAK_IF(PChar == nullptr);
     TPZ_DEBUG_BREAK_IF(PChar->loc.zone != m_zone);
+    TracyZoneScoped;
 
     battleutils::RelinquishClaim(PChar);
 
@@ -388,6 +390,7 @@ void CZoneEntities::DespawnPC(CCharEntity* PChar)
 
 void CZoneEntities::SpawnMOBs(CCharEntity* PChar)
 {
+    TracyZoneScoped;
     for (EntityList_t::const_iterator it = m_mobList.begin(); it != m_mobList.end(); ++it)
     {
         CMobEntity* PCurrentMob = (CMobEntity*)it->second;
@@ -430,6 +433,7 @@ void CZoneEntities::SpawnMOBs(CCharEntity* PChar)
 
 void CZoneEntities::SpawnPETs(CCharEntity* PChar)
 {
+    TracyZoneScoped;
     for (EntityList_t::const_iterator it = m_petList.begin(); it != m_petList.end(); ++it)
     {
         CPetEntity* PCurrentPet = (CPetEntity*)it->second;
@@ -458,6 +462,7 @@ void CZoneEntities::SpawnPETs(CCharEntity* PChar)
 
 void CZoneEntities::SpawnNPCs(CCharEntity* PChar)
 {
+    TracyZoneScoped;
     if (!PChar->m_moghouseID)
     {
         for (EntityList_t::const_iterator it = m_npcList.begin(); it != m_npcList.end(); ++it)
@@ -491,6 +496,7 @@ void CZoneEntities::SpawnNPCs(CCharEntity* PChar)
 
 void CZoneEntities::SpawnPCs(CCharEntity* PChar)
 {
+    TracyZoneScoped;
     for (EntityList_t::const_iterator it = m_charList.begin(); it != m_charList.end(); ++it)
     {
         CCharEntity* PCurrentChar = (CCharEntity*)it->second;
@@ -761,6 +767,9 @@ CCharEntity* CZoneEntities::GetCharByID(uint32 id)
 
 void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message_type, CBasicPacket* packet)
 {
+    TracyZoneScoped;
+    TracyZoneHex16(packet->id());
+
     if (!packet) { return; }
     // Do not send packets that are updates of a hidden GM..
     if (packet->id() == 0x00D && PEntity != nullptr && PEntity->objtype == TYPE_PC && ((CCharEntity*)PEntity)->m_isGMHidden)
@@ -779,6 +788,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
         {
             case CHAR_INRANGE_SELF:
             {
+                TracyZoneCString("CHAR_INRANGE_SELF");
                 if (PEntity->objtype == TYPE_PC)
                 {
                     ((CCharEntity*)PEntity)->pushPacket(new CBasicPacket(*packet));
@@ -786,6 +796,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
             }
             case CHAR_INRANGE:
             {
+                TracyZoneCString("CHAR_INRANGE");
                 // todo: rewrite packet handlers and use enums instead of rawdog packet ids
                 // 30 yalms if action packet, 50 otherwise
                 const int checkDistanceSq = packet->id() == 0x0028 ? 900 : 2500;
@@ -855,6 +866,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
             break;
             case CHAR_INSHOUT:
             {
+                TracyZoneCString("CHAR_INSHOUT");
                 for (EntityList_t::const_iterator it = m_charList.begin(); it != m_charList.end(); ++it)
                 {
                     CCharEntity* PCurrentChar = (CCharEntity*)it->second;
@@ -871,6 +883,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
             break;
             case CHAR_INZONE:
             {
+                TracyZoneCString("CHAR_INZONE");
                 for (EntityList_t::const_iterator it = m_charList.begin(); it != m_charList.end(); ++it)
                 {
                     CCharEntity* PCurrentChar = (CCharEntity*)it->second;
@@ -892,6 +905,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
 
 void CZoneEntities::WideScan(CCharEntity* PChar, uint16 radius)
 {
+    TracyZoneScoped;
     PChar->pushPacket(new CWideScanPacket(WIDESCAN_BEGIN));
     for (EntityList_t::const_iterator it = m_npcList.begin(); it != m_npcList.end(); ++it)
     {
@@ -914,6 +928,9 @@ void CZoneEntities::WideScan(CCharEntity* PChar, uint16 radius)
 
 void CZoneEntities::ZoneServer(time_point tick, bool check_regions)
 {
+    TracyZoneScoped;
+    TracyZoneIString(m_zone->GetName());
+
     for (EntityList_t::const_iterator it = m_mobList.begin(); it != m_mobList.end(); ++it)
     {
         CMobEntity* PMob = (CMobEntity*)it->second;


### PR DESCRIPTION
This is the power of CMake!

Build with `TRACY_ENABLE` to turn on the profiling, otherwise, everything will get stripped away and has no effect on the build.

This PR adds support for the Tracy client in topaz_game. Once the game is built and running, you can connect the server to it to see the beautiful stats in realtime:

![image](https://user-images.githubusercontent.com/1389729/97106613-832f0100-16cb-11eb-8452-267e406bceb9.png)

We are hardcoded to v0.7.3, different versions of client and server are not compatible!

https://github.com/wolfpld/tracy/releases/tag/v0.7.3

**GUIDE**

https://github.com/project-topaz/topaz/wiki/Performance-Profiling-with-Tracy

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

