### PR TITLE
Add GetRandomElement helpers and cleanup tpzrand

### DIFF
--- a/src/common/tpzrand.h
+++ b/src/common/tpzrand.h
@@ -18,14 +18,13 @@ public:
         mt().seed(seq);
     }
 
-    /*Generates a random number in the half-open interval [min, max)
-    @param min
-    @param max
-    @returns result
-    */
+    // Generates a random number in the half-open interval [min, max]
+    // @param min
+    // @param max
+    // @returns result
     template <typename T>
     static inline typename std::enable_if<std::is_integral<T>::value, T>::type
-        GetRandomNumber(T min, T max)
+    GetRandomNumber(T min, T max)
     {
         if (min == max - 1 || max == min)
         {
@@ -37,7 +36,7 @@ public:
 
     template<typename T>
     static inline typename std::enable_if<std::is_floating_point<T>::value, T>::type
-        GetRandomNumber(T min, T max)
+    GetRandomNumber(T min, T max)
     {
         if (min == max)
         {
@@ -47,14 +46,39 @@ public:
         return dist(mt());
     }
 
-    /*Generates a random number in the half-open interval [0, max)
-    @param min
-    @param max
-    @returns result
-    */
+    // Generates a random number in the half-open interval [0, max)
+    // @param min
+    // @param max
+    // @returns result
     template <typename T>
     static inline T GetRandomNumber(T max)
     {
         return GetRandomNumber<T>(0, max);
+    }
+
+    // Gets a random element from the given stl-like container (container must have members: at() and size()).
+    // @param container
+    // @returns result
+    template <typename T> static inline typename T::value_type GetRandomElement(T* container)
+    {
+        // NOTE: the specialisation for integral types uses: dist(min, max - 1), so no need to offset container->size()
+        return container->at(GetRandomNumber<std::size_t>(0U, container->size()));
+    }
+
+    // Gets a random element from the given stl-like container (container must have members: at() and size()).
+    // @param container
+    // @returns result
+    template <typename T> static inline typename T::value_type GetRandomElement(T& container)
+    {
+        return GetRandomElement(&container);
+    }
+
+    // Gets a random element from the given initializer_list.
+    // @param initializer_list
+    // @returns result
+    template <typename T> static inline T GetRandomElement(std::initializer_list<T> list)
+    {
+        std::vector<T> container(list);
+        return GetRandomElement(container);
     }
 };


### PR DESCRIPTION
This allows:

```cpp
std::vector<int> v{ 1, 2, 3, 4, 5 };
auto ptrToV = &v;

tpzrand::GetRandomElement(v);
tpzrand::GetRandomElement(ptrToV);
tpzrand::GetRandomElement({ 1, 2, 3, 4, 5 });
```
... on any type that has  `at()` and `size()`.

For the C++ nerds out there, I tried to use SFINAE to validate if passed in containers had access to `at()` and `size()`, but template voodoo isn't my speciality. I got as far as:

```cpp
template <typename T, typename Enable = void>
inline constexpr bool is_container_like = false;

template <typename T>
inline constexpr bool is_container_like
<T, std::void_t<
    decltype(std::declval<T>().at()),
    decltype(std::declval<T>().size())>
> = true;

template <typename T>
static inline auto GetRandomElement(T* container)
-> std::enable_if_t<is_container_like<T>, typename T::value_type>
{
    return container->at(GetRandomNumber<std::size_t>(0U, container->size()));
}
```

🤷 

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

