### PR TITLE
Add introductory dialogues for the Dynamis currency goblins

### DIFF
--- a/scripts/globals/dynamis.lua
+++ b/scripts/globals/dynamis.lua
@@ -335,7 +335,7 @@ dynamis.entryNpcOnEventFinish = function(player, csid, option)
         npcUtil.giveKeyItem(player, tpz.ki.VIAL_OF_SHROUDED_SAND)
         player:setCharVar("Dynamis_Status", utils.mask.setBit(mask, 0, false))
         -- flag to make any currency goblin introduce prismatic hourglass
-        player:setCharVar("currencyGoblinIntro", utils.mask.setBit(introMask, 0, true))
+        player:setCharVar("currencyGoblinIntro", utils.mask.setBit(player:getCharVar("currencyGoblinIntro"), 0, true))
 
     -- first visit cutscene
     elseif info.csFirst and csid == info.csFirst then

--- a/scripts/globals/dynamis.lua
+++ b/scripts/globals/dynamis.lua
@@ -334,6 +334,8 @@ dynamis.entryNpcOnEventFinish = function(player, csid, option)
     if info.csSand and csid == info.csSand then
         npcUtil.giveKeyItem(player, tpz.ki.VIAL_OF_SHROUDED_SAND)
         player:setCharVar("Dynamis_Status", utils.mask.setBit(mask, 0, false))
+        -- flag to make any currency goblin introduce prismatic hourglass
+        player:setCharVar("currencyGoblinIntro", utils.mask.setBit(introMask, 0, true))
 
     -- first visit cutscene
     elseif info.csFirst and csid == info.csFirst then

--- a/scripts/zones/Beadeaux/npcs/Haggleblix.lua
+++ b/scripts/zones/Beadeaux/npcs/Haggleblix.lua
@@ -146,11 +146,10 @@ function onEventFinish(player, csid, option)
         player:setCharVar("currencyGoblinIntro", utils.mask.setBit(introMask, 4, true))
 
     elseif csid == 132 then
+        player:setCharVar("currencyGoblinIntro", utils.mask.setBit(introMask, 3, true))
         -- remove if this was the last of the three goblins that introduced currency
-        if utils.mask.getBit(introMask, 1) and utils.mask.getBit(introMask, 2) then
+        if utils.mask.isFull(player:getCharVar("currencyGoblinIntro"), 5) then
             player:setCharVar("currencyGoblinIntro", 0)
-        else
-            player:setCharVar("currencyGoblinIntro", utils.mask.setBit(introMask, 3, true))
         end
 
     -- bought prismatic hourglass

--- a/scripts/zones/Beadeaux/npcs/Haggleblix.lua
+++ b/scripts/zones/Beadeaux/npcs/Haggleblix.lua
@@ -38,22 +38,22 @@ function onTrade(player, npc, trade)
     local gil = trade:getGil()
     local count = trade:getItemCount()
 
-    if (player:hasKeyItem(tpz.ki.VIAL_OF_SHROUDED_SAND)) then
+    if player:hasKeyItem(tpz.ki.VIAL_OF_SHROUDED_SAND) then
 
         -- buy prismatic hourglass
-        if (gil == PRISMATIC_HOURGLASS_COST and count == 1 and not player:hasKeyItem(tpz.ki.PRISMATIC_HOURGLASS)) then
+        if gil == PRISMATIC_HOURGLASS_COST and count == 1 and not player:hasKeyItem(tpz.ki.PRISMATIC_HOURGLASS) then
             player:startEvent(134)
 
         -- return timeless hourglass for refund
-        elseif (count == 1 and trade:hasItemQty(TIMELESS_HOURGLASS, 1)) then
+        elseif count == 1 and trade:hasItemQty(TIMELESS_HOURGLASS, 1) then
             player:startEvent(153)
 
         -- currency exchanges
-        elseif (count == CURRENCY_EXCHANGE_RATE and trade:hasItemQty(currency[1], CURRENCY_EXCHANGE_RATE)) then
+        elseif count == CURRENCY_EXCHANGE_RATE and trade:hasItemQty(currency[1], CURRENCY_EXCHANGE_RATE) then
             player:startEvent(135, CURRENCY_EXCHANGE_RATE)
