### PR TITLE
Corrected POS values of NPCs Rotih Moalghett and ??? QM

### DIFF
--- a/scripts/zones/Fort_Karugo-Narugo_[S]/npcs/Rotih_Moalghett.lua
+++ b/scripts/zones/Fort_Karugo-Narugo_[S]/npcs/Rotih_Moalghett.lua
@@ -2,7 +2,7 @@
 -- Area: Fort Karugo Narugo [S]
 --  NPC: Rotih_Moalghett
 -- Type: Quest
--- !pos -64 -75 3 96
+-- !pos -64 -75 4 96
 -----------------------------------
 require("scripts/globals/quests")
 -----------------------------------

--- a/scripts/zones/Fort_Karugo-Narugo_[S]/npcs/Rotih_Moalghett.lua
+++ b/scripts/zones/Fort_Karugo-Narugo_[S]/npcs/Rotih_Moalghett.lua
@@ -2,7 +2,7 @@
 -- Area: Fort Karugo Narugo [S]
 --  NPC: Rotih_Moalghett
 -- Type: Quest
--- !pos 280 -20 85 96
+-- !pos -64 -75 3 96
 -----------------------------------
 require("scripts/globals/quests")
 -----------------------------------

--- a/scripts/zones/Fort_Karugo-Narugo_[S]/npcs/qm6.lua
+++ b/scripts/zones/Fort_Karugo-Narugo_[S]/npcs/qm6.lua
@@ -2,7 +2,7 @@
 -- Area: Fort Karugo Narugo [S]
 --  NPC: ???
 -- Type: Quest
--- !pos -63 -75 4 96
+-- !pos 280 -20 85 96
 -----------------------------------
 local ID = require("scripts/zones/Fort_Karugo-Narugo_[S]/IDs")
 require("scripts/globals/quests")


### PR DESCRIPTION
--- Both are involved in quest The Tigress Strikes
--- Appears values for the POSes of both NPCs were inversed.

EDIT: Forgot my Xs....but not my Ps and Qs!!!!!

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [X] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [X] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

