### PR TITLE
Add MAX_SWINGS, ADDITIONAL_SWING_CHANCE mod and JOB_MULTIPLE latent

### DIFF
--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1065,8 +1065,8 @@ tpz.mod =
     MARTIAL_ARTS                    = 173,
     SKILLCHAINBONUS                 = 174,
     SKILLCHAINDMG                   = 175,
-    MAX_SWINGS                      = 977,
-    ADDITIONAL_SWING_CHANCE         = 978,
+    MAX_SWINGS                      = 978,
+    ADDITIONAL_SWING_CHANCE         = 979,
     FOOD_HPP                        = 176,
     FOOD_HP_CAP                     = 177,
     FOOD_MPP                        = 178,
@@ -1570,9 +1570,9 @@ tpz.mod =
 
     -- The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     -- 570 - 825 used by WS DMG mods these are not spares.
-    -- SPARE = 979, -- stuff
     -- SPARE = 980, -- stuff
     -- SPARE = 981, -- stuff
+    -- SPARE = 982, -- stuff
 }
 
 tpz.latent =

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1065,6 +1065,8 @@ tpz.mod =
     MARTIAL_ARTS                    = 173,
     SKILLCHAINBONUS                 = 174,
     SKILLCHAINDMG                   = 175,
+    MAX_SWINGS                      = 977,
+    ADDITIONAL_SWING_CHANCE         = 978,
     FOOD_HPP                        = 176,
     FOOD_HP_CAP                     = 177,
     FOOD_MPP                        = 178,
@@ -1568,9 +1570,9 @@ tpz.mod =
 
     -- The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     -- 570 - 825 used by WS DMG mods these are not spares.
-    -- SPARE = 977, -- stuff
-    -- SPARE = 978, -- stuff
     -- SPARE = 979, -- stuff
+    -- SPARE = 980, -- stuff
+    -- SPARE = 981, -- stuff
 }
 
 tpz.latent =
@@ -1618,7 +1620,7 @@ tpz.latent =
     JOB_LEVEL_ODD            = 41,
     JOB_LEVEL_EVEN           = 42,
     WEAPON_DRAWN_HP_UNDER    = 43, -- PARAM: HP PERCENT
-    --                       = 44  -- Unused
+    JOB_MULTIPLE_8           = 44,
     MP_UNDER_VISIBLE_GEAR    = 45, -- mp less than or equal to %, calculated using MP bonuses from visible gear only
     HP_OVER_VISIBLE_GEAR     = 46, -- hp more than or equal to %, calculated using HP bonuses from visible gear only
     WEAPON_BROKEN            = 47,

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1614,13 +1614,13 @@ tpz.latent =
     LIGHTNINGSDAY            = 35,
     LIGHTSDAY                = 36,
     MOON_PHASE               = 37, -- PARAM: 0: New Moon, 1: Waxing Crescent, 2: First Quarter, 3: Waxing Gibbous, 4: Full Moon, 5: Waning Gibbous, 6: Last Quarter, 7: Waning Crescent
-    JOB_MULTIPLE_5           = 38,
-    JOB_MULTIPLE_10          = 39,
-    JOB_MULTIPLE_13_NIGHT    = 40,
-    JOB_LEVEL_ODD            = 41,
-    JOB_LEVEL_EVEN           = 42,
+    JOB_MULTIPLE             = 38, -- PARAM: 0: ODD, 2: EVEN, 3-99: DIVISOR
+    JOB_MULTIPLE_AT_NIGHT    = 39, -- PARAM: 0: ODD, 2: EVEN, 3-99: DIVISOR
+    -- 40 free to use
+    -- 41 free to use
+    -- 42 free to use
     WEAPON_DRAWN_HP_UNDER    = 43, -- PARAM: HP PERCENT
-    JOB_MULTIPLE_8           = 44,
+    -- 44 free to use
     MP_UNDER_VISIBLE_GEAR    = 45, -- mp less than or equal to %, calculated using MP bonuses from visible gear only
     HP_OVER_VISIBLE_GEAR     = 46, -- hp more than or equal to %, calculated using HP bonuses from visible gear only
     WEAPON_BROKEN            = 47,

--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -2946,8 +2946,8 @@ INSERT INTO `item_latents` VALUES(18850, 366, 5, 6, 1000);  -- DMG+5 while TP <1
 -- -------------------------------------------------------
 -- Octave Club
 -- -------------------------------------------------------
-INSERT INTO `item_latents` VALUES(18852, 977, 2, 38, 2);    -- Occasionally attacks 2 times when mjob multiple of 2
-INSERT INTO `item_latents` VALUES(18852, 977, 6, 38, 8);    -- Occasionally attacks 2 to 8 times when mjob multiple of 8
+INSERT INTO `item_latents` VALUES(18852, 978, 2, 38, 2);    -- Occasionally attacks 2 times when mjob multiple of 2
+INSERT INTO `item_latents` VALUES(18852, 978, 6, 38, 8);    -- Occasionally attacks 2 to 8 times when mjob multiple of 8
 
 -- -------------------------------------------------------
 -- Kerykeion