-        elseif (count == CURRENCY_EXCHANGE_RATE and trade:hasItemQty(currency[2], CURRENCY_EXCHANGE_RATE)) then
+        elseif count == CURRENCY_EXCHANGE_RATE and trade:hasItemQty(currency[2], CURRENCY_EXCHANGE_RATE) then
             player:startEvent(136, CURRENCY_EXCHANGE_RATE)
-        elseif (count == 1 and trade:hasItemQty(currency[3], 1)) then
+        elseif count == 1 and trade:hasItemQty(currency[3], 1) then
             player:startEvent(138, currency[3], currency[2], CURRENCY_EXCHANGE_RATE)
 
         -- shop
@@ -63,7 +63,7 @@ function onTrade(player, npc, trade)
             for i=1, 13, 2 do
                 price = shop[i]
                 item = shop[i+1]
-                if (count == price and trade:hasItemQty(currency[2], price)) then
+                if count == price and trade:hasItemQty(currency[2], price) then
                     player:setLocalVar("hundoItemBought", item)
                     player:startEvent(137, currency[2], price, item)
                     break
@@ -75,41 +75,57 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-    if (player:hasKeyItem(tpz.ki.VIAL_OF_SHROUDED_SAND)) then
+    local introMask = player:getCharVar("currencyGoblinIntro")
+    
+    -- Introduces the Prismatic Hourglass
+    if utils.mask.getBit(introMask, 0) and not utils.mask.getBit(introMask, 4) then
+        player:startEvent(131, TIMELESS_HOURGLASS, TIMELESS_HOURGLASS_COST, tpz.ki.PRISMATIC_HOURGLASS, PRISMATIC_HOURGLASS_COST)
+
+    -- Introduces Currency
+    elseif utils.mask.getBit(introMask, 4) and not utils.mask.getBit(introMask, 3) then
+        player:startEvent(132, currency[1], CURRENCY_EXCHANGE_RATE, currency[2], CURRENCY_EXCHANGE_RATE, currency[3], currency[3], CURRENCY_EXCHANGE_RATE, currency[2])
+
+    elseif player:hasKeyItem(tpz.ki.VIAL_OF_SHROUDED_SAND) then
         player:startEvent(133, currency[1], CURRENCY_EXCHANGE_RATE, currency[2], CURRENCY_EXCHANGE_RATE, currency[3], PRISMATIC_HOURGLASS_COST, TIMELESS_HOURGLASS, TIMELESS_HOURGLASS_COST)
+    
     else
         player:startEvent(130)
     end
 end
 
 function onEventUpdate(player, csid, option)
-    if (csid == 133) then
+
+    -- currency gets re-ordered in introduction
+    if csid == 132 then
+        player:updateEvent(currency[3], currency[2], CURRENCY_EXCHANGE_RATE)
+
+    elseif csid == 133 then
 
         -- asking about hourglasses
-        if (option == 1) then
-            if (not player:hasItem(TIMELESS_HOURGLASS)) then
-                -- must figure out what changes here to prevent the additional dialog
+        if option == 1 then
+            if not player:hasItem(TIMELESS_HOURGLASS) then
+                -- TODO: must figure out what changes here to prevent the additional dialog
                 -- player:updateEvent(?)
             end
 
         -- shop
-        elseif (option == 2) then
+        elseif option == 2 then
             player:updateEvent(unpack(shop, 1, 8))
-        elseif (option == 3) then
+        elseif option == 3 then
             player:updateEvent(unpack(shop, 9, 14))
 
         -- offer to trade down from a 10k
-        elseif (option == 10) then
+        elseif option == 10 then
             player:updateEvent(currency[3], currency[2], CURRENCY_EXCHANGE_RATE)
 
         -- main menu (param1 = dynamis map bitmask, param2 = gil)
-        elseif (option == 11) then
+        elseif option == 11 then
             player:updateEvent(getDynamisMapList(player), player:getGil())
 
         -- maps
