### PR TITLE
Resolve BLU spell setting exploits

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -5931,10 +5931,17 @@ void SmallPacket0x102(map_session_data_t* session, CCharEntity* PChar, CBasicPac
                     CBlueSpell* spell = (CBlueSpell*)spell::GetSpell(static_cast<SpellID>(spellInQuestion + 0x200)); // the spells in this packet are offsetted by 0x200 from their spell IDs.
 
                     if (spell != nullptr) {
-                        blueutils::SetBlueSpell(PChar, spell, spellIndex, false);
+                        if (PChar->m_SetBlueSpells[spellIndex] == 0x00)
+                        {
+                            ShowExploit(CL_RED "SmallPacket0x102: Player %s trying to unset BLU spell they don't have set! \n" CL_RESET, PChar->GetName());
+                        }
+                        else
+                        {
+                            blueutils::SetBlueSpell(PChar, spell, spellIndex, false);
+                        }
                     }
                     else {
-                        ShowDebug("Cannot resolve spell id \n");
+                        ShowDebug("SmallPacket0x102: Cannot resolve spell id %u \n", spellInQuestion);
                     }
                 }
             }
@@ -5968,7 +5975,7 @@ void SmallPacket0x102(map_session_data_t* session, CCharEntity* PChar, CBasicPac
                     PChar->UpdateHealth();
                 }
                 else {
-                    ShowDebug("Cannot resolve spell id \n");
+                    ShowDebug("SmallPacket0x102: Cannot resolve spell id %u \n", spellInQuestion);
                 }
             }
             else {

--- a/src/map/utils/blueutils.cpp
+++ b/src/map/utils/blueutils.cpp
@@ -50,24 +50,25 @@ void SetBlueSpell(CCharEntity* PChar, CBlueSpell* PSpell, uint8 slotIndex, bool 
 	if (slotIndex < 20) {
 		if (dynamic_cast<CBlueSpell*>(PSpell))
         {
-            if (addingSpell)
+            // Blue spells in SetBlueSpells must be 0x200 ofsetted so it's 1 byte per spell.
+            if (PChar->m_SetBlueSpells[slotIndex] != 0)
             {
-                if (!IsSpellSet(PChar, PSpell) && HasEnoughSetPoints(PChar, PSpell, slotIndex))
+                CBlueSpell* POldSpell = (CBlueSpell*)spell::GetSpell(static_cast<SpellID>(PChar->m_SetBlueSpells[slotIndex] + 0x200));
+                PChar->delModifiers(&POldSpell->modList);
+                PChar->m_SetBlueSpells[slotIndex] = 0x00;
+            }
+            if (addingSpell && !IsSpellSet(PChar, PSpell) && HasEnoughSetPoints(PChar, PSpell, slotIndex))
+            {
+                uint16 spellID = static_cast<uint16>(PSpell->getID());
+                if (charutils::hasSpell(PChar, spellID))
                 {
-				    // Blue spells in SetBlueSpells must be 0x200 ofsetted so it's 1 byte per spell.
-                    if (PChar->m_SetBlueSpells[slotIndex] != 0)
-                    {
-                        CBlueSpell* POldSpell = (CBlueSpell*)spell::GetSpell(static_cast<SpellID>(PChar->m_SetBlueSpells[slotIndex] + 0x200));
-                        PChar->delModifiers(&POldSpell->modList);
-                    }
-				    PChar->m_SetBlueSpells[slotIndex] = static_cast<uint16>(PSpell->getID()) - 0x200;
-				    PChar->addModifiers(&PSpell->modList);
+                    PChar->m_SetBlueSpells[slotIndex] = spellID - 0x200;
+                    PChar->addModifiers(&PSpell->modList);
                 }
-			}
-			else
-            {
-				PChar->m_SetBlueSpells[slotIndex] = 0x00;
-				PChar->delModifiers(&PSpell->modList);
+                else
+                {
+                    ShowExploit(CL_RED "SetBlueSpell: Player %s trying to set spell ID %u they don't have! \n" CL_RESET, PChar->GetName(), spellID);
+                }
 			}
             SaveSetSpells(PChar);
 		}


### PR DESCRIPTION
Most public servers should already have this fix. If you're a public server operator who didn't know this PR was coming, get in touch with either zach2good or myself on Discord.

As this is an exploit fix, I'll wait a while before going into further details.

If you're a server operator who doesn't have this patched already, don't sleep on this. I'll eventually demonstrate how a BLU player on any DSP derived server can do this:
![cheat](https://user-images.githubusercontent.com/13112942/97792360-00c7a500-1bd5-11eb-8493-c8382fbc0ac6.png)

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

