### PR TITLE
Corrects typo in PUP Scripts

### DIFF
--- a/scripts/globals/abilities/maintenance.lua
+++ b/scripts/globals/abilities/maintenance.lua
@@ -45,7 +45,7 @@ function onUseAbility(player, target, ability)
         if pet:delStatusEffect(tpz.effect.SILENCE) then return true end
         if pet:delStatusEffect(tpz.effect.BANE) then return true end
         if pet:delStatusEffect(tpz.effect.CURSE_II) then return true end
-        if pet:delStatusEffect(tpz.effect.CURSE) then return true end
+        if pet:delStatusEffect(tpz.effect.CURSE_I) then return true end
         if pet:delStatusEffect(tpz.effect.PARALYSIS) then return true end
         if pet:delStatusEffect(tpz.effect.PLAGUE) then return true end
         if pet:delStatusEffect(tpz.effect.POISON) then return true end

--- a/scripts/globals/abilities/pets/attachments/eraser.lua
+++ b/scripts/globals/abilities/pets/attachments/eraser.lua
@@ -9,7 +9,7 @@ local removable = {
     tpz.effect.SILENCE,
     tpz.effect.BANE,
     tpz.effect.CURSE_II,
-    tpz.effect.CURSE,
+    tpz.effect.CURSE_I,
     tpz.effect.PARALYSIS,
     tpz.effect.PLAGUE,
     tpz.effect.POISON,

--- a/scripts/globals/abilities/pets/eraser.lua
+++ b/scripts/globals/abilities/pets/eraser.lua
@@ -21,7 +21,7 @@ function onPetAbility(target, automaton, skill, master, action)
         if target:delStatusEffect(tpz.effect.SILENCE) then return true end
         if target:delStatusEffect(tpz.effect.BANE) then return true end
         if target:delStatusEffect(tpz.effect.CURSE_II) then return true end
-        if target:delStatusEffect(tpz.effect.CURSE) then return true end
+        if target:delStatusEffect(tpz.effect.CURSE_I) then return true end
         if target:delStatusEffect(tpz.effect.PARALYSIS) then return true end
         if target:delStatusEffect(tpz.effect.PLAGUE) then return true end
         if target:delStatusEffect(tpz.effect.POISON) then return true end

--- a/scripts/globals/abilities/repair.lua
+++ b/scripts/globals/abilities/repair.lua
@@ -69,7 +69,7 @@ function onUseAbility(player, target, ability)
         if pet:delStatusEffect(tpz.effect.SILENCE) then return true end
         if pet:delStatusEffect(tpz.effect.BANE) then return true end
         if pet:delStatusEffect(tpz.effect.CURSE_II) then return true end
-        if pet:delStatusEffect(tpz.effect.CURSE) then return true end
+        if pet:delStatusEffect(tpz.effect.CURSE_I) then return true end
         if pet:delStatusEffect(tpz.effect.PARALYSIS) then return true end
         if pet:delStatusEffect(tpz.effect.PLAGUE) then return true end
         if pet:delStatusEffect(tpz.effect.POISON) then return true end


### PR DESCRIPTION
Corrects `CURSE` to `CURSE_I`

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