-        elseif (maps[option] ~= nil) then
+        elseif maps[option] ~= nil then
             local price = maps[option]
-            if (price > player:getGil()) then
+            if price > player:getGil() then
                 player:messageSpecial(ID.text.NOT_ENOUGH_GIL)
             else
                 player:delGil(price)
@@ -123,22 +139,37 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
+    local introMask = player:getCharVar("currencyGoblinIntro")
+
+    if csid == 131 then
+        -- make prismatic hourglass introduction unavailable to the other goblins
+        player:setCharVar("currencyGoblinIntro", utils.mask.setBit(introMask, 4, true))
+
+    elseif csid == 132 then
+        -- remove if this was the last of the three goblins that introduced currency
+        if utils.mask.getBit(introMask, 1) and utils.mask.getBit(introMask, 2) then
+            player:setCharVar("currencyGoblinIntro", 0)
+        else
+            player:setCharVar("currencyGoblinIntro", utils.mask.setBit(introMask, 3, true))
+        end
 
     -- bought prismatic hourglass
-    if (csid == 134) then
+    elseif csid == 134 then
         player:tradeComplete()
         player:addKeyItem(tpz.ki.PRISMATIC_HOURGLASS)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.PRISMATIC_HOURGLASS)
+        -- player may trade right away before introduction, make sure this gets set
+        player:setCharVar("currencyGoblinIntro", utils.mask.setBit(introMask, 4, true))
 
     -- refund timeless hourglass
-    elseif (csid == 153) then
+    elseif csid == 153 then
         player:tradeComplete()
         player:addGil(TIMELESS_HOURGLASS_COST)
         player:messageSpecial(ID.text.GIL_OBTAINED, TIMELESS_HOURGLASS_COST)
 
     -- singles to hundos
-    elseif (csid == 135) then
-        if (player:getFreeSlotsCount() == 0) then
+    elseif csid == 135 then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, currency[2])
         else
             player:tradeComplete()
@@ -147,8 +178,8 @@ function onEventFinish(player, csid, option)
         end
 
     -- hundos to 10k pieces
-    elseif (csid == 136) then
-        if (player:getFreeSlotsCount() == 0) then
+    elseif csid == 136 then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, currency[3])
         else
             player:tradeComplete()
@@ -157,14 +188,14 @@ function onEventFinish(player, csid, option)
         end
 
     -- 10k pieces to hundos
-    elseif (csid == 138) then
+    elseif csid == 138 then
         local slotsReq = math.ceil(CURRENCY_EXCHANGE_RATE / 99)
-        if (player:getFreeSlotsCount() < slotsReq) then
+        if player:getFreeSlotsCount() < slotsReq then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, currency[2])
         else
             player:tradeComplete()
             for i=1, slotsReq do
-                if (i < slotsReq or (CURRENCY_EXCHANGE_RATE % 99) == 0) then
+                if i < slotsReq or (CURRENCY_EXCHANGE_RATE % 99) == 0 then
                     player:addItem(currency[2], CURRENCY_EXCHANGE_RATE)
                 else
                     player:addItem(currency[2], CURRENCY_EXCHANGE_RATE % 99)
@@ -174,9 +205,9 @@ function onEventFinish(player, csid, option)
         end
 
     -- bought item from shop
-    elseif (csid == 137) then
+    elseif csid == 137 then
         local item = player:getLocalVar("hundoItemBought")
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, item)
         else
             player:tradeComplete()

--- a/scripts/zones/Castle_Oztroja/npcs/Antiqix.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/Antiqix.lua
@@ -38,22 +38,22 @@ function onTrade(player, npc, trade)
     local gil = trade:getGil()
     local count = trade:getItemCount()
 
-    if (player:hasKeyItem(tpz.ki.VIAL_OF_SHROUDED_SAND)) then
+    if player:hasKeyItem(tpz.ki.VIAL_OF_SHROUDED_SAND) then
 
         -- buy prismatic hourglass
