### PR TITLE
Amended keepalive timeout value from 8 hours to 2 hours

### DIFF
--- a/src/common/sql.cpp
+++ b/src/common/sql.cpp
@@ -201,7 +201,7 @@ int32 Sql_Keepalive(Sql_t* self)
 	uint32 timeout, ping_interval;
 
 	// set a default value first
-	timeout = 28800; // 8 hours
+	timeout = 7200; // 2 hours
 
 	// request the timeout value from the mysql server
 	Sql_GetTimeout(self, &timeout);


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

This PR will go unnoticed by all except those that use a separate machine for the DB and Server Client. 
From my testing (MariaDB on AWS, Server Client on local machine at home) I've found that DB's hosted separately will sever TCP/IP read and writes if they are silent for more than 2 hours. 

This change should mean Server Client and DB will work "Out of the box" when hosted on separate machines. 
