### PR TITLE
ROE Records Typo fix for Castle Oztroja and Ordelle's Caves

### DIFF
--- a/scripts/globals/roe_records.lua
+++ b/scripts/globals/roe_records.lua
@@ -902,7 +902,7 @@ tpz.roe.records =
     [ 237] = { -- Conflict: Ordelle's Caves
         trigger = triggers.mobKill,
         goal = 10,
-        reqs = { zone = set{102} },
+        reqs = { zone = set{193} },
         flags = set{"repeat"},
         reward = { sparks = 12, xp = 100, unity = 5, item = { 13470 } },
     },
@@ -1268,7 +1268,7 @@ tpz.roe.records =
     [ 288] = { -- Conflict: Castle Oztroja
         trigger = triggers.mobKill,
         goal = 10,
-        reqs = { zone = set{200} },
+        reqs = { zone = set{151} },
         flags = set{"repeat"},
         reward = { sparks = 13, xp = 650, unity = 5, item = { 13723 } },
     },


### PR DESCRIPTION
Fixes Zone ID for both regimes.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