-        if (gil == PRISMATIC_HOURGLASS_COST and count == 1 and not player:hasKeyItem(tpz.ki.PRISMATIC_HOURGLASS)) then
+        if gil == PRISMATIC_HOURGLASS_COST and count == 1 and not player:hasKeyItem(tpz.ki.PRISMATIC_HOURGLASS) then
             player:startEvent(54)
 
         -- return timeless hourglass for refund
-        elseif (count == 1 and trade:hasItemQty(TIMELESS_HOURGLASS, 1)) then
+        elseif count == 1 and trade:hasItemQty(TIMELESS_HOURGLASS, 1) then
             player:startEvent(97)
 
         -- currency exchanges
-        elseif (count == CURRENCY_EXCHANGE_RATE and trade:hasItemQty(currency[1], CURRENCY_EXCHANGE_RATE)) then
+        elseif count == CURRENCY_EXCHANGE_RATE and trade:hasItemQty(currency[1], CURRENCY_EXCHANGE_RATE) then
             player:startEvent(55, CURRENCY_EXCHANGE_RATE)
-        elseif (count == CURRENCY_EXCHANGE_RATE and trade:hasItemQty(currency[2], CURRENCY_EXCHANGE_RATE)) then
+        elseif count == CURRENCY_EXCHANGE_RATE and trade:hasItemQty(currency[2], CURRENCY_EXCHANGE_RATE) then
             player:startEvent(56, CURRENCY_EXCHANGE_RATE)
-        elseif (count == 1 and trade:hasItemQty(currency[3], 1)) then
+        elseif count == 1 and trade:hasItemQty(currency[3], 1) then
             player:startEvent(58, currency[3], currency[2], CURRENCY_EXCHANGE_RATE)
 
         -- shop
@@ -63,7 +63,7 @@ function onTrade(player, npc, trade)
             for i=1, 13, 2 do
                 price = shop[i]
                 item = shop[i+1]
-                if (count == price and trade:hasItemQty(currency[2], price)) then
+                if count == price and trade:hasItemQty(currency[2], price) then
                     player:setLocalVar("hundoItemBought", item)
                     player:startEvent(57, currency[2], price, item)
                     break
@@ -75,41 +75,57 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-    if (player:hasKeyItem(tpz.ki.VIAL_OF_SHROUDED_SAND)) then
+    local introMask = player:getCharVar("currencyGoblinIntro")
+    
+    -- Introduces the Prismatic Hourglass
+    if utils.mask.getBit(introMask, 0) and not utils.mask.getBit(introMask, 4) then
+        player:startEvent(51, TIMELESS_HOURGLASS, TIMELESS_HOURGLASS_COST, tpz.ki.PRISMATIC_HOURGLASS, PRISMATIC_HOURGLASS_COST)
+
+    -- Introduces Currency
+    elseif utils.mask.getBit(introMask, 4) and not utils.mask.getBit(introMask, 2) then
+        player:startEvent(52, currency[1], CURRENCY_EXCHANGE_RATE, currency[2], CURRENCY_EXCHANGE_RATE, currency[3], currency[3], CURRENCY_EXCHANGE_RATE, currency[2])
+
+    elseif player:hasKeyItem(tpz.ki.VIAL_OF_SHROUDED_SAND) then
         player:startEvent(53, currency[1], CURRENCY_EXCHANGE_RATE, currency[2], CURRENCY_EXCHANGE_RATE, currency[3], PRISMATIC_HOURGLASS_COST, TIMELESS_HOURGLASS, TIMELESS_HOURGLASS_COST)
+    
     else
         player:startEvent(50)
     end
 end
 
 function onEventUpdate(player, csid, option)
-    if (csid == 53) then
+
+    -- currency gets re-ordered in introduction
+    if csid == 52 then
+        player:updateEvent(currency[3], currency[2], CURRENCY_EXCHANGE_RATE)
+
+    elseif csid == 53 then
 
         -- asking about hourglasses
-        if (option == 1) then
-            if (not player:hasItem(TIMELESS_HOURGLASS)) then
-                -- must figure out what changes here to prevent the additional dialog
+        if option == 1 then
+            if not player:hasItem(TIMELESS_HOURGLASS) then
+                -- TODO: must figure out what changes here to prevent the additional dialog
                 -- player:updateEvent(?)
             end
 
         -- shop
-        elseif (option == 2) then
+        elseif option == 2 then
             player:updateEvent(unpack(shop, 1, 8))
-        elseif (option == 3) then
+        elseif option == 3 then
             player:updateEvent(unpack(shop, 9, 14))
 
         -- offer to trade down from a 10k
-        elseif (option == 10) then
+        elseif option == 10 then
             player:updateEvent(currency[3], currency[2], CURRENCY_EXCHANGE_RATE)
 
         -- main menu (param1 = dynamis map bitmask, param2 = gil)
-        elseif (option == 11) then
+        elseif option == 11 then
             player:updateEvent(getDynamisMapList(player), player:getGil())
 
         -- maps
-        elseif (maps[option] ~= nil) then
+        elseif maps[option] ~= nil then
             local price = maps[option]
-            if (price > player:getGil()) then
+            if price > player:getGil() then
                 player:messageSpecial(ID.text.NOT_ENOUGH_GIL)
             else
                 player:delGil(price)
@@ -123,22 +139,37 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
+    local introMask = player:getCharVar("currencyGoblinIntro")
+
+    if csid == 51 then
+        -- make prismatic hourglass introduction unavailable to the other goblins
+        player:setCharVar("currencyGoblinIntro", utils.mask.setBit(introMask, 4, true))
+
+    elseif csid == 52 then
+        -- remove if this was the last of the three goblins that introduced currency
+        if utils.mask.getBit(introMask, 1) and utils.mask.getBit(introMask, 3) then
+            player:setCharVar("currencyGoblinIntro", 0)
+        else
+            player:setCharVar("currencyGoblinIntro", utils.mask.setBit(introMask, 2, true))
+        end
 
     -- bought prismatic hourglass
-    if (csid == 54) then
+    elseif csid == 54 then
         player:tradeComplete()
         player:addKeyItem(tpz.ki.PRISMATIC_HOURGLASS)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.PRISMATIC_HOURGLASS)
+        -- player may trade right away before introduction, make sure this gets set
+        player:setCharVar("currencyGoblinIntro", utils.mask.setBit(introMask, 4, true))
 
     -- refund timeless hourglass
-    elseif (csid == 97) then
+    elseif csid == 97 then
         player:tradeComplete()
         player:addGil(TIMELESS_HOURGLASS_COST)
         player:messageSpecial(ID.text.GIL_OBTAINED, TIMELESS_HOURGLASS_COST)
 
     -- singles to hundos
-    elseif (csid == 55) then
-        if (player:getFreeSlotsCount() == 0) then
+    elseif csid == 55 then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, currency[2])
         else
             player:tradeComplete()
@@ -147,8 +178,8 @@ function onEventFinish(player, csid, option)
         end
 
     -- hundos to 10k pieces
-    elseif (csid == 56) then
-        if (player:getFreeSlotsCount() == 0) then
+    elseif csid == 56 then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, currency[3])
         else
             player:tradeComplete()
@@ -157,14 +188,14 @@ function onEventFinish(player, csid, option)
         end
 
     -- 10k pieces to hundos
-    elseif (csid == 58) then
+    elseif csid == 58 then
         local slotsReq = math.ceil(CURRENCY_EXCHANGE_RATE / 99)
-        if (player:getFreeSlotsCount() < slotsReq) then
+        if player:getFreeSlotsCount() < slotsReq then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, currency[2])
         else
             player:tradeComplete()
             for i=1, slotsReq do
-                if (i < slotsReq or (CURRENCY_EXCHANGE_RATE % 99) == 0) then
+                if i < slotsReq or (CURRENCY_EXCHANGE_RATE % 99) == 0 then
                     player:addItem(currency[2], CURRENCY_EXCHANGE_RATE)
                 else
                     player:addItem(currency[2], CURRENCY_EXCHANGE_RATE % 99)
@@ -174,9 +205,9 @@ function onEventFinish(player, csid, option)
         end
 
     -- bought item from shop
-    elseif (csid == 57) then
+    elseif csid == 57 then
         local item = player:getLocalVar("hundoItemBought")
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, item)
         else
             player:tradeComplete()

--- a/scripts/zones/Castle_Oztroja/npcs/Antiqix.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/Antiqix.lua
@@ -146,11 +146,10 @@ function onEventFinish(player, csid, option)
         player:setCharVar("currencyGoblinIntro", utils.mask.setBit(introMask, 4, true))
 
     elseif csid == 52 then
+        player:setCharVar("currencyGoblinIntro", utils.mask.setBit(introMask, 2, true))
         -- remove if this was the last of the three goblins that introduced currency
-        if utils.mask.getBit(introMask, 1) and utils.mask.getBit(introMask, 3) then
+        if utils.mask.isFull(player:getCharVar("currencyGoblinIntro"), 5) then
             player:setCharVar("currencyGoblinIntro", 0)
-        else
-            player:setCharVar("currencyGoblinIntro", utils.mask.setBit(introMask, 2, true))
         end
 
     -- bought prismatic hourglass

--- a/scripts/zones/Davoi/npcs/Lootblox.lua
+++ b/scripts/zones/Davoi/npcs/Lootblox.lua
@@ -37,23 +37,24 @@ local maps = {
 function onTrade(player, npc, trade)
     local gil = trade:getGil()
     local count = trade:getItemCount()
+    local introMask = player:getCharVar("currencyGoblinIntro")
 
-    if (player:hasKeyItem(tpz.ki.VIAL_OF_SHROUDED_SAND)) then
+    if player:hasKeyItem(tpz.ki.VIAL_OF_SHROUDED_SAND) then
 
         -- buy prismatic hourglass
-        if (gil == PRISMATIC_HOURGLASS_COST and count == 1 and not player:hasKeyItem(tpz.ki.PRISMATIC_HOURGLASS)) then
+        if gil == PRISMATIC_HOURGLASS_COST and count == 1 and not player:hasKeyItem(tpz.ki.PRISMATIC_HOURGLASS) then
             player:startEvent(134)
 
         -- return timeless hourglass for refund
-        elseif (count == 1 and trade:hasItemQty(TIMELESS_HOURGLASS, 1)) then
+        elseif count == 1 and trade:hasItemQty(TIMELESS_HOURGLASS, 1) then
             player:startEvent(153)
 
         -- currency exchanges
-        elseif (count == CURRENCY_EXCHANGE_RATE and trade:hasItemQty(currency[1], CURRENCY_EXCHANGE_RATE)) then
+        elseif count == CURRENCY_EXCHANGE_RATE and trade:hasItemQty(currency[1], CURRENCY_EXCHANGE_RATE) then
             player:startEvent(135, CURRENCY_EXCHANGE_RATE)
-        elseif (count == CURRENCY_EXCHANGE_RATE and trade:hasItemQty(currency[2], CURRENCY_EXCHANGE_RATE)) then
+        elseif count == CURRENCY_EXCHANGE_RATE and trade:hasItemQty(currency[2], CURRENCY_EXCHANGE_RATE) then
             player:startEvent(136, CURRENCY_EXCHANGE_RATE)
-        elseif (count == 1 and trade:hasItemQty(currency[3], 1)) then
+        elseif count == 1 and trade:hasItemQty(currency[3], 1) then
             player:startEvent(138, currency[3], currency[2], CURRENCY_EXCHANGE_RATE)
 
         -- shop
@@ -63,7 +64,7 @@ function onTrade(player, npc, trade)
             for i=1, 13, 2 do
                 price = shop[i]
                 item = shop[i+1]
-                if (count == price and trade:hasItemQty(currency[2], price)) then
+                if count == price and trade:hasItemQty(currency[2], price) then
                     player:setLocalVar("hundoItemBought", item)
                     player:startEvent(137, currency[2], price, item)
                     break
@@ -75,41 +76,64 @@ function onTrade(player, npc, trade)
 end
 
 function onTrigger(player, npc)
-    if (player:hasKeyItem(tpz.ki.VIAL_OF_SHROUDED_SAND)) then
+    local introMask = player:getCharVar("currencyGoblinIntro")
+    
+    if
+        utils.mask.getBit(introMask, 0) and
+        not utils.mask.getBit(introMask, 4) and
+        not player:hasKeyItem(tpz.ki.PRISMATIC_HOURGLASS)
+    then
+        -- Introduces Prismatic Hourglass
+        player:startEvent(131, TIMELESS_HOURGLASS, TIMELESS_HOURGLASS_COST, tpz.ki.PRISMATIC_HOURGLASS, PRISMATIC_HOURGLASS_COST)
+
+    elseif
+        utils.mask.getBit(introMask, 4) and
+        not utils.mask.getBit(introMask, 1)
+    then
+        -- Introduces Currency
+        player:startEvent(132, currency[1], CURRENCY_EXCHANGE_RATE, currency[2], CURRENCY_EXCHANGE_RATE, currency[3], currency[3], CURRENCY_EXCHANGE_RATE, currency[2])
+
+    elseif player:hasKeyItem(tpz.ki.VIAL_OF_SHROUDED_SAND) then
         player:startEvent(133, currency[1], CURRENCY_EXCHANGE_RATE, currency[2], CURRENCY_EXCHANGE_RATE, currency[3], PRISMATIC_HOURGLASS_COST, TIMELESS_HOURGLASS, TIMELESS_HOURGLASS_COST)
+    
     else
         player:startEvent(130)
     end
 end
 
 function onEventUpdate(player, csid, option)
-    if (csid == 133) then
+
+    -- currency gets re-ordered in introduction
+    if csid == 132 then
+        player:updateEvent(currency[3], currency[2], CURRENCY_EXCHANGE_RATE)
+
+    elseif csid == 133 then
 
         -- asking about hourglasses
-        if (option == 1) then
-            if (not player:hasItem(TIMELESS_HOURGLASS)) then
+        if option == 1 then
+            if not player:hasItem(TIMELESS_HOURGLASS) then
                 -- must figure out what changes here to prevent the additional dialog
                 -- player:updateEvent(?)
             end
 
         -- shop
-        elseif (option == 2) then
+        elseif option == 2 then
             player:updateEvent(unpack(shop, 1, 8))
-        elseif (option == 3) then
+        elseif option == 3 then
             player:updateEvent(unpack(shop, 9, 14))
 
         -- offer to trade down from a 10k
-        elseif (option == 10) then
+        elseif option == 10 then
             player:updateEvent(currency[3], currency[2], CURRENCY_EXCHANGE_RATE)
 
         -- main menu (param1 = dynamis map bitmask, param2 = gil)
-        elseif (option == 11) then
+        elseif option == 11 then
             player:updateEvent(getDynamisMapList(player), player:getGil())
 
         -- maps
-        elseif (maps[option] ~= nil) then
+        elseif maps[option] ~= nil then
             local price = maps[option]
-            if (price > player:getGil()) then
+            if price > player:getGil() then
                 player:messageSpecial(ID.text.NOT_ENOUGH_GIL)
             else
                 player:delGil(price)
@@ -123,22 +147,37 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
+    local introMask = player:getCharVar("currencyGoblinIntro")
+
+    if csid == 131 then
+        -- make prismatic hourglass introduction unavailable to the other goblins
+        player:setCharVar("currencyGoblinIntro", utils.mask.setBit(introMask, 4, true))
+
+    elseif csid == 132 then
+        -- remove if this was the last of the three goblins that introduced currency
+        if utils.mask.getBit(introMask, 2) and utils.mask.getBit(introMask, 3) then
+            player:setCharVar("currencyGoblinIntro", 0)
+        else
+            player:setCharVar("currencyGoblinIntro", utils.mask.setBit(introMask, 1, true))
+        end
 
     -- bought prismatic hourglass
-    if (csid == 134) then
+    elseif csid == 134 then
         player:tradeComplete()
         player:addKeyItem(tpz.ki.PRISMATIC_HOURGLASS)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, tpz.ki.PRISMATIC_HOURGLASS)
