### PR TITLE
Fix broken mob animations if interrupted during death

### DIFF
--- a/src/map/packets/action.cpp
+++ b/src/map/packets/action.cpp
@@ -100,6 +100,8 @@ CActionPacket::CActionPacket(action_t& action)
         ref<uint8>(0x0C) = 0x1C;
         ref<uint8>(0x0D) = 0x5D;
         ref<uint8>(0x0E) = 0x19;
+
+        ActionType = ACTION_WEAPONSKILL_START;
     }
     break;
     case ACTION_MOBABILITY_FINISH:


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

If `ActionType` isn't set, there is an area of empty space left behind. The bitpacking at the end of this packet sees that empty space and thinks "Ohh, free real estate" and puts information in there - resulting in a shift of the rest of the packet - which leads to broken animations.

Thanks to Setzor for the explanation!