### PR TITLE
CI: Add support for SonarCloud analysis

### DIFF
--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -1,0 +1,62 @@
+name: analyse
+
+on:
+  schedule:
+      # Once a day at midnight
+      - cron:  '0 0 * * *' 
+
+jobs:
+  sonarcloud:
+    name: "SonarCloud Scan"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Install Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y software-properties-common wget cmake libmariadb-dev-compat libluajit-5.1-dev libzmq3-dev zlib1g-dev libssl-dev
+    
+    - name: Configure CMake
+      run: |
+        cmake .
+        
+    - name: Download Sonar Build Wrapper
+      run: |
+        wget -c https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip
+        unzip build-wrapper-linux-x86.zip
+        cp ./build-wrapper-linux-x86/* ./
+    
+    - name: Build Wrapped Binaries
+      run: |
+        ./build-wrapper-linux-x86-64 --out-dir . make -j $(nproc)
+        
+    - name: Extract git info
+      run: |
+        GIT_TAG=`git describe --abbrev=0`
+        echo "GIT_TAG=${GIT_TAG}" >> $GITHUB_ENV
+        echo $GIT_TAG
+        
+        GIT_BRANCH=`git branch --show-current`
+        echo "GIT_BRANCH=${GIT_BRANCH}" >> $GITHUB_ENV
+        echo $GIT_BRANCH
+    - name: Setup Sonar
+      uses: warchant/setup-sonar-scanner@v3
+      
+    - name: Run Sonar Scanner
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: sonar-scanner
+           -Dsonar.login=${{ secrets.SONAR_TOKEN }}
+           -Dsonar.organization=project-topaz
+           -Dsonar.projectKey=topaz
+           -Dsonar.branch.name=${{ env.GIT_BRANCH }}
+           -Dsonar.projectVersion=${{ env.GIT_TAG }}
+           -Dsonar.host.url=https://sonarcloud.io/
+           -Dsonar.sources=src
+           -Dsonar.exclusions=src/common/detour/**/*,src/common/fmt/**/*,src/common/lua/**/*,src/common/recast/**/*
+           -Dsonar.cfamily.build-wrapper-output=.
+           -Dsonar.cfamily.threads=2
+           -Dsonar.cfamily.cache.enabled=false


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Next up in my unrelenting march to turn this mess into a corporate code utopia. 
I've been testing this on my fork, it works very nicely and is FREEEEEEEEEE.

There _is_ support for running this on PRs and having Sonar leave comments telling you about your changes, but I feel like a robot telling you your code is trash would be demoralising to newcomers.

Currently runs once a day at midnight

**TODO**
- Make SonarCloud account for topaz
- Add `${{ secrets.SONAR_TOKEN }}` to repo