+        -- player may trade right away before introduction, make sure this gets set
+        player:setCharVar("currencyGoblinIntro", utils.mask.setBit(introMask, 4, true))
 
     -- refund timeless hourglass
-    elseif (csid == 153) then
+    elseif csid == 153 then
         player:tradeComplete()
         player:addGil(TIMELESS_HOURGLASS_COST)
         player:messageSpecial(ID.text.GIL_OBTAINED, TIMELESS_HOURGLASS_COST)
 
     -- singles to hundos
-    elseif (csid == 135) then
-        if (player:getFreeSlotsCount() == 0) then
+    elseif csid == 135 then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, currency[2])
         else
             player:tradeComplete()
@@ -147,8 +186,8 @@ function onEventFinish(player, csid, option)
         end
 
     -- hundos to 10k pieces
-    elseif (csid == 136) then
-        if (player:getFreeSlotsCount() == 0) then
+    elseif csid == 136 then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, currency[3])
         else
             player:tradeComplete()
@@ -159,12 +198,12 @@ function onEventFinish(player, csid, option)
     -- 10k pieces to hundos
     elseif (csid == 138) then
         local slotsReq = math.ceil(CURRENCY_EXCHANGE_RATE / 99)
-        if (player:getFreeSlotsCount() < slotsReq) then
+        if player:getFreeSlotsCount() < slotsReq then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, currency[2])
         else
             player:tradeComplete()
             for i=1, slotsReq do
-                if (i < slotsReq or (CURRENCY_EXCHANGE_RATE % 99) == 0) then
+                if i < slotsReq or (CURRENCY_EXCHANGE_RATE % 99) == 0 then
                     player:addItem(currency[2], CURRENCY_EXCHANGE_RATE)
                 else
                     player:addItem(currency[2], CURRENCY_EXCHANGE_RATE % 99)
@@ -174,9 +213,9 @@ function onEventFinish(player, csid, option)
         end
 
     -- bought item from shop
-    elseif (csid == 137) then
+    elseif csid == 137 then
         local item = player:getLocalVar("hundoItemBought")
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, item)
         else
             player:tradeComplete()

--- a/scripts/zones/Davoi/npcs/Lootblox.lua
+++ b/scripts/zones/Davoi/npcs/Lootblox.lua
@@ -77,7 +77,7 @@ end
 
 function onTrigger(player, npc)
     local introMask = player:getCharVar("currencyGoblinIntro")
-    
+
     if
         utils.mask.getBit(introMask, 0) and
         not utils.mask.getBit(introMask, 4) and
@@ -154,11 +154,10 @@ function onEventFinish(player, csid, option)
         player:setCharVar("currencyGoblinIntro", utils.mask.setBit(introMask, 4, true))
 
     elseif csid == 132 then
+        player:setCharVar("currencyGoblinIntro", utils.mask.setBit(introMask, 1, true))
         -- remove if this was the last of the three goblins that introduced currency
-        if utils.mask.getBit(introMask, 2) and utils.mask.getBit(introMask, 3) then
+        if utils.mask.isFull(player:getCharVar("currencyGoblinIntro"), 5) then
             player:setCharVar("currencyGoblinIntro", 0)
-        else
-            player:setCharVar("currencyGoblinIntro", utils.mask.setBit(introMask, 1, true))
         end
 
     -- bought prismatic hourglass


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

After getting access to Dynamis and having been instructed to go get a Prismatic Hourglass, any Dynamis currency goblin in Beadeaux, Davoi or Castle Oztroja will [talk to the player about the key item](https://youtu.be/mD91QXsDvSM?t=410) at this point. Once.
After that all goblins will introduce their currency to the player. Once.
After that they will all show the menu.

This PR adds the missing events and makes it so that:
• either of the goblins will introduce the hourglass. After doing so, the others won't.
• the player may skip this dialogue by trading 50k gil right away without talking to the goblin and receiving the hourglass
• before offering the dialogue menu each goblin will introduce the currency he trades once and then never again
• after all three goblins have introduced their currency to the player the charVar responsible for this is deleted
• the player may move freely between these three in any state of this logic without messing anything up

A lot of the lines in the commit are just parenthesis clean up. The important bit is the `onTrigger()` function in each goblins script and the resulting `onEventFinish()`.