### PR TITLE
Add Sheltered Ring / Brachyura Earring MODs Logic / Effect Audit

### DIFF
--- a/scripts/globals/items/coated_shield.lua
+++ b/scripts/globals/items/coated_shield.lua
@@ -5,13 +5,21 @@
 -----------------------------------------
 require("scripts/globals/status")
 require("scripts/globals/msg")
+require("scripts/globals/utils")
 
 function onItemCheck(target)
     return 0
 end
 
 function onItemUse(target)
-    if (target:addStatusEffect(tpz.effect.SHELL, 9, 0, 1800)) then
+    local power = 27 -- power/256 handled below before passing final DMGMAGIC value
+    local tier = 1
+    local buff = 0
+    if target:getMod(tpz.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 1 -- Adds the tier as a bonus to power before calculation
+    end
+    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
+    if (target:addStatusEffect(tpz.effect.SHELL, power, 0, 1800, 0, 0, tier)) then
         target:messageBasic(tpz.msg.basic.GAINS_EFFECT_OF_STATUS, tpz.effect.SHELL)
     else
         target:messageBasic(tpz.msg.basic.NO_EFFECT)

--- a/scripts/globals/items/protect_earring.lua
+++ b/scripts/globals/items/protect_earring.lua
@@ -11,7 +11,16 @@ function onItemCheck(target)
 end
 
 function onItemUse(target)
-    if (target:addStatusEffect(tpz.effect.PROTECT, 15, 0, 1800)) then
+    local power = 20
+    local tier = 1
+    local buff = 0
+    if target:getMod(tpz.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 2 -- 2x Tier from MOD
+    end
+
+    local power = power + (buff * tier)
+
+    if (target:addStatusEffect(tpz.effect.PROTECT, power, 0, 1800, 0, 0, tier)) then
         target:messageBasic(tpz.msg.basic.GAINS_EFFECT_OF_STATUS, tpz.effect.PROTECT)
     else
         target:messageBasic(tpz.msg.basic.NO_EFFECT)

--- a/scripts/globals/items/protect_ring.lua
+++ b/scripts/globals/items/protect_ring.lua
@@ -11,7 +11,15 @@ function onItemCheck(target)
 end
 
 function onItemUse(target)
-    if (target:addStatusEffect(tpz.effect.PROTECT, 40, 0, 1800)) then
+    local power = 50
+    local tier = 2
+    local buff = 0
+    if target:getMod(tpz.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 2 -- 2x Tier from MOD
+    end
+
+    local power = power + (buff * tier)
+    if (target:addStatusEffect(tpz.effect.PROTECT, power, 0, 1800, 0, 0, tier)) then
         target:messageBasic(tpz.msg.basic.GAINS_EFFECT_OF_STATUS, tpz.effect.PROTECT)
     else
         target:messageBasic(tpz.msg.basic.NO_EFFECT)

--- a/scripts/globals/mobskills/crystal_shield.lua
+++ b/scripts/globals/mobskills/crystal_shield.lua
@@ -12,7 +12,7 @@ function onMobSkillCheck(target, mob, skill)
 end
 
 function onMobWeaponSkill(target, mob, skill)
-    local power = 40
+    local power = 50
     local duration = 300
 
     local typeEffect = tpz.effect.PROTECT

--- a/scripts/globals/regimes.lua
+++ b/scripts/globals/regimes.lua
@@ -1198,35 +1198,62 @@ tpz.regime.bookOnEventFinish = function(player, option, regimeType)
         elseif act == "PROTECT" then
             local mLvl = player:getMainLvl()
             local power = 0
+            local tier = 0
 
             if mLvl < 27 then
-                power = 15
+                power = 20
+                tier = 1
             elseif mLvl < 47 then
-                power = 40
+                power = 50
+                tier = 2
             elseif mLvl < 63 then
-                power = 75
+                power = 90
+                tier = 3
+            elseif mLvl < 76 then
+                power = 140
+                tier = 4
             else
-                power = 120
+                power = 220
+                tier = 5
             end
 
+            local buff = 0
+            if player:getMod(tpz.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+                buff = 2 -- 2x Tier from MOD
+            end
+
+            local power = power + (buff * tier)
             player:delStatusEffectSilent(tpz.effect.PROTECT)
-            player:addStatusEffect(tpz.effect.PROTECT, power, 0, 1800)
+            player:addStatusEffect(tpz.effect.PROTECT, power, 0, 1800, 0, 0, tier)
 
         elseif act == "SHELL" then
             local mLvl = player:getMainLvl()
             local power = 0
+            local tier = 0
 
             if mLvl < 37 then
-                power = 9
+                power = 27 -- power/256 handled below before passing final DMGMAGIC value
+                tier = 1
             elseif mLvl < 57 then
-                power = 14
+                power = 42 -- power/256 handled below before passing final DMGMAGIC value
+                tier = 2
             elseif mLvl < 68 then
-                power = 19
+                power = 56 -- power/256 handled below before passing final DMGMAGIC value
+                tier = 3
+            elseif mLvl < 76 then
+                power = 67 -- power/256 handled below before passing final DMGMAGIC value
+                tier = 4
             else
-                power = 22
+                power = 75 -- power/256 handled below before passing final DMGMAGIC value
+                tier = 5
             end
+            local buff = 0
+            if player:getMod(tpz.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+                buff = 1 -- Adds the tier as a bonus to power before calculation
+            end
+            local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
             player:delStatusEffectSilent(tpz.effect.SHELL)
-            player:addStatusEffect(tpz.effect.SHELL, power, 0, 1800)
+            player:addStatusEffect(tpz.effect.SHELL, power, 0, 1800, 0, 0, tier)
 
         elseif act == "HASTE" then
             player:delStatusEffectSilent(tpz.effect.HASTE)

--- a/scripts/globals/spells/protect.lua
+++ b/scripts/globals/spells/protect.lua
@@ -11,16 +11,25 @@ function onMagicCastingCheck(caster, target, spell)
 end
 
 function onSpellCast(caster, target, spell)
-    local power = 15
+    local power = 20
+    local tier = 1
+    local spelllevel = 7
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 7, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+    local buff = 0
+    if target:getMod(tpz.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 2 -- 2x Tier from MOD
+    end
+
+    local power = power + (buff * tier)
 
     local typeEffect = tpz.effect.PROTECT
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(tpz.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(tpz.msg.basic.MAGIC_NO_EFFECT) -- no effect
     end
 
     return typeEffect
+
 end

--- a/scripts/globals/spells/protect_ii.lua
+++ b/scripts/globals/spells/protect_ii.lua
@@ -11,12 +11,20 @@ function onMagicCastingCheck(caster, target, spell)
 end
 
 function onSpellCast(caster, target, spell)
-    local power = 40
+    local power = 50
+    local tier = 2
+    local spelllevel = 27
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 27, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+    local buff = 0
+    if target:getMod(tpz.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 2 -- 2x Tier from MOD
+    end
+
+    local power = power + (buff * tier)
 
     local typeEffect = tpz.effect.PROTECT
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(tpz.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(tpz.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/protect_iii.lua
+++ b/scripts/globals/spells/protect_iii.lua
@@ -11,12 +11,20 @@ function onMagicCastingCheck(caster, target, spell)
 end
 
 function onSpellCast(caster, target, spell)
-    local power = 75
+    local power = 90
+    local tier = 3
+    local spelllevel = 47
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 47, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+    local buff = 0
+    if target:getMod(tpz.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 2 -- 2x Tier from MOD
+    end
+
+    local power = power + (buff * tier)
 
     local typeEffect = tpz.effect.PROTECT
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(tpz.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(tpz.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/protect_iv.lua
+++ b/scripts/globals/spells/protect_iv.lua
@@ -11,12 +11,20 @@ function onMagicCastingCheck(caster, target, spell)
 end
 
 function onSpellCast(caster, target, spell)
-    local power = 120
+    local power = 140
+    local tier = 4
+    local spelllevel = 63
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 63, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+    local buff = 0
+    if target:getMod(tpz.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 2 -- 2x Tier from MOD
+    end
+
+    local power = power + (buff * tier)
 
     local typeEffect = tpz.effect.PROTECT
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(tpz.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(tpz.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/protect_v.lua
+++ b/scripts/globals/spells/protect_v.lua
@@ -1,5 +1,5 @@
 -----------------------------------------
--- Spell: Protect IV
+-- Spell: Protect V
 -----------------------------------------
 require("scripts/globals/magic")
 require("scripts/globals/msg")
@@ -11,12 +11,20 @@ function onMagicCastingCheck(caster, target, spell)
 end
 
 function onSpellCast(caster, target, spell)
-    local power = 175
+    local power = 220
+    local tier = 5
+    local spelllevel = 76
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 76, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+    local buff = 0
+    if target:getMod(tpz.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 2 -- 2x Tier from MOD
+    end
+
+    local power = power + (buff * tier)
 
     local typeEffect = tpz.effect.PROTECT
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(tpz.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(tpz.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/protectra.lua
+++ b/scripts/globals/spells/protectra.lua
@@ -11,16 +11,25 @@ function onMagicCastingCheck(caster, target, spell)
 end
 
 function onSpellCast(caster, target, spell)
-    local power = 15
+    local power = 20
+    local tier = 1
+    local spelllevel = 7
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 7, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+    local buff = 0
+    if target:getMod(tpz.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 2 -- 2x Tier from MOD
+    end
+
+    local power = power + (buff * tier)
 
     local typeEffect = tpz.effect.PROTECT
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(tpz.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(tpz.msg.basic.MAGIC_NO_EFFECT) -- no effect
     end
 
     return typeEffect
+
 end

--- a/scripts/globals/spells/protectra_ii.lua
+++ b/scripts/globals/spells/protectra_ii.lua
@@ -11,12 +11,20 @@ function onMagicCastingCheck(caster, target, spell)
 end
 
 function onSpellCast(caster, target, spell)
-    local power = 40
+    local power = 50
+    local tier = 2
+    local spelllevel = 27
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 27, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+    local buff = 0
+    if target:getMod(tpz.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 2 -- 2x Tier from MOD
+    end
+
+    local power = power + (buff * tier)
 
     local typeEffect = tpz.effect.PROTECT
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(tpz.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(tpz.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/protectra_iii.lua
+++ b/scripts/globals/spells/protectra_iii.lua
@@ -11,12 +11,20 @@ function onMagicCastingCheck(caster, target, spell)
 end
 
 function onSpellCast(caster, target, spell)
-    local power = 75
+    local power = 90
+    local tier = 3
+    local spelllevel = 47
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 47, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+    local buff = 0
+    if target:getMod(tpz.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 2 -- 2x Tier from MOD
+    end
+
+    local power = power + (buff * tier)
 
     local typeEffect = tpz.effect.PROTECT
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(tpz.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(tpz.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/protectra_iv.lua
+++ b/scripts/globals/spells/protectra_iv.lua
@@ -11,12 +11,20 @@ function onMagicCastingCheck(caster, target, spell)
 end
 
 function onSpellCast(caster, target, spell)
-    local power = 120
+    local power = 140
+    local tier = 4
+    local spelllevel = 63
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 63, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+    local buff = 0
+    if target:getMod(tpz.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 2 -- 2x Tier from MOD
+    end
+
+    local power = power + (buff * tier)
 
     local typeEffect = tpz.effect.PROTECT
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(tpz.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(tpz.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/protectra_v.lua
+++ b/scripts/globals/spells/protectra_v.lua
@@ -11,12 +11,20 @@ function onMagicCastingCheck(caster, target, spell)
 end
 
 function onSpellCast(caster, target, spell)
+    local power = 220
+    local tier = 5
+    local spelllevel = 75
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 75, target:getMainLvl())
-    local power = 220 -- bg-wiki
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+    local buff = 0
+    if target:getMod(tpz.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 2 -- 2x Tier from MOD
+    end
+
+    local power = power + (buff * tier)
 
     local typeEffect = tpz.effect.PROTECT
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(tpz.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(tpz.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/shell.lua
+++ b/scripts/globals/spells/shell.lua
@@ -4,6 +4,7 @@
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
+require("scripts/globals/utils")
 -----------------------------------------
 
 function onMagicCastingCheck(caster, target, spell)
@@ -11,12 +12,20 @@ function onMagicCastingCheck(caster, target, spell)
 end
 
 function onSpellCast(caster, target, spell)
-    local power = 9
+    local power = 27 -- power/256 handled below before passing final DMGMAGIC value
+    local tier = 1
+    local spelllevel = 18
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 18, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+
+    local buff = 0
+    if target:getMod(tpz.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 1 -- Adds the tier as a bonus to power before calculation
+    end
+    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
 
     local typeEffect = tpz.effect.SHELL
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(tpz.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(tpz.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/shell_ii.lua
+++ b/scripts/globals/spells/shell_ii.lua
@@ -4,6 +4,7 @@
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
+require("scripts/globals/utils")
 -----------------------------------------
 
 function onMagicCastingCheck(caster, target, spell)
@@ -11,15 +12,24 @@ function onMagicCastingCheck(caster, target, spell)
 end
 
 function onSpellCast(caster, target, spell)
-    local power = 14
+    local power = 42 -- power/256 handled below before passing final DMGMAGIC value
+    local tier = 2
+    local spelllevel = 37
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 37, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+
+    local buff = 0
+    if target:getMod(tpz.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 1 -- Adds the tier as a bonus to power before calculation
+    end
+    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
 
     local typeEffect = tpz.effect.SHELL
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(tpz.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(tpz.msg.basic.MAGIC_NO_EFFECT) -- no effect
     end
+
     return typeEffect
 end

--- a/scripts/globals/spells/shell_iii.lua
+++ b/scripts/globals/spells/shell_iii.lua
@@ -4,6 +4,7 @@
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
+require("scripts/globals/utils")
 -----------------------------------------
 
 function onMagicCastingCheck(caster, target, spell)
@@ -11,16 +12,24 @@ function onMagicCastingCheck(caster, target, spell)
 end
 
 function onSpellCast(caster, target, spell)
-    local power = 19
+    local power = 56 -- power/256 handled below before passing final DMGMAGIC value
+    local tier = 3
+    local spelllevel = 57
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
 
-    duration = calculateDurationForLvl(duration, 57, target:getMainLvl())
+    local buff = 0
+    if target:getMod(tpz.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 1 -- Adds the tier as a bonus to power before calculation
+    end
+    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
 
     local typeEffect = tpz.effect.SHELL
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(tpz.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(tpz.msg.basic.MAGIC_NO_EFFECT) -- no effect
     end
+
     return typeEffect
 end

--- a/scripts/globals/spells/shell_iv.lua
+++ b/scripts/globals/spells/shell_iv.lua
@@ -4,6 +4,7 @@
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
+require("scripts/globals/utils")
 -----------------------------------------
 
 function onMagicCastingCheck(caster, target, spell)
@@ -11,15 +12,24 @@ function onMagicCastingCheck(caster, target, spell)
 end
 
 function onSpellCast(caster, target, spell)
-    local power = 22
+    local power = 67 -- power/256 handled below before passing final DMGMAGIC value
+    local tier = 4
+    local spelllevel = 68
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 68, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+
+    local buff = 0
+    if target:getMod(tpz.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 1 -- Adds the tier as a bonus to power before calculation
+    end
+    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
 
     local typeEffect = tpz.effect.SHELL
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(tpz.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(tpz.msg.basic.MAGIC_NO_EFFECT) -- no effect
     end
+
     return typeEffect
 end

--- a/scripts/globals/spells/shell_v.lua
+++ b/scripts/globals/spells/shell_v.lua
@@ -1,9 +1,10 @@
 -----------------------------------------
--- Spell: Shell IV
+-- Spell: Shell V
 -----------------------------------------
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
+require("scripts/globals/utils")
 -----------------------------------------
 
 function onMagicCastingCheck(caster, target, spell)
@@ -11,15 +12,24 @@ function onMagicCastingCheck(caster, target, spell)
 end
 
 function onSpellCast(caster, target, spell)
-    local power = 24
+    local power = 75 -- power/256 handled below before passing final DMGMAGIC value
+    local tier = 5
+    local spelllevel = 76
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 76, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+
+    local buff = 0
+    if target:getMod(tpz.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 1 -- Adds the tier as a bonus to power before calculation
+    end
+    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
 
     local typeEffect = tpz.effect.SHELL
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(tpz.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(tpz.msg.basic.MAGIC_NO_EFFECT) -- no effect
     end
+
     return typeEffect
 end

--- a/scripts/globals/spells/shellra.lua
+++ b/scripts/globals/spells/shellra.lua
@@ -4,6 +4,7 @@
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
+require("scripts/globals/utils")
 -----------------------------------------
 
 function onMagicCastingCheck(caster, target, spell)
@@ -11,15 +12,24 @@ function onMagicCastingCheck(caster, target, spell)
 end
 
 function onSpellCast(caster, target, spell)
-    local power = 9
+    local power = 27 -- power/256 handled below before passing final DMGMAGIC value
+    local tier = 1
+    local spelllevel = 18
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 18, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+
+    local buff = 0
+    if target:getMod(tpz.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 1 -- Adds the tier as a bonus to power before calculation
+    end
+    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
 
     local typeEffect = tpz.effect.SHELL
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(tpz.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(tpz.msg.basic.MAGIC_NO_EFFECT) -- no effect
     end
+
     return typeEffect
 end

--- a/scripts/globals/spells/shellra_ii.lua
+++ b/scripts/globals/spells/shellra_ii.lua
@@ -4,6 +4,7 @@
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
+require("scripts/globals/utils")
 -----------------------------------------
 
 function onMagicCastingCheck(caster, target, spell)
@@ -11,15 +12,24 @@ function onMagicCastingCheck(caster, target, spell)
 end
 
 function onSpellCast(caster, target, spell)
-    local power = 14
+    local power = 42 -- power/256 handled below before passing final DMGMAGIC value
+    local tier = 2
+    local spelllevel = 37
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 37, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+
+    local buff = 0
+    if target:getMod(tpz.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 1 -- Adds the tier as a bonus to power before calculation
+    end
+    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
 
     local typeEffect = tpz.effect.SHELL
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(tpz.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(tpz.msg.basic.MAGIC_NO_EFFECT) -- no effect
     end
+
     return typeEffect
 end

--- a/scripts/globals/spells/shellra_iii.lua
+++ b/scripts/globals/spells/shellra_iii.lua
@@ -4,6 +4,7 @@
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
+require("scripts/globals/utils")
 -----------------------------------------
 
 function onMagicCastingCheck(caster, target, spell)
@@ -11,15 +12,24 @@ function onMagicCastingCheck(caster, target, spell)
 end
 
 function onSpellCast(caster, target, spell)
-    local power = 19
+    local power = 56 -- power/256 handled below before passing final DMGMAGIC value
+    local tier = 3
+    local spelllevel = 57
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 57, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+
+    local buff = 0
+    if target:getMod(tpz.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 1 -- Adds the tier as a bonus to power before calculation
+    end
+    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
 
     local typeEffect = tpz.effect.SHELL
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(tpz.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(tpz.msg.basic.MAGIC_NO_EFFECT) -- no effect
     end
+
     return typeEffect
 end

--- a/scripts/globals/spells/shellra_iv.lua
+++ b/scripts/globals/spells/shellra_iv.lua
@@ -4,6 +4,7 @@
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
+require("scripts/globals/utils")
 -----------------------------------------
 
 function onMagicCastingCheck(caster, target, spell)
@@ -11,15 +12,24 @@ function onMagicCastingCheck(caster, target, spell)
 end
 
 function onSpellCast(caster, target, spell)
-    local power = 22
+    local power = 67 -- power/256 handled below before passing final DMGMAGIC value
+    local tier = 4
+    local spelllevel = 68
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 68, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+
+    local buff = 0
+    if target:getMod(tpz.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 1 -- Adds the tier as a bonus to power before calculation
+    end
+    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
 
     local typeEffect = tpz.effect.SHELL
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(tpz.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(tpz.msg.basic.MAGIC_NO_EFFECT) -- no effect
     end
+
     return typeEffect
 end

--- a/scripts/globals/spells/shellra_v.lua
+++ b/scripts/globals/spells/shellra_v.lua
@@ -1,9 +1,10 @@
 -----------------------------------------
--- Spell: Shellra
+-- Spell: Shellra V
 -----------------------------------------
-require("scripts/globals/status")
 require("scripts/globals/magic")
 require("scripts/globals/msg")
+require("scripts/globals/status")
+require("scripts/globals/utils")
 -----------------------------------------
 
 function onMagicCastingCheck(caster, target, spell)
@@ -11,16 +12,24 @@ function onMagicCastingCheck(caster, target, spell)
 end
 
 function onSpellCast(caster, target, spell)
-    local power = 29 -- according to bg-wiki
-
+    local power = 75 -- power/256 handled below before passing final DMGMAGIC value
+    local tier = 5
+    local spelllevel = 75
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 75, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+
+    local buff = 0
+    if target:getMod(tpz.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 1 -- Adds the tier as a bonus to power before calculation
+    end
+    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
 
     local typeEffect = tpz.effect.SHELL
-    if (target:addStatusEffect(typeEffect, power, 0, duration)) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(tpz.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(tpz.msg.basic.MAGIC_NO_EFFECT) -- no effect
     end
+
     return typeEffect
 end

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1409,6 +1409,7 @@ tpz.mod =
     ENHANCES_CURSNA_RCVD            = 67,  -- Potency of "Cursna" effects received
     ENHANCES_CURSNA                 = 310, -- Raises success rate of Cursna when removing effect (like Doom) that are not 100% chance to remove
     ENHANCES_HOLYWATER              = 495, -- Used by gear with the "Enhances Holy Water" or "Holy Water+" attribute
+    ENHANCES_PROT_SHELL_RCVD        = 977, -- Enhances Protect and Shell Effects Received (Binary MOD)
 
     RETALIATION                     = 414, -- Increases damage of Retaliation hits
     THIRD_EYE_COUNTER_RATE          = 508, -- Adds counter to 3rd eye anticipates & if using Seigan counter rate is increased by 15%
@@ -1568,9 +1569,9 @@ tpz.mod =
 
     -- The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     -- 570 - 825 used by WS DMG mods these are not spares.
-    -- SPARE = 977, -- stuff
     -- SPARE = 978, -- stuff
     -- SPARE = 979, -- stuff
+    -- SPARE = 980, -- stuff
 }
 
 tpz.latent =

--- a/scripts/globals/utils.lua
+++ b/scripts/globals/utils.lua
@@ -16,6 +16,11 @@ function utils.shuffle(tab)
     return res
 end
 
+function utils.roundup(num)
+    local mult = 10^(0)
+    return math.floor(num * mult + 0.5) / mult
+end
+
 function utils.clamp(input, min_val, max_val)
     if input < min_val then
         input = min_val

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -2290,7 +2290,8 @@ INSERT INTO `item_mods` VALUES (10762,30,4);
 INSERT INTO `item_mods` VALUES (10762,71,2);
 INSERT INTO `item_mods` VALUES (10763,24,8);
 INSERT INTO `item_mods` VALUES (10763,73,-4);
-INSERT INTO `item_mods` VALUES (10764,370,1);
+INSERT INTO `item_mods` VALUES (10764,370,1); -- Sheltered Ring  Regen +1
+INSERT INTO `item_mods` VALUES (10764,977,1); -- Enhances Prot/Shell Received
 INSERT INTO `item_mods` VALUES (10765,11,4);
 INSERT INTO `item_mods` VALUES (10765,30,2);
 INSERT INTO `item_mods` VALUES (10765,105,3);
@@ -3133,7 +3134,8 @@ INSERT INTO `item_mods` VALUES (11036,30,2);
 INSERT INTO `item_mods` VALUES (11037,57,10);     -- Earthcry Earring: Earth resistance +10
 INSERT INTO `item_mods` VALUES (11037,539,10);    -- Enhances Stoneskin effect +10
 INSERT INTO `item_mods` VALUES (11038,23,7);
-INSERT INTO `item_mods` VALUES (11039,5,20);
+INSERT INTO `item_mods` VALUES (11039,5,20);      -- brachyura earring MP+20
+INSERT INTO `item_mods` VALUES (11039,977,1);     -- Enhances Prot/Shell Received
 INSERT INTO `item_mods` VALUES (11040,2,10);      -- terminus_earring HP+10
 INSERT INTO `item_mods` VALUES (11040,64,1);      -- combat skill +1
 INSERT INTO `item_mods` VALUES (11041,5,10);      -- liminus_earring MP+10

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -710,6 +710,7 @@ enum class Mod
     ENHANCES_CURSNA_RCVD      = 67,  // Potency of "Cursna" effects received
     ENHANCES_CURSNA           = 310, // Used by gear with the "Enhances Cursna" or "Cursna+" attribute
     ENHANCES_HOLYWATER        = 495, // Used by gear with the "Enhances Holy Water" or "Holy Water+" attribute
+    ENHANCES_PROT_SHELL_RCVD  = 977, // Enhances Protect and Shell Effects Received (Binary MOD)
 
     RETALIATION               = 414, // Increases damage of Retaliation hits
 
@@ -811,9 +812,9 @@ enum class Mod
 
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     // 570 through 825 used by WS DMG mods these are not spares.
-    // SPARE = 977, // stuff
     // SPARE = 978, // stuff
     // SPARE = 979, // stuff
+    // SPARE = 980, // stuff
 };
 
 //temporary workaround for using enum class as unordered_map key until compilers support it


### PR DESCRIPTION
Adds MOD ENHANCES_PROT_SHELL_RCVD (977) to the following:
Sheltered Ring 10764
Brachyura Earring 11039

Adds Tier of Spell x 2 DEF to Protect Spells/Effects
Adds Tier of Spell / 256 to Shell Spells/Effects

Effect Detail and confirmation items do not stack:

https://www.ffxiah.com/item/10764/sheltered-ring
https://www.ffxiah.com/item/11039/brachyura-earring

Current BG Values:

https://www.bg-wiki.com/bg/Protect (and _II -> _V)
https://www.bg-wiki.com/bg/Protectra (and _II -> _V)
https://www.bg-wiki.com/bg/Shell (and _II -> _V)
https://www.bg-wiki.com/bg/Shellra (and _II -> _V)

```
Protect/ra  DEF            DEF
                           With MOD
       I -   20             22
      II -   50             54
     III -   90             96
      IV -  140            148
       V -  220            230

Shell/ra    MDT  as /256   MDT  as /256
                           With MOD
       I -  -11 (-27/256)  -11 (-28/256)
      II -  -16 (-42/256)  -17 (-44/256)
     III -  -22 (-56/256)  -23 (-59/256)
      IV -  -26 (-67/256)  -28 (-71/256)
       V -  -29 (-75/256)  -31 (-80/256)
```

Script Adjustments:

Added checks on individual Spells/Item Scripts
Logic will check for MOD Value > 0
Updated Protect Values in scripts to match BG.
Updated regimes to include Tier V and apply buff bonus with MOD present.
Tested gaining and losing buffs with and without MOD items:
Shell -> Shell V
Protect -> Protect V
Shellra -> Shellra V
Protectra -> Protectra V
Coated Shield
Protect Earring
Protect Ring
Regime Protect/Shell

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

