### PR TITLE
Raycasting Fix (and small pathing tweaks)

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -872,7 +872,7 @@ void CMobController::FollowRoamPath()
         PMob->PAI->PathFind->FollowPath();
 
         CBattleEntity* PPet = PMob->PPet;
-        if (PPet != nullptr && !PPet->PAI->IsEngaged())
+        if (PPet != nullptr && PPet->PAI->IsSpawned() && !PPet->PAI->IsEngaged())
         {
             // pet should follow me if roaming
             position_t targetPoint = nearPosition(PMob->loc.p, 2.1f, (float)M_PI);

--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -347,7 +347,7 @@ bool CPathFind::FindPath(const position_t& start, const position_t& end)
 
     if (m_points.size() <= 0)
     {
-        ShowNavError("CPathFind::FindPath Entity (%d) could not find path\n", m_PTarget->id);
+        ShowNavError("CPathFind::FindPath Entity (%s - %d) could not find path\n", m_PTarget->GetName(), m_PTarget->id);
         return false;
     }
 

--- a/src/map/navmesh.cpp
+++ b/src/map/navmesh.cpp
@@ -386,8 +386,12 @@ bool CNavMesh::validPosition(const position_t& position)
 bool CNavMesh::raycast(const position_t& start, const position_t& end)
 {
     TracyZoneScoped;
+
     if (start.x == end.x && start.y == end.y && start.z == end.z)
+    {
         return true;
+    }
+
     dtStatus status;
 
     float spos[3];
@@ -401,26 +405,41 @@ bool CNavMesh::raycast(const position_t& start, const position_t& end)
     polyPickExt[1] = 60;
     polyPickExt[2] = 30;
 
-    float snearest[3];
-
     dtQueryFilter filter;
     filter.setIncludeFlags(0xffff);
     filter.setExcludeFlags(0);
 
     dtPolyRef startRef;
-
+    float snearest[3];
     status = m_navMeshQuery.findNearestPoly(spos, polyPickExt, &filter, &startRef, snearest);
 
     if (dtStatusFailed(status))
     {
-        ShowNavError("CNavMesh::raycastPoint start point invalid (%f, %f, %f) (%u)\n", spos[0], spos[1], spos[2], m_zoneID);
+        ShowNavError("CNavMesh::raycast start point invalid (%f, %f, %f) (%u)\n", spos[0], spos[1], spos[2], m_zoneID);
         outputError(status);
         return true;
     }
 
     if (!m_navMesh->isValidPolyRef(startRef))
     {
-        ShowNavError("CNavMesh::raycastPoint startRef is invalid (%f, %f, %f) (%u)\n", start.x, start.y, start.z, m_zoneID);
+        ShowNavError("CNavMesh::raycast startRef is invalid (%f, %f, %f) (%u)\n", start.x, start.y, start.z, m_zoneID);
+        return true;
+    }
+
+    dtPolyRef endRef;
+    float enearest[3];
+    status = m_navMeshQuery.findNearestPoly(epos, polyPickExt, &filter, &endRef, enearest);
+
+    if (dtStatusFailed(status))
+    {
+        ShowNavError("CNavMesh::raycast end point invalid (%f, %f, %f) (%u)\n", epos[0], epos[1], epos[2], m_zoneID);
+        outputError(status);
+        return true;
+    }
+
+    if (!m_navMesh->isValidPolyRef(startRef))
+    {
+        ShowNavError("CNavMesh::raycast endRef is invalid (%f, %f, %f) (%u)\n", end.x, end.y, end.z, m_zoneID);
         return true;
     }
 
@@ -428,15 +447,52 @@ bool CNavMesh::raycast(const position_t& start, const position_t& end)
 
     if (dtStatusFailed(status))
     {
-        ShowNavError("CNavMesh::raycastPoint raycast failed (%f, %f, %f)->(%f, %f, %f) (%u)\n", spos[0], spos[1], spos[2], epos[0], epos[1], epos[2], m_zoneID);
+        ShowNavError("CNavMesh::raycast raycast failed (%f, %f, %f)->(%f, %f, %f) (%u)\n", spos[0], spos[1], spos[2], epos[0], epos[1], epos[2], m_zoneID);
         outputError(status);
         return true;
     }
 
-    // no wall was hit
+    // no wall was hit (success or catastrophic failure)
     if (m_hit.t == FLT_MAX)
     {
         return true;
+    }
+
+    // very close to edge of navmesh, look past the mesh for target
+    float distanceToWall = 0.0f;
+    float hitPos[3];
+    float hitNormal[3];
+    status = m_navMeshQuery.findDistanceToWall(endRef, enearest, 50.0f, &filter, &distanceToWall, hitPos, hitNormal);
+    if (dtStatusFailed(status))
+    {
+        ShowNavError("CNavMesh::raycast findDistanceToWall failed (%f, %f, %f) (%u)\n", epos[0], epos[1], epos[2], m_zoneID);
+        outputError(status);
+        return true;
+    }
+
+    if (distanceToWall < 2.5f)
+    {
+        float closest[3];
+        status = m_navMeshQuery.closestPointOnPolyBoundary(startRef, epos, closest);
+        if (dtStatusFailed(status))
+        {
+            ShowNavError("CNavMesh::raycast closestPointOnPolyBoundary failed (%u)\n", m_zoneID);
+            outputError(status);
+            return false;
+        }
+
+        status = m_navMeshQuery.raycast(startRef, spos, closest, &filter, 0, &m_hit);
+
+        if (dtStatusFailed(status))
+        {
+            ShowNavError("CNavMesh::raycast lookOffNavmesh raycast failed (%f, %f, %f)->(%f, %f, %f) (%u)\n", spos[0], spos[1], spos[2], closest[0], closest[1],
+                         closest[2], m_zoneID);
+            outputError(status);
+            return true;
+        }
+
+        // success
+        return m_hit.t == FLT_MAX;
     }
 
     return false;


### PR DESCRIPTION
**NOTE:** There is a patch that must be applied to this PR if you're taking it in isolation, otherwise you get strange behaviour (see comments below).
**PATCH:** https://github.com/project-topaz/topaz/commit/26263447def756aead19281e19cd5f3757cd467b

Stop players being able to hide off-navmesh close to walls.

This is a further cleaned up and tested version of the code changes in here: https://github.com/project-topaz/topaz/pull/1423
I'm going to dedicate that PR solely to actual navmesh changes.

EDIT: Thanks again to @xenonsmurf for digging into recast/detour and figuring out all of this stuff, and for teaching the community how to deal with navigation and navmeshes 🙏 

EDIT2: Added exploit tag, while this isn't directly harmful to a server, it does allow abusers to avoid dangers and 'cheese' certain zones. No bueno.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