--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -2947,7 +2947,7 @@ INSERT INTO `item_latents` VALUES(18850, 366, 5, 6, 1000);  -- DMG+5 while TP <1
 -- Octave Club
 -- -------------------------------------------------------
 INSERT INTO `item_latents` VALUES(18852, 977, 2, 38, 2);    -- Occasionally attacks 2 times when mjob multiple of 2
-INSERT INTO `item_latents` VALUES(18852, 977, 8, 38, 8);    -- Occasionally attacks 2 to 8 times when mjob multiple of 8
+INSERT INTO `item_latents` VALUES(18852, 977, 6, 38, 8);    -- Occasionally attacks 2 to 8 times when mjob multiple of 8
 
 -- -------------------------------------------------------
 -- Kerykeion

--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -2946,8 +2946,7 @@ INSERT INTO `item_latents` VALUES(18850, 366, 5, 6, 1000);  -- DMG+5 while TP <1
 -- -------------------------------------------------------
 -- Octave Club
 -- -------------------------------------------------------
--- TODO: Optimize latent_efffect_container.cpp to allow a mod be overwritten with a higher value
--- INSERT INTO `item_latents` VALUES(18852, 977, 2, 38, 2); -- Occasionally attacks 2 times when mjob multiple of 2
+INSERT INTO `item_latents` VALUES(18852, 977, 2, 38, 2);    -- Occasionally attacks 2 times when mjob multiple of 2
 INSERT INTO `item_latents` VALUES(18852, 977, 8, 38, 8);    -- Occasionally attacks 2 to 8 times when mjob multiple of 8
 
 -- -------------------------------------------------------

--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -78,14 +78,9 @@ INSERT INTO `item_latents` VALUES(10975, 25, 13, 52, 8);   -- DARK WEATHER:ACC
 INSERT INTO `item_latents` VALUES(10975, 23, 13, 52, 8);   -- DARK WEATHER:ATT
 
 -- -------------------------------------------------------
--- Eerie Cloak +1
--- -------------------------------------------------------
-INSERT INTO `item_latents` VALUES(11300, 369, 1, 40, 0);    -- Level multiple of 13 and Nighttime: Refresh +1MP/tick
-
--- -------------------------------------------------------
 -- Eerie cloak +1
 -- -------------------------------------------------------
-INSERT INTO `item_latents` VALUES(11301, 369, 1, 40, 0);    -- Refresh+1 at night when the level of the player's main job is a multiple of 13.
+INSERT INTO `item_latents` VALUES(11301, 369, 1, 39, 13);    -- Refresh+1 at night when the level of the player's main job is a multiple of 13.
 
 -- -------------------------------------------------------
 -- Rambler's Cloak
@@ -1742,14 +1737,14 @@ INSERT INTO `item_latents` VALUES(15784, 5, 30, 8, 3);      -- MP+30 when WHM su
 -- -------------------------------------------------------
 -- Divisor Ring (Active when level is divisible by 5)
 -- -------------------------------------------------------
-INSERT INTO `item_latents` VALUES(15786, 23, 3, 38, 0);     -- Attack+3
-INSERT INTO `item_latents` VALUES(15786, 25, 6, 38, 0);     -- Accuracy+6
+INSERT INTO `item_latents` VALUES(15786, 23, 3, 38, 5);     -- Attack+3
+INSERT INTO `item_latents` VALUES(15786, 25, 6, 38, 5);     -- Accuracy+6
 
 -- -------------------------------------------------------
 -- Multiple Ring (Active when level is a multiple of 10)
 -- -------------------------------------------------------
-INSERT INTO `item_latents` VALUES(15790, 1, 50, 39, 0);     -- HP+50
-INSERT INTO `item_latents` VALUES(15790, 5, 20, 39, 0);     -- MP+20
+INSERT INTO `item_latents` VALUES(15790, 1, 50, 38, 10);     -- HP+50
+INSERT INTO `item_latents` VALUES(15790, 5, 20, 38, 10);     -- MP+20
 
 -- -------------------------------------------------------
 -- Balrahn's Ring
@@ -1877,8 +1872,8 @@ INSERT INTO `item_latents` VALUES(16071, 165, 5, 13, 5);
 -- -------------------------------------------------------
 -- Coven Hat
 -- -------------------------------------------------------
-INSERT INTO `item_latents` VALUES(16076, 3, 3, 41, 0);      -- HP+3% is active when your current job level is odd.
-INSERT INTO `item_latents` VALUES(16076, 6, 3, 42, 0);      -- MP+3% is active when your current job level is even.
+INSERT INTO `item_latents` VALUES(16076, 3, 3, 38, 0);      -- HP+3% is active when your current job level is odd.
+INSERT INTO `item_latents` VALUES(16076, 6, 3, 38, 2);      -- MP+3% is active when your current job level is even.
 
 -- -------------------------------------------------------
 -- Mamool Ja Helm Latent Effect is active in Mamook, Arrapago Reef, and Halvung
@@ -2951,9 +2946,9 @@ INSERT INTO `item_latents` VALUES(18850, 366, 5, 6, 1000);  -- DMG+5 while TP <1
 -- -------------------------------------------------------
 -- Octave Club
 -- -------------------------------------------------------
--- TODO: Optimize latent_efffect_container.cpp to allow multiple divisors and have the rarer one take precedence over the other
--- INSERT INTO `item_latents` VALUES(18852, 977, 2, 42, 0); -- Occasionally attacks 2 times when mjob multiple of 2
-INSERT INTO `item_latents` VALUES(18852, 977, 8, 44, 0);    -- Occasionally attacks 2 to 8 times when mjob multiple of 8
+-- TODO: Optimize latent_efffect_container.cpp to allow a mod be overwritten with a higher value
+-- INSERT INTO `item_latents` VALUES(18852, 977, 2, 38, 2); -- Occasionally attacks 2 times when mjob multiple of 2
+INSERT INTO `item_latents` VALUES(18852, 977, 8, 38, 8);    -- Occasionally attacks 2 to 8 times when mjob multiple of 8
 
 -- -------------------------------------------------------
 -- Kerykeion

--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -2949,6 +2949,13 @@ INSERT INTO `item_latents` VALUES(18850, 25, 5, 6, 1000);   -- Accuracy+5 while 
 INSERT INTO `item_latents` VALUES(18850, 366, 5, 6, 1000);  -- DMG+5 while TP <100%
 
 -- -------------------------------------------------------
+-- Octave Club
+-- -------------------------------------------------------
+-- TODO: Optimize latent_efffect_container.cpp to allow multiple divisors and have the rarer one take precedence over the other
+-- INSERT INTO `item_latents` VALUES(18852, 977, 2, 42, 0); -- Occasionally attacks 2 times when mjob multiple of 2
+INSERT INTO `item_latents` VALUES(18852, 977, 8, 44, 0);    -- Occasionally attacks 2 to 8 times when mjob multiple of 8
+
+-- -------------------------------------------------------
 -- Kerykeion
 -- -------------------------------------------------------
 INSERT INTO `item_latents` VALUES(18859, 370, 3, 0, 50);    -- Regen+3 when HP <51%

--- a/src/map/attackround.cpp
+++ b/src/map/attackround.cpp
@@ -232,6 +232,13 @@ void CAttackRound::CreateAttacks(CItemWeapon* PWeapon, PHYSICAL_ATTACK_DIRECTION
         num = PWeapon->getHitCount();
     }
 
+    // Existance of "Occasionally attacks X times" overwrites PWeapon hit count
+    if (isPC && m_attacker->getMod(Mod::MAX_SWINGS))
+    {
+        auto modSwings = (uint8)static_cast<CCharEntity*>(m_attacker)->getMod(Mod::MAX_SWINGS);
+        num = battleutils::getHitCount(modSwings);
+    }
+
     // If the attacker is a mobentity or derived from mobentity, check to see if it has any special mutli-hit capabilties
     if (dynamic_cast<CMobEntity*>(m_attacker))
     {
@@ -241,20 +248,24 @@ void CAttackRound::CreateAttacks(CItemWeapon* PWeapon, PHYSICAL_ATTACK_DIRECTION
             num = 1 + battleutils::getHitCount(multiHitMax);
     }
 
-    AddAttackSwing(PHYSICAL_ATTACK_TYPE::NORMAL, direction, num);
-
     // Checking the players triple, double and quadruple attack
     int16 tripleAttack = m_attacker->getMod(Mod::TRIPLE_ATTACK);
     int16 doubleAttack = m_attacker->getMod(Mod::DOUBLE_ATTACK);
     int16 quadAttack = m_attacker->getMod(Mod::QUAD_ATTACK);
+    // Checking for Mythic Weapon Aftermath
+    int16 occAttThriceRate = std::clamp<int16>(m_attacker->getMod(Mod::MYTHIC_OCC_ATT_THRICE), 0, 100);
+    int16 occAttTwiceRate = std::clamp<int16>(m_attacker->getMod(Mod::MYTHIC_OCC_ATT_TWICE), 0, 100);
 
-    //check for merit upgrades
+    // Checking for merit upgrades
     if (isPC)
     {
         CCharEntity* PChar = (CCharEntity*)m_attacker;
 
-        //merit chance only applies if player has the job trait
-        if (charutils::hasTrait(PChar, TRAIT_TRIPLE_ATTACK)) tripleAttack += PChar->PMeritPoints->GetMeritValue(MERIT_TRIPLE_ATTACK_RATE, PChar);
+        // Merit chance only applies if player has the job trait
+        if (charutils::hasTrait(PChar, TRAIT_TRIPLE_ATTACK))
+        {
+            tripleAttack += PChar->PMeritPoints->GetMeritValue(MERIT_TRIPLE_ATTACK_RATE, PChar);
+        }
 
         // Ambush Augment adds +1% Triple Attack per merit (need to satisfy conditions for Ambush)
         if (charutils::hasTrait(PChar, TRAIT_AMBUSH) && PChar->getMod(Mod::AUGMENTS_AMBUSH) > 0 && abs(m_defender->loc.p.rotation - m_attacker->loc.p.rotation) < 23)
@@ -262,13 +273,19 @@ void CAttackRound::CreateAttacks(CItemWeapon* PWeapon, PHYSICAL_ATTACK_DIRECTION
             tripleAttack += PChar->PMeritPoints->GetMerit(MERIT_AMBUSH)->count;
         }
 
-        if (charutils::hasTrait(PChar, TRAIT_DOUBLE_ATTACK)) doubleAttack += PChar->PMeritPoints->GetMeritValue(MERIT_DOUBLE_ATTACK_RATE, PChar);
+        if (charutils::hasTrait(PChar, TRAIT_DOUBLE_ATTACK))
+        {
+            doubleAttack += PChar->PMeritPoints->GetMeritValue(MERIT_DOUBLE_ATTACK_RATE, PChar);
+        }
         // TODO: Quadruple attack merits when SE release them.
     }
-
     quadAttack = std::clamp<int16>(quadAttack, 0, 100);
     doubleAttack = std::clamp<int16>(doubleAttack, 0, 100);
     tripleAttack = std::clamp<int16>(tripleAttack, 0, 100);
+
+    // Preference matters! The following are additional hits to the default hit that don't stack up
+    // Mikage > Quad > Triple > Double > Mythic Aftermath > Occasionally Attacks > Dynamis [D] Follow-Up > Hasso + Zanshin
+    // Daken is handled separately in CreateDakenAttack() and Zanshin in src/map/entities/battleentity.cpp#L1768
 
     // Checking Mikage Effect - Hits Vary With Num of Utsusemi Shadows for Main Weapon
     if (m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_MIKAGE) && m_attacker->m_Weapons[SLOT_MAIN]->getID() == PWeapon->getID())
@@ -277,31 +294,49 @@ void CAttackRound::CreateAttacks(CItemWeapon* PWeapon, PHYSICAL_ATTACK_DIRECTION
         //ShowDebug(CL_CYAN"Create Attacks: Mikage Active, Rolling Attack Chance for %d Shadowss...\n" CL_RESET, shadows);
         AddAttackSwing(PHYSICAL_ATTACK_TYPE::NORMAL, direction, shadows);
     }
-    else if (num == 1 && tpzrand::GetRandomNumber(100) < quadAttack)
-        AddAttackSwing(PHYSICAL_ATTACK_TYPE::QUAD, direction, 3);
-
-    else if (num == 1 && tpzrand::GetRandomNumber(100) < tripleAttack)
-        AddAttackSwing(PHYSICAL_ATTACK_TYPE::TRIPLE, direction, 2);
-
-    else if (num == 1 && tpzrand::GetRandomNumber(100) < doubleAttack)
-        AddAttackSwing(PHYSICAL_ATTACK_TYPE::DOUBLE, direction, 1);
-
-    // Apply Mythic OAT mods (mainhand only)
-    if (direction == PHYSICAL_ATTACK_DIRECTION::RIGHTATTACK)
+    // Quad/Triple/Double Attack
+    else if (tpzrand::GetRandomNumber(100) < quadAttack)
     {
-        int16 occAttThriceRate = std::clamp<int16>(m_attacker->getMod(Mod::MYTHIC_OCC_ATT_THRICE), 0, 100);
-        int16 occAttTwiceRate = std::clamp<int16>(m_attacker->getMod(Mod::MYTHIC_OCC_ATT_TWICE), 0, 100);
-        if (num == 1 && tpzrand::GetRandomNumber(100) < occAttThriceRate)
-        {
-            AddAttackSwing(PHYSICAL_ATTACK_TYPE::NORMAL, direction, 2);
-        }
-        else if (num == 1 && tpzrand::GetRandomNumber(100) < occAttTwiceRate)
-        {
-            AddAttackSwing(PHYSICAL_ATTACK_TYPE::NORMAL, direction, 1);
-        }
+        AddAttackSwing(PHYSICAL_ATTACK_TYPE::QUAD, direction, 3);
+    }
+    else if (tpzrand::GetRandomNumber(100) < tripleAttack)
+    {
+        AddAttackSwing(PHYSICAL_ATTACK_TYPE::TRIPLE, direction, 2);
+    }
+    else if (tpzrand::GetRandomNumber(100) < doubleAttack)
+    {
+        AddAttackSwing(PHYSICAL_ATTACK_TYPE::DOUBLE, direction, 1);
+    }
+    // Mythic Weapons Aftermath, only main hand
+    else if (direction == PHYSICAL_ATTACK_DIRECTION::RIGHTATTACK && tpzrand::GetRandomNumber(100) < occAttThriceRate)
+    {
+        AddAttackSwing(PHYSICAL_ATTACK_TYPE::NORMAL, direction, 2);
+    }
+    else if (direction == PHYSICAL_ATTACK_DIRECTION::RIGHTATTACK && tpzrand::GetRandomNumber(100) < occAttTwiceRate)
+    {
+        AddAttackSwing(PHYSICAL_ATTACK_TYPE::NORMAL, direction, 1);
+    }
+    // Iga Garb +2 Set augment: possibility to add another swing while using Dual Wield
+    // TODO: Double check correct priority for Empyrian armor modifiers? Outsource? Lua function?
+    else if (direction == LEFTATTACK && tpzrand::GetRandomNumber(100) < m_attacker->getMod(Mod::EXTRA_DUAL_WIELD_ATTACK))
+    {
+        AddAttackSwing(PHYSICAL_ATTACK_TYPE::NORMAL, RIGHTATTACK, 1);
+    }
+    // "Occasionally attacks X times" and regular multiple hits
+    else if (num > 1)
+    {
+        // Deduct the final default hit!
+        AddAttackSwing(PHYSICAL_ATTACK_TYPE::NORMAL, direction, (num - 1));
+    }
+    // TODO: Dynamis [D] weapons Follow-Up attack chance
+
+    // Additional swing modifier (stacks!), mostly for Amood weapons
+    if (isPC && tpzrand::GetRandomNumber(100) < m_attacker->getMod(Mod::ADDITIONAL_SWING_CHANCE))
+    {
+        AddAttackSwing(PHYSICAL_ATTACK_TYPE::NORMAL, direction, 1);
     }
 
