### PR TITLE
Reset Activate recast when using Deactivate at full Auto HP

### DIFF
--- a/scripts/globals/abilities/deactivate.lua
+++ b/scripts/globals/abilities/deactivate.lua
@@ -14,5 +14,10 @@ function onAbilityCheck(player, target, ability)
 end
 
 function onUseAbility(player, target, ability)
+    -- Reset the Activate ability.
+    local pet = player:getPet()
+    if pet:getHP() == pet:getMaxHP() then
+        player:resetRecast(tpz.recast.ABILITY, 205) -- activate
+    end
     target:despawnPet()
 end


### PR DESCRIPTION
Deactivate is supposed to reset the recast timer for Activate when the Automaton's HP is full. Simple copypasta of method we're using for DRG's Dismiss under same conditions.

https://www.bg-wiki.com/bg/Deactivate

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

