### PR TITLE
Assassins Charge Fixes

### DIFF
--- a/scripts/globals/abilities/assassins_charge.lua
+++ b/scripts/globals/abilities/assassins_charge.lua
@@ -14,5 +14,10 @@ end
 
 function onUseAbility(player, target, ability)
     local merits = player:getMerit(tpz.merit.ASSASSINS_CHARGE)
-    player:addStatusEffect(tpz.effect.ASSASSINS_CHARGE, merits - 5, 0, 60, player:getMod(tpz.mod.AUGMENTS_ASSASSINS_CHARGE), merits / 5)
+    local crit = 0
+    if player:getMod(tpz.mod.AUGMENTS_ASSASSINS_CHARGE) > 0 then
+        crit = merits / 5
+    end
+
+    player:addStatusEffect(tpz.effect.ASSASSINS_CHARGE, merits - 5, 0, 60, 0, crit)
 end

--- a/scripts/globals/effects/assassins_charge.lua
+++ b/scripts/globals/effects/assassins_charge.lua
@@ -9,7 +9,7 @@ require("scripts/globals/status")
 function onEffectGain(target, effect)
     target:addMod(tpz.mod.QUAD_ATTACK, effect:getPower())
     target:addMod(tpz.mod.TRIPLE_ATTACK, 100)
-    if (effect:getSubType() > 0) then
+    if (effect:getSubPower() > 0) then
         target:addMod(tpz.mod.CRITHITRATE, effect:getSubPower())
     end
 end

--- a/sql/augments.sql
+++ b/sql/augments.sql
@@ -1649,7 +1649,7 @@ INSERT INTO `augments` VALUES (1357, 0, 0, 0, 0, 0); -- Enhances "Paralyze II" e
 INSERT INTO `augments` VALUES (1358, 0, 0, 0, 0, 0); -- Enhances "Aura Steal" effect
 INSERT INTO `augments` VALUES (1359, 0, 0, 0, 0, 0); -- Enhances "Ambush" effect
 INSERT INTO `augments` VALUES (1360, 0, 0, 0, 0, 0); -- Enhances "Feint" effect
-INSERT INTO `augments` VALUES (1361, 0, 0, 0, 0, 0); -- Enh. "Assassins Charge" effect
+INSERT INTO `augments` VALUES (1361, 0, 886, 1, 0, 0); -- Enh. "Assassins Charge" effect
 INSERT INTO `augments` VALUES (1362, 0, 0, 0, 0, 0); -- 1362 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
 INSERT INTO `augments` VALUES (1363, 0, 0, 0, 0, 0); -- 1363 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
 INSERT INTO `augments` VALUES (1364, 0, 0, 0, 0, 0); -- Enhances "Iron Will" effect


### PR DESCRIPTION
Typo correction in effect script, update augment table, and tweaked ability script.

Will now properly apply both Quad Rate AND Crit Rate (if augmented gear is equipped).

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