-    // Ammo extra swing - players only
+    // Ammunition provoked additional swing (stacks!), mostly for Virtue Stone weapons
     if (isPC && m_attacker->getMod(Mod::AMMO_SWING) > 0)
     {
         // Check for ammo
@@ -313,13 +348,14 @@ void CAttackRound::CreateAttacks(CItemWeapon* PWeapon, PHYSICAL_ATTACK_DIRECTION
         uint8 loc = PChar->equipLoc[SLOT_AMMO];
         uint8 ammoCount = 0;
 
-        // Handedness check, checking mod of the weapon for the purposes of level scaling
+        // Two handed and Hand-to-Hand
         if (battleutils::GetScaledItemModifier(PChar, PMain, Mod::AMMO_SWING_TYPE) == 2 &&
             tpzrand::GetRandomNumber(100) < m_attacker->getMod(Mod::AMMO_SWING) && PAmmo != nullptr && ammoCount < PAmmo->getQuantity())
         {
             AddAttackSwing(PHYSICAL_ATTACK_TYPE::NORMAL, direction, 1);
             ammoCount += 1;
         }
+        // One handed
         else
         {
             if (direction == RIGHTATTACK && battleutils::GetScaledItemModifier(PChar, PMain, Mod::AMMO_SWING_TYPE) == 1 &&
@@ -336,6 +372,7 @@ void CAttackRound::CreateAttacks(CItemWeapon* PWeapon, PHYSICAL_ATTACK_DIRECTION
             }
         }
 
+        // Deduct ammo
         if (PAmmo != nullptr)
         {
             if (PAmmo->getQuantity() == ammoCount)
@@ -348,13 +385,8 @@ void CAttackRound::CreateAttacks(CItemWeapon* PWeapon, PHYSICAL_ATTACK_DIRECTION
         }
     }
 
-
-    // TODO: Possible Lua function for the nitty gritty stuff below.
-
-    // Iga mod: Extra attack chance whilst dual wield is on.
-    if (direction == LEFTATTACK && tpzrand::GetRandomNumber(100) < m_attacker->getMod(Mod::EXTRA_DUAL_WIELD_ATTACK))
-        AddAttackSwing(PHYSICAL_ATTACK_TYPE::NORMAL, RIGHTATTACK, 1);
-
+    // Default hit
+    AddAttackSwing(PHYSICAL_ATTACK_TYPE::NORMAL, direction, 1);
 }
 
 /************************************************************************

--- a/src/map/attackround.cpp
+++ b/src/map/attackround.cpp
@@ -235,7 +235,7 @@ void CAttackRound::CreateAttacks(CItemWeapon* PWeapon, PHYSICAL_ATTACK_DIRECTION
     // Existance of "Occasionally attacks X times" overwrites PWeapon hit count
     if (isPC && m_attacker->getMod(Mod::MAX_SWINGS))
     {
-        auto modSwings = (uint8)static_cast<CCharEntity*>(m_attacker)->getMod(Mod::MAX_SWINGS);
+        auto modSwings = std::min<uint8>((uint8)static_cast<CCharEntity*>(m_attacker)->getMod(Mod::MAX_SWINGS),8);
         num = battleutils::getHitCount(modSwings);
     }
 

--- a/src/map/latent_effect.h
+++ b/src/map/latent_effect.h
@@ -71,7 +71,7 @@ enum LATENT
     LATENT_JOB_LEVEL_ODD            = 41,
     LATENT_JOB_LEVEL_EVEN           = 42,
     LATENT_WEAPON_DRAWN_HP_UNDER    = 43, //PARAM: HP PERCENT
-    //                              = 44  //Unused
+    LATENT_JOB_MULTIPLE_8           = 44,
     LATENT_MP_UNDER_VISIBLE_GEAR    = 45, //mp less than or equal to %, calculated using MP bonuses from visible gear only
     LATENT_HP_OVER_VISIBLE_GEAR     = 46, //hp more than or equal to %, calculated using HP bonuses from visible gear only
     LATENT_WEAPON_BROKEN            = 47,

--- a/src/map/latent_effect.h
+++ b/src/map/latent_effect.h
@@ -65,13 +65,13 @@ enum LATENT
     LATENT_LIGHTNINGSDAY            = 35,
     LATENT_LIGHTSDAY                = 36,
     LATENT_MOON_PHASE               = 37, //PARAM: 0: New Moon, 1: Waxing Crescent, 2: First Quarter, 3: Waxing Gibbous, 4: Full Moon, 5: Waning Gibbous, 6: Last Quarter, 7: Waning Crescent
-    LATENT_JOB_MULTIPLE_5           = 38,
-    LATENT_JOB_MULTIPLE_10          = 39,
-    LATENT_JOB_MULTIPLE_13_NIGHT    = 40,
-    LATENT_JOB_LEVEL_ODD            = 41,
-    LATENT_JOB_LEVEL_EVEN           = 42,
+    LATENT_JOB_MULTIPLE             = 38, //PARAM: 0: ODD, 2: EVEN, 3-X: DIVISOR
+    LATENT_JOB_MULTIPLE_AT_NIGHT    = 39, //PARAM: 0: ODD, 2: EVEN, 3-X: DIVISOR
+    // 40 free to use
+    // 41 free to use
+    // 42 free to use
     LATENT_WEAPON_DRAWN_HP_UNDER    = 43, //PARAM: HP PERCENT
-    LATENT_JOB_MULTIPLE_8           = 44,
+    // 44 free to use
     LATENT_MP_UNDER_VISIBLE_GEAR    = 45, //mp less than or equal to %, calculated using MP bonuses from visible gear only
     LATENT_HP_OVER_VISIBLE_GEAR     = 46, //hp more than or equal to %, calculated using HP bonuses from visible gear only
     LATENT_WEAPON_BROKEN            = 47,

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -531,14 +531,8 @@ void CLatentEffectContainer::CheckLatentsJobLevel()
     {
         switch (latentEffect.GetConditionsID())
         {
-        case LATENT_JOB_LEVEL_EVEN:
-        case LATENT_JOB_LEVEL_ODD:
-        case LATENT_JOB_MULTIPLE_5:
-        case LATENT_JOB_MULTIPLE_8:
-        case LATENT_JOB_MULTIPLE_10:
-        case LATENT_JOB_MULTIPLE_13_NIGHT:
-        case LATENT_JOB_LEVEL_BELOW:
-        case LATENT_JOB_LEVEL_ABOVE:
+        case LATENT_JOB_MULTIPLE:
+        case LATENT_JOB_MULTIPLE_AT_NIGHT:
             return ProcessLatentEffect(latentEffect);
             break;
         default:
@@ -947,23 +941,20 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
         }
         break;
     }
-    case LATENT_JOB_MULTIPLE_5:
-        expression = m_POwner->GetMLevel() % 5 == 0;
+    case LATENT_JOB_MULTIPLE:
+        // Check if level is odd
+        if (latentEffect.GetConditionsValue() == 0)
+        {
+            expression = m_POwner->GetMLevel() % 2 == 1;
+        }
+        // Check if level is multiple of divisor
+        else {
+            expression = m_POwner->GetMLevel() % latentEffect.GetConditionsValue() == 0;
+        }
         break;
-    case LATENT_JOB_MULTIPLE_8:
-        expression = m_POwner->GetMLevel() % 8 == 0;
-        break;
-    case LATENT_JOB_MULTIPLE_10:
-        expression = m_POwner->GetMLevel() % 10 == 0;
-        break;
-    case LATENT_JOB_MULTIPLE_13_NIGHT:
-        expression = m_POwner->GetMLevel() % 13 == 0 && CVanaTime::getInstance()->SyncTime() == TIME_NIGHT;
-        break;
-    case LATENT_JOB_LEVEL_ODD:
-        expression = m_POwner->GetMLevel() % 2 == 1;
-        break;
-    case LATENT_JOB_LEVEL_EVEN:
-        expression = m_POwner->GetMLevel() % 2 == 0;
+    case LATENT_JOB_MULTIPLE_AT_NIGHT:
+        expression = m_POwner->GetMLevel() % latentEffect.GetConditionsValue() == 0 &&
+            CVanaTime::getInstance()->SyncTime() == TIME_NIGHT;
         break;
     case LATENT_WEAPON_DRAWN_HP_UNDER:
         expression = m_POwner->health.hp < latentEffect.GetConditionsValue() && m_POwner->animation == ANIMATION_ATTACK;

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -534,6 +534,7 @@ void CLatentEffectContainer::CheckLatentsJobLevel()
         case LATENT_JOB_LEVEL_EVEN:
         case LATENT_JOB_LEVEL_ODD:
         case LATENT_JOB_MULTIPLE_5:
+        case LATENT_JOB_MULTIPLE_8:
         case LATENT_JOB_MULTIPLE_10:
         case LATENT_JOB_MULTIPLE_13_NIGHT:
         case LATENT_JOB_LEVEL_BELOW:
@@ -948,6 +949,9 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
     }
     case LATENT_JOB_MULTIPLE_5:
         expression = m_POwner->GetMLevel() % 5 == 0;
+        break;
+    case LATENT_JOB_MULTIPLE_8:
+        expression = m_POwner->GetMLevel() % 8 == 0;
         break;
     case LATENT_JOB_MULTIPLE_10:
         expression = m_POwner->GetMLevel() % 10 == 0;

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -948,13 +948,22 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
             expression = m_POwner->GetMLevel() % 2 == 1;
         }
         // Check if level is multiple of divisor
-        else {
+        else
+        {
             expression = m_POwner->GetMLevel() % latentEffect.GetConditionsValue() == 0;
         }
         break;
     case LATENT_JOB_MULTIPLE_AT_NIGHT:
-        expression = m_POwner->GetMLevel() % latentEffect.GetConditionsValue() == 0 &&
-            CVanaTime::getInstance()->SyncTime() == TIME_NIGHT;
+        if (latentEffect.GetConditionsValue() == 0)
+        {
+            expression = m_POwner->GetMLevel() % 2 == 1 &&
+                CVanaTime::getInstance()->SyncTime() == TIME_NIGHT;
+        }
+        else
+        {
+            expression = m_POwner->GetMLevel() % latentEffect.GetConditionsValue() == 0 &&
+                CVanaTime::getInstance()->SyncTime() == TIME_NIGHT;
+        }
         break;
     case LATENT_WEAPON_DRAWN_HP_UNDER:
         expression = m_POwner->health.hp < latentEffect.GetConditionsValue() && m_POwner->animation == ANIMATION_ATTACK;

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -232,6 +232,8 @@ enum class Mod
     MARTIAL_ARTS              = 173, // The integer amount of delay to reduce from H2H weapons' base delay. (TRAIT)
     SKILLCHAINBONUS           = 174, // Damage bonus applied to skill chain damage.  Modifier from effects/traits
     SKILLCHAINDMG             = 175, // Damage bonus applied to skill chain damage.  Modifier from gear (multiplicative after effect/traits)
+    MAX_SWINGS                = 977, // Max swings for "Occasionally attacks X times"
+    ADDITIONAL_SWING_CHANCE   = 978, // Chance that allows for an additional swing despite of multiple hits, mostly for Amood weapons
 
     MAGIC_DAMAGE             = 311, // Magic damage added directly to the spell's base damage
 
@@ -811,9 +813,9 @@ enum class Mod
 
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     // 570 through 825 used by WS DMG mods these are not spares.
-    // SPARE = 977, // stuff
-    // SPARE = 978, // stuff
     // SPARE = 979, // stuff
+    // SPARE = 980, // stuff
+    // SPARE = 981, // stuff
 };
 
 //temporary workaround for using enum class as unordered_map key until compilers support it

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -232,8 +232,8 @@ enum class Mod
     MARTIAL_ARTS              = 173, // The integer amount of delay to reduce from H2H weapons' base delay. (TRAIT)
     SKILLCHAINBONUS           = 174, // Damage bonus applied to skill chain damage.  Modifier from effects/traits
     SKILLCHAINDMG             = 175, // Damage bonus applied to skill chain damage.  Modifier from gear (multiplicative after effect/traits)
-    MAX_SWINGS                = 977, // Max swings for "Occasionally attacks X times"
-    ADDITIONAL_SWING_CHANCE   = 978, // Chance that allows for an additional swing despite of multiple hits, mostly for Amood weapons
+    MAX_SWINGS                = 978, // Max swings for "Occasionally attacks X times"
+    ADDITIONAL_SWING_CHANCE   = 979, // Chance that allows for an additional swing despite of multiple hits, mostly for Amood weapons
 
     MAGIC_DAMAGE             = 311, // Magic damage added directly to the spell's base damage
 
@@ -813,9 +813,9 @@ enum class Mod
 
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     // 570 through 825 used by WS DMG mods these are not spares.
-    // SPARE = 979, // stuff
     // SPARE = 980, // stuff
     // SPARE = 981, // stuff
+    // SPARE = 982, // stuff
 };
 
 //temporary workaround for using enum class as unordered_map key until compilers support it


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

This PR seeks to add:
• a **latent** of name **`JOB_MULTIPLE_8`** for weapons that trigger an effect while the players job is a multiple of 8 _(Octave Club)_
• a **modifier** of name **`ADDITIONAL_SWING_CHANCE`** for weapons that can trigger an additional attack *on top of* other multiple hits like Double Attack as a latent.
• a **modifier** of name **`MAX_SWINGS`** for weapons that increase their hitCount while under a latent effect.
• the latent database entry for Octave Club

As a consequence of this, this PR also had to:
• create conditions for the additional swings in `CAttackRound::CreateAttacks()`
• slightly restructure the conditions of additional swings and how they block each other in that same function
• See 4ea931fc3cf1e8db9e73e5982d087af1bee47341
(Mythic Aftermath was not blocked behind Quad/Triple/Double Attack and latent modifiers for OAT not considered)

In Detail:
• If `MAX_SWINGS` exists (should pretty much only be flagged by a latent) it will overwrite the hitCount of that weapon from the database
• The default swing now functions as a fallback after all else is considered. This improves recognition of priorities
• Quad/Triple/Double attack got their num check removed, they should be rolled in any case, also when a weapon or monster can attack several times. It is the top most priority and does not stack with regular multiple hits or mythic modifiers
• Triple/Double attack from Mythic weapons gets rolled after this if Aftermath is in effect
• Equipment modifiers from Empyrian armor is then considered
• Only if any of these fail will a weapon or monster use regular multiple hits
• In preparation for Amood Great Axes a modifier and a condition has been added especially for these, since they do indeed stack
• After all these considerations, ammo triggered additional swings from weapons like the Jailer weapons are considered, the check itself has not been changed
• All of the above are possible *additional swings*, care has been taken to make sure they can not stack up to more than 8 hits
• At the very end a default hit will always occur

This makes implementation of most weapons that increase their hitCount with a latent or some other effect now possible and secure with these mods. (Although there are extremely few to begin with)

I tested this successfully with the following setups and it works as expected.
• RDM99/PLD49
Regular Weapon: one hit
Joyeuse: occ. 2-3 hits
Kraken Club: occ. 2-8 hits
Octave Club: one hit
• RDM96/PLD48
Octave Club: occ. 2-8 hits
• WAR99/PLD49
Regular Weapon: occ. Double Attack
Joyeuse: occ. 2-3 hits with more 2's than 3's
Kraken Club: occ. 2-8 hits with a few more 2' than others
Octave Club: occ. Double Attack
• THF99/PLD49
All of the above in the same manner but with triple attack
Justice Sword + Virtue Stones: Successfully triggers an additional hit even on top of Triple Attack, making it 4 hits
Vajra + 3000TP Aftermath: occ. 2-3 hits with frequent 2's
• SAM99/PLD49
Hardwood Katana + Zanshin: occ. hits again after missing
_(Zanshin is not a member of the function in question but I wanted to be sure it works)_
Hardwood Katana + Virtue Stone: stones won't get accidentally get used
Hardwood Katana + Zanshin + Triple/Double Attack equip: Zanshin swing stacks

Things I did not implement or I could not figure out but should not be part of this PR:
• Empyrian armor modifiers have various effects on attack swings but there is little people talking about whether it stacks or not
(for now I think it is sensible to treat the Iga Garb condition that was there as if it was a roll on Double Attack)
• Somebody before me who implemented this condition mentioned something about creating a lua function, but it was not very clear what "nitty gritty stuff" refers to. I suppose its the idea of outsourcing these?
• I did not implement the missing condition for Dynamis [D] Follow-Up attack chances
• Octave Club is probably the only item in the game (?) that checks on two different lvl multipliers at the same time. This simply interferes with how the according latent switch statements are written and neither will flag in that condition.
(for now comment the multiplier of 2 out)

I'm well aware that this messes with one of the most basic mechanics of the game. Please take the time to read what I wrote as carefully as I wrote and tested this PR. Much appreciated.