### PR TITLE
CoP 5-1 Player obtains Mysterious Amulet and Light of Vahzl

### DIFF
--- a/scripts/zones/AlTaieu/Zone.lua
+++ b/scripts/zones/AlTaieu/Zone.lua
@@ -45,6 +45,7 @@ function onEventFinish(player, csid, option)
             tpz.ki.LIGHT_OF_MEA
         }
         player:setCharVar("PromathiaStatus", 1)
+        player:delKeyItem(tpz.ki.MYSTERIOUS_AMULET_DRAINED)
         player:addKeyItem(tpz.ki.LIGHT_OF_ALTAIEU)
         player:messageSpecial(ID.text.AMULET_SHATTERED, tpz.ki.MYSTERIOUS_AMULET)
         player:messageSpecial(ID.text.LIGHT_STOLEN, copCraigLights[math.random(#copCraigLights)])

--- a/scripts/zones/Beaucedine_Glacier/Zone.lua
+++ b/scripts/zones/Beaucedine_Glacier/Zone.lua
@@ -53,6 +53,8 @@ function onEventUpdate(player, csid, option)
         quests.rainbow.onEventUpdate(player)
     elseif csid == 116 then
         player:updateEvent(0, 0, 0, 0, 0, 4)
+    elseif csid == 206 then
+        player:updateEvent(0, tpz.ki.MYSTERIOUS_AMULET)
     end
 end
 

--- a/scripts/zones/Promyvion-Vahzl/IDs.lua
+++ b/scripts/zones/Promyvion-Vahzl/IDs.lua
@@ -18,6 +18,8 @@ zones[tpz.zone.PROMYVION_VAHZL] =
         OVERFLOWING_MEMORIES    = 7211, -- It appears to be a barrier woven from the energy of overflowing memories...
         ON_NM_SPAWN             = 7215, -- You sense a dark, empty presence...
         EERIE_GREEN_GLOW        = 7217, -- The sphere is emitting an eerie green glow.
+        AMULET_RETURNED         = 7260, -- The mysterious amulet has been returned to you.
+        LIGHT_OF_VAHZL          = 7261, -- You cannot remember when exactly, but you have obtained the light of Vahzl!
         POPPED_NM_OFFSET        = 7297, -- Remnants of a cerebrator lie scattered about the area.
     },
     mob =

--- a/scripts/zones/Promyvion-Vahzl/Zone.lua
+++ b/scripts/zones/Promyvion-Vahzl/Zone.lua
@@ -47,6 +47,10 @@ end
 function onEventFinish(player, csid, option)
     if csid == 50 then
         player:setCharVar("PromathiaStatus", 1)
+        player:addKeyItem(tpz.ki.MYSTERIOUS_AMULET_DRAINED)
+        player:addKeyItem(tpz.ki.LIGHT_OF_VAHZL)
+        player:messageSpecial(ID.text.AMULET_RETURNED, tpz.ki.MYSTERIOUS_AMULET)
+        player:messageSpecial(ID.text.LIGHT_OF_VAHZL, tpz.ki.LIGHT_OF_VAHZL)
     elseif csid == 45 and option == 1 then
         player:setPos(-379.947, 48.045, 334.059, 192, 9) -- To Pso'Xja {R}
     end

--- a/scripts/zones/PsoXja/npcs/_i99.lua
+++ b/scripts/zones/PsoXja/npcs/_i99.lua
@@ -36,8 +36,6 @@ function onEventFinish(player, csid, option)
         player:setCharVar("PromathiaStatus", 0)
         player:completeMission(COP, tpz.mission.id.cop.THE_ENDURING_TUMULT_OF_WAR)
         player:addMission(COP, tpz.mission.id.cop.DESIRES_OF_EMPTINESS)
-        player:addKeyItem(tpz.ki.LIGHT_OF_VAHZL)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.LIGHT_OF_VAHZL)
         player:setPos(-14.744, 0.036, -119.736, 1, 22) -- To Floor 1 {R}
     elseif (csid == 50 and option == 1) then
         player:setPos(-14.744, 0.036, -119.736, 1, 22) -- To Floor 1 {R}


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

These slipped my attention in #1433 With this they should be complete. See the spoiler if you're curious :)
- In [Mission 5-1 (Capture)](https://youtu.be/yfBfXpeosFg?t=2196), before getting warped to Promyvion-Vahzl, Prishe returns the drained amulet from Selh'teus to the player. After waking up in Promyvion, the player obtains the amulet key item and the light of Vahzl key item and gets both printed with a special message. This was missing.
<details>
  <summary>Spoiler</summary>
This was a key moment for me because in 6-3 all of a sudden Prishe appears again with an amulet but now you already have one and she got another one. Apparently when Prishe becomes sick in 3-5 and wakes up without her amulet, it was actually Eshan'tarl (formerly known as Cardinal Mildaurion) who "stole" the amulet from her. She tells Prishe though that she only needs to lend it and in 6-3 it becomes clear that she returned Prishe her original amulet. From here on the player has his and Prishe has hers. In 7-5 Nag'molada actually takes the one that legitimately belongs to Prishe, and the one from Selh'teus hold by the player, already weak, now shatters. (Has to be removed at this point, was also missing)
</details>

- In Mission 5-2 the Tarus try to steal the amulet again but get caught and return it to the unconscious player immediately
This cutscene was missing the key item as argument

- [x] Tested working locally.