### PR TITLE
Add flag to disable timed RoE records + minor fix

### DIFF
--- a/scripts/globals/roe_records.lua
+++ b/scripts/globals/roe_records.lua
@@ -17,7 +17,9 @@ local timedSchedule = {
     {     0,  4009,  4015,  4011,  4017,  4014}, -- Saturday
 }
 -- Load timetable for timed records
-RoeParseTimed(timedSchedule)
+if ENABLE_ROE_TIMED and ENABLE_ROE_TIMED > 0 then
+    RoeParseTimed(timedSchedule)
+end
 
 local defaults = {
     check = checks.masterCheck, -- Check function should return true/false

--- a/scripts/globals/settings.lua
+++ b/scripts/globals/settings.lua
@@ -37,6 +37,7 @@ GOV_REWARD_ALLIANCE = 1 -- Allow Grounds of Valor rewards while being a member o
 
 -- Records of Eminence
 ENABLE_ROE = 1
+ENABLE_ROE_TIMED = 1 -- Enable 4-hour timed records
 
 -- TREASURE CASKETS
 -- Retail droprate = 0.1 (10%) with no other effects active

--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -420,7 +420,7 @@ void onCharLoad(CCharEntity* PChar)
 
             if (lastOnline < lastJstTimedBlock || PChar->m_eminenceLog.active[30] != GetActiveTimedRecord())
             {
-                PChar->m_eminenceCache.notifyTimedRecord = true;
+                PChar->m_eminenceCache.notifyTimedRecord = static_cast<bool>(GetActiveTimedRecord());
                 AddActiveTimedRecord(PChar);
             }
         }

--- a/src/map/roe.h
+++ b/src/map/roe.h
@@ -55,7 +55,7 @@ typedef std::array<uint16, 6> RecordTimetable_D;
 typedef std::array<RecordTimetable_D, 7> RecordTimetable_W;
 struct RoeSystemData
 {
-    bool RoeEnabled;
+    bool RoeEnabled = true;
     RecordTimetable_W TimedRecordTable;
     std::bitset<4096> ImplementedRecords;
     std::bitset<4096> RepeatableRecords;
@@ -63,6 +63,11 @@ struct RoeSystemData
     std::vector<uint16> DailyRecordIDs;
     std::bitset<4096> TimedRecords;
     std::array<uint32, 4096> NotifyThresholds;
+
+    RoeSystemData()
+    {
+        TimedRecordTable.fill(RecordTimetable_D{});
+    }
 };
 
 struct RoeCheckHandler


### PR DESCRIPTION
This patch is good to go into release and should be the last of the straight-to-release fixes. Future PRs will have more recordsets and features which may warrant their own branch once again. :)

Some have mentioned they don't mind RoE, but don't want or don't like the CHALLENGE SPLASH SPAM. These people are crazy, but regardless here's a settings flag to ~~turn just those off~~ turn all timed records off.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

