### PR TITLE
Couple reported RoE fixes

### DIFF
--- a/scripts/globals/roe_records.lua
+++ b/scripts/globals/roe_records.lua
@@ -2156,7 +2156,7 @@ tpz.roe.records =
         goal = 20,
         reqs = { mobXP = true, mobSystem = set{tpz.eco.AQUAN} },
         flags = set{"timed", "repeat"},
-        reward = { sparks = 300, exp = 1500, unity = 300, item = { 8711 } },
+        reward = { sparks = 300, xp = 1500, unity = 300, item = { 8711 } },
     },
 
     [4009] = {   -- Vanquish Beasts
@@ -2164,7 +2164,7 @@ tpz.roe.records =
         goal = 20,
         reqs = { mobXP = true, mobSystem = set{tpz.eco.BEAST} },
         flags = set{"timed", "repeat"},
-        reward = { sparks = 300, exp = 1500, unity = 300, item = { 8711 } },
+        reward = { sparks = 300, xp = 1500, unity = 300, item = { 8711 } },
     },
 
     [4010] = {   -- Vanquish Plantoids
@@ -2172,7 +2172,7 @@ tpz.roe.records =
         goal = 20,
         reqs = { mobXP = true, mobSystem = set{tpz.eco.PLANTOID} },
         flags = set{"timed", "repeat"},
-        reward = { sparks = 300, exp = 1500, unity = 300, item = { 8711 } },
+        reward = { sparks = 300, xp = 1500, unity = 300, item = { 8711 } },
     },
 
     [4011] = {   -- Vanquish Lizards
@@ -2180,7 +2180,7 @@ tpz.roe.records =
         goal = 20,
         reqs = { mobXP = true, mobSystem = set{tpz.eco.LIZARD} },
         flags = set{"timed", "repeat"},
-        reward = { sparks = 300, exp = 1500, unity = 300, item = { 8711 } },
+        reward = { sparks = 300, xp = 1500, unity = 300, item = { 8711 } },
     },
 
     [4012] = {   -- Vanquish Vermin
@@ -2188,7 +2188,7 @@ tpz.roe.records =
         goal = 20,
         reqs = { mobXP = true, mobSystem = set{tpz.eco.VERMIN} },
         flags = set{"timed", "repeat"},
-        reward = { sparks = 300, exp = 1500, unity = 300, item = { 8711 } },
+        reward = { sparks = 300, xp = 1500, unity = 300, item = { 8711 } },
     },
 
     [4013] = { -- Gain Experience
@@ -2211,7 +2211,7 @@ tpz.roe.records =
         goal = 3,
         reqs = { itemID = set{1126, 1127, 2955, 2956, 2957} },
         flags = set{"timed", "repeat"},
-        reward = { sparks = 300, exp = 1500, unity = 300, item = { 8711 } },
+        reward = { sparks = 300, xp = 1500, unity = 300, item = { 8711 } },
     },
 
     [4015] = {   -- Vanquish Birds (TODO: No abyssea zone kills for vanquishes when exists)
@@ -2219,7 +2219,7 @@ tpz.roe.records =
         goal = 20,
         reqs = { mobXP = true, mobSystem = set{tpz.eco.BIRD} },
         flags = set{"timed", "repeat"},
-        reward = { sparks = 300, exp = 1500, unity = 300, item = { 8711 } },
+        reward = { sparks = 300, xp = 1500, unity = 300, item = { 8711 } },
     },
 
     [4016] = {   -- Vanquish Amorphs
@@ -2227,7 +2227,7 @@ tpz.roe.records =
         goal = 20,
         reqs = { mobXP = true, mobSystem = set{tpz.eco.AMORPH} },
         flags = set{"timed", "repeat"},
-        reward = { sparks = 300, exp = 1500, unity = 300, item = { 8711 } },
+        reward = { sparks = 300, xp = 1500, unity = 300, item = { 8711 } },
     },
 
     [4017] = {   -- Vanquish Undead
@@ -2235,7 +2235,7 @@ tpz.roe.records =
         goal = 20,
         reqs = { mobXP = true, mobSystem = set{tpz.eco.UNDEAD} },
         flags = set{"timed", "repeat"},
-        reward = { sparks = 300, exp = 1500, unity = 300, item = { 8711 } },
+        reward = { sparks = 300, xp = 1500, unity = 300, item = { 8711 } },
     },
 
     [4018] = {   -- Vanquish Arcana
@@ -2243,13 +2243,13 @@ tpz.roe.records =
         goal = 20,
         reqs = { mobXP = true, mobSystem = set{tpz.eco.ARCANA} },
         flags = set{"timed", "repeat"},
-        reward = { sparks = 300, exp = 1500, unity = 300, item = { 8711 } },
+        reward = { sparks = 300, xp = 1500, unity = 300, item = { 8711 } },
     },
 
     [4019] = {   -- Crack Treasure Caskets (Triggered from caskets.lua)
         goal = 10,
         flags = set{"timed", "repeat"},
-        reward = { sparks = 300, exp = 1500, unity = 300, item = { 8711 } },
+        reward = { sparks = 300, xp = 1500, unity = 300, item = { 8711 } },
     },
 
     -- [4020] = {  -- Physical Damage Kills

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3769,10 +3769,6 @@ namespace charutils
         }
 
         PChar->PAI->EventHandler.triggerListener("EXPERIENCE_POINTS", PChar, exp);
-        if (PMob != PChar) // Only mob kills count for gain EXP records
-        {
-            roeutils::event(ROE_EXPGAIN, PChar, RoeDatagram("exp", exp));
-        }
 
         // Player levels up
         if ((currentExp + exp) >= GetExpNEXTLevel(PChar->jobs.job[PChar->GetMJob()]) && !onLimitMode)
@@ -3856,6 +3852,11 @@ namespace charutils
 
         if (onLimitMode)
             PChar->pushPacket(new CMenuMeritPacket(PChar));
+
+        if (PMob != PChar) // Only mob kills count for gain EXP records
+        {
+            roeutils::event(ROE_EXPGAIN, PChar, RoeDatagram("exp", exp));
+        }
     }
 
     /************************************************************************


### PR DESCRIPTION
-Fixes case where an unintended double level up could occur with one record under specific circumstances.
-Fixes certain timed records not granting EXP.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

