### PR TITLE
Block attempts to Ranged Attack from incorrect states

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -794,8 +794,15 @@ void SmallPacket0x01A(map_session_data_t* PSession, CCharEntity* PChar, CBasicPa
             PChar->PAI->ChangeTarget(TargID);
         }
         break;
-        case 0x10: // rangedattack
+        case 0x10: // Ranged Attack
         {
+            uint8 currentAnimation = PChar->animation;
+            if (currentAnimation != ANIMATION_NONE && currentAnimation != ANIMATION_ATTACK)
+            {
+                ShowExploit(CL_YELLOW "SmallPacket0x01A: Player %s trying to Ranged Attack from invalid state\n" CL_RESET, PChar->GetName());
+                return;
+            }
+
             PChar->PAI->RangedAttack(TargID);
         }
         break;


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Extremely minor exploit that's been kicking around for a while.

Tested, works as expected.
```
[12/Nov] [17:18:01][Possible Exploit] SmallPacket0x01A: Player Test trying to Ranged Attack from invalid state
```