### PR TITLE
PacketGuard: Add allow for Event Update (String Update) (0x060)

### DIFF
--- a/src/map/packet_guard.cpp
+++ b/src/map/packet_guard.cpp
@@ -39,6 +39,7 @@ void Init()
     allowList[SUBSTATE_IN_CS][0x05A] = true; // Map Update (Conquest, Besieged, Campaign)
     allowList[SUBSTATE_IN_CS][0x05B] = true; // Event Update (Completion or Update)
     allowList[SUBSTATE_IN_CS][0x05C] = true; // Event Update (Update Player Position)
+    allowList[SUBSTATE_IN_CS][0x060] = true; // Event Update (String Update)  
     allowList[SUBSTATE_IN_CS][0x061] = true; // Full Char Update
     allowList[SUBSTATE_IN_CS][0x0B5] = true; // Chat Message
     allowList[SUBSTATE_IN_CS][0x0B6] = true; // Tell Message


### PR DESCRIPTION
Shout out to Derahine from Noct. Souls for testing Packet Guard, I had no idea 😆 

This packet was missing.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

