### PR TITLE
RoE Expansion 4

### DIFF
--- a/scripts/globals/roe.lua
+++ b/scripts/globals/roe.lua
@@ -2,19 +2,28 @@
 -- Records of Eminence
 ------------------------------------
 require("scripts/globals/status")
+require("scripts/globals/quests")
+require("scripts/globals/missions")
+require("scripts/globals/log_ids")
+------------------------------------
 
 tpz = tpz or {}
 tpz.roe = tpz.roe or {}
 
 tpz.roe.triggers =
 {
-    mobKill = 1,        -- Player kills a Mob (Counts for mobs killed by partymembers)
-    wSkillUse = 2,      -- Player Weapon skill used
-    itemLooted = 3,     -- Player successfully loots an item
-    synthSuccess = 4,   -- Player synth success
-    dmgTaken = 5,       -- Player takes Damage
-    dmgDealt = 6,       -- Player deals Damage
-    expGain = 7,        -- Player gains EXP
+    mobKill = 1,            -- Player kills a Mob (Counts for mobs killed by partymembers)
+    wSkillUse = 2,          -- Player Weapon skill used
+    itemLooted = 3,         -- Player successfully loots an item
+    synthSuccess = 4,       -- Player synth success
+    dmgTaken = 5,           -- Player takes Damage
+    dmgDealt = 6,           -- Player deals Damage
+    expGain = 7,            -- Player gains EXP
+    healAlly = 8,           -- Player heals self/ally with spell
+    buffAlly = 9,           -- Player buffs ally
+    levelUp = 10,           -- Player levelup
+    questComplete = 11,     -- Player completes quest
+    missionComplete = 12,   -- Player completes mission
 }
 
 tpz.roe.checks = {}
@@ -56,6 +65,14 @@ checks.dmgMax = function(self, player, params)  -- Maximum Dmg Dealt/Taken
     return (params.dmg and params.dmg <= self.reqs.dmgMax) and true or false
 end
 
+checks.atkType = function(self, player, params)  -- Dmg Type is
+    return (params.atkType == self.reqs.atkType) and true or false
+end
+
+checks.healMin = function(self, player, params)  -- Minimum Amount healed
+    return (params.heal and params.heal >= self.reqs.healMin) and true or false
+end
+
 checks.zone = function(self, player, params)  -- Player in Zone
     return (self.reqs.zone[player:getZoneID()]) and true or false
 end
@@ -71,6 +88,19 @@ end
 checks.levelSync = function(self, player, params)  -- Player is Level Sync'd
     return self.reqs.levelSync and player:isLevelSync() and true or false
 end
+
+checks.jobLvl = function(self, player, params)  -- Player has job at minimum level X
+    return player:getJobLevel(self.reqs.jobLvl[1]) >= self.reqs.jobLvl[2] and true or false
+end
+
+checks.questComplete = function(self, player, params) -- Player has {KINGDOM, QUEST} marked complete
+    return player:getQuestStatus(self.reqs.questComplete[1], self.reqs.questComplete[2]) == QUEST_COMPLETED
+end
+
+checks.missionComplete = function(self, player, params) -- Player has {NATION, MISSION} marked complete
+    return player:hasCompletedMission(self.reqs.missionComplete[1], self.reqs.missionComplete[2])
+end
+
 
 -- Load Records
 package.loaded["scripts/globals/roe_records"] = nil
@@ -124,7 +154,6 @@ local function completeRecord(player, record)
         npcUtil.giveKeyItem(player, rewards["keyItem"])
     end
 
-    -- successfully complete the record
     if recordFlags["repeat"] then
         if recordFlags["timed"] then
             player:messageBasic(tpz.msg.basic.ROE_TIMED_CLEAR)
@@ -143,13 +172,25 @@ end
 -- have record information entered in roe_records.lua. This keeps everything neat.
 
 function tpz.roe.onRecordTrigger(player, recordID, params)
+    params = params or {}
+    params.progress = params.progress or player:getEminenceProgress(recordID)
     local entry = tpz.roe.records[recordID]
-    if entry and entry:check(player, params) then
-        local progress = (params and params.progress or player:getEminenceProgress(recordID)) + entry.increment
-        if progress >= entry.goal then
-            completeRecord(player, recordID)
-        else
-            player:setEminenceProgress(recordID, progress, entry.goal)
+    local isClaiming = params.claim
+
+    if entry and params.progress then
+        local awaitingClaim = params.progress >= entry.goal
+        if awaitingClaim and not isClaiming then
+            player:messageBasic(tpz.msg.basic.ROE_YET_TO_RECEIVE)
+            return
+        elseif isClaiming or entry:check(player, params) then
+            params.progress = params.progress + (isClaiming and 0 or entry.increment)
+            if params.progress >= entry.goal then
+                if not completeRecord(player, recordID) and not awaitingClaim then
+                    player:setEminenceProgress(recordID, entry.goal)
+                end
+            else
+                player:setEminenceProgress(recordID, params.progress, entry.goal)
+            end
         end
     end
 end

--- a/scripts/globals/roe_records.lua
+++ b/scripts/globals/roe_records.lua
@@ -8,13 +8,13 @@ local checks = tpz.roe.checks
 local timedSchedule = {
 -- 4-hour timeslots (6 per day) all days/times are in JST
 --    00-04  04-08  08-12  12-16  16-20  20-00
-    {     0,  4010,  4016,  4012,  4018,  4013}, -- Sunday
+    {  4021,  4010,  4016,  4012,  4018,  4013}, -- Sunday
     {  4015,  4011,  4017,  4014,  4019,  4008}, -- Monday
-    {  4016,  4012,  4018,  4013,     0,  4009}, -- Tuesday
-    {  4017,  4014,  4019,  4008,     0,  4010}, -- Wednesday
-    {  4018,  4013,     0,  4009,  4015,  4011}, -- Thursdsay
-    {  4019,  4008,     0,  4010,  4016,  4012}, -- Friday
-    {     0,  4009,  4015,  4011,  4017,  4014}, -- Saturday
+    {  4016,  4012,  4018,  4013,  4020,  4009}, -- Tuesday
+    {  4017,  4014,  4019,  4008,  4021,  4010}, -- Wednesday
+    {  4018,  4013,  4020,  4009,  4015,  4011}, -- Thursdsay
+    {  4019,  4008,  4021,  4010,  4016,  4012}, -- Friday
+    {  4020,  4009,  4015,  4011,  4017,  4014}, -- Saturday
 }
 -- Load timetable for timed records
 if ENABLE_ROE_TIMED and ENABLE_ROE_TIMED > 0 then
@@ -26,7 +26,11 @@ local defaults = {
     increment = 1,              -- Amount to increment per successful check
     notify = 1,                 -- Progress notifications shown every X increases
     goal = 1,                   -- Progress goal
-    flags = {},                 -- Special flags. Possible values: "timed" "repeat" "daily"
+    flags = {},                 -- Special flags. This should be a set. Possible values: 
+                                --        "timed"  - 4-hour record.
+                                --        "repeat" - Repeatable record.
+                                --        "daily"  - Daily record.
+                                --        "retro"  - Can be claimed retroactively. Calls check on taking record.
     reqs = {},                  -- Other requirements. List of function names from above, with required values.
     reward = {},                -- Reward parameters give on completion. (See completeRecord directly below.)
 }
@@ -111,6 +115,197 @@ tpz.roe.records =
         reward =  { sparks = 200, xp = 300, item = { 10140 }  }
     },
     ]]
+
+  ----------------------------------------
+  -- Tutorial -> Quests 1               --
+  ----------------------------------------
+
+    [ 501] = { -- Mog House Exit: Bastok
+        trigger = triggers.questComplete,
+        reqs = { questComplete = {BASTOK, tpz.quest.id.bastok.A_LADY_S_HEART} },
+        flags = set{"retro"},
+        reward = { sparks = 100, xp = 300 },
+    },
+    
+  ----------------------------------------
+  -- Tutorial -> Level Cap Increase     --
+  ----------------------------------------
+
+    [ 705] = { -- Level Cap Increase: 55
+        trigger = triggers.questComplete,
+        reqs = { questComplete = {JEUNO, tpz.quest.id.jeuno.IN_DEFIANT_CHALLENGE} },
+        flags = set{"retro"},
+        reward = { sparks = 100, xp = 300 },
+    },
+
+    [ 706] = { -- Level Cap Increase: 60
+        trigger = triggers.questComplete,
+        reqs = { questComplete = {JEUNO, tpz.quest.id.jeuno.ATOP_THE_HIGHEST_MOUNTAINS} },
+        flags = set{"retro"},
+        reward = { sparks = 100, xp = 300 },
+    },
+
+    [ 707] = { -- Level Cap Increase: 65
+        trigger = triggers.questComplete,
+        reqs = { questComplete = {JEUNO, tpz.quest.id.jeuno.WHENCE_BLOWS_THE_WIND} },
+        flags = set{"retro"},
+        reward = { sparks = 100, xp = 300 },
+    },
+
+    [ 708] = { -- Level Cap Increase: 70
+        trigger = triggers.questComplete,
+        reqs = { questComplete = {JEUNO, tpz.quest.id.jeuno.RIDING_ON_THE_CLOUDS} },
+        flags = set{"retro"},
+        reward = { sparks = 100, xp = 300 },
+    },
+
+    [ 709] = { -- Level Cap Increase: 75
+        trigger = triggers.questComplete,
+        reqs = { questComplete = {JEUNO, tpz.quest.id.jeuno.SHATTERING_STARS} },
+        flags = set{"retro"},
+        reward = { sparks = 100, xp = 300 },
+    },
+
+    [ 710] = { -- Level Cap Increase: 80
+        trigger = triggers.questComplete,
+        reqs = { questComplete = {JEUNO, tpz.quest.id.jeuno.NEW_WORLDS_AWAIT} },
+        flags = set{"retro"},
+        reward = { sparks = 100, xp = 300 },
+    },
+
+    [ 711] = { -- Level Cap Increase: 85
+        trigger = triggers.questComplete,
+        reqs = { questComplete = {JEUNO, tpz.quest.id.jeuno.EXPANDING_HORIZONS} },
+        flags = set{"retro"},
+        reward = { sparks = 100, xp = 300 },
+    },
+
+    [ 712] = { -- Level Cap Increase: 90
+        trigger = triggers.questComplete,
+        reqs = { questComplete = {JEUNO, tpz.quest.id.jeuno.BEYOND_THE_STARS} },
+        flags = set{"retro"},
+        reward = { sparks = 100, xp = 300 },
+    },
+
+    [ 713] = { -- Level Cap Increase: 95
+        trigger = triggers.questComplete,
+        reqs = { questComplete = {JEUNO, tpz.quest.id.jeuno.DORMANT_POWERS_DISLODGED} },
+        flags = set{"retro"},
+        reward = { sparks = 100, xp = 300 },
+    },
+
+    [ 714] = { -- Level Cap Increase: 99
+        trigger = triggers.questComplete,
+        reqs = { questComplete = {JEUNO, tpz.quest.id.jeuno.BEYOND_INFINITY} },
+        flags = set{"retro"},
+        reward = { sparks = 100, xp = 300 },
+    },
+    
+  ----------------------------------------
+  -- Tutorial -> Storage Expansion      --
+  ----------------------------------------
+
+    [ 715] = { -- Inventory Expansion 35
+        trigger = triggers.questComplete,
+        reqs = { questComplete = {JEUNO, tpz.quest.id.jeuno.THE_GOBBIEBAG_PART_I} },
+        flags = set{"retro"},
+        reward = { sparks = 100, xp = 300 },
+    },
+
+    [ 716] = { -- Inventory Expansion 40
+        trigger = triggers.questComplete,
+        reqs = { questComplete = {JEUNO, tpz.quest.id.jeuno.THE_GOBBIEBAG_PART_II} },
+        flags = set{"retro"},
+        reward = { sparks = 100, xp = 300 },
+    },
+
+    [ 717] = { -- Inventory Expansion 45
+        trigger = triggers.questComplete,
+        reqs = { questComplete = {JEUNO, tpz.quest.id.jeuno.THE_GOBBIEBAG_PART_III} },
+        flags = set{"retro"},
+        reward = { sparks = 100, xp = 300 },
+    },
+
+    [ 718] = { -- Inventory Expansion 50
+        trigger = triggers.questComplete,
+        reqs = { questComplete = {JEUNO, tpz.quest.id.jeuno.THE_GOBBIEBAG_PART_IV} },
+        flags = set{"retro"},
+        reward = { sparks = 100, xp = 300 },
+    },
+
+    [ 719] = { -- Inventory Expansion 55
+        trigger = triggers.questComplete,
+        reqs = { questComplete = {JEUNO, tpz.quest.id.jeuno.THE_GOBBIEBAG_PART_V} },
+        flags = set{"retro"},
+        reward = { sparks = 100, xp = 300 },
+    },
+
+    [ 720] = { -- Inventory Expansion 60
+        trigger = triggers.questComplete,
+        reqs = { questComplete = {JEUNO, tpz.quest.id.jeuno.THE_GOBBIEBAG_PART_VI} },
+        flags = set{"retro"},
+        reward = { sparks = 100, xp = 300 },
+    },
+
+    [ 721] = { -- Inventory Expansion 65
+        trigger = triggers.questComplete,
+        reqs = { questComplete = {JEUNO, tpz.quest.id.jeuno.THE_GOBBIEBAG_PART_VII} },
+        flags = set{"retro"},
+        reward = { sparks = 100, xp = 300 },
+    },
+
+    [ 722] = { -- Inventory Expansion 70
+        trigger = triggers.questComplete,
+        reqs = { questComplete = {JEUNO, tpz.quest.id.jeuno.THE_GOBBIEBAG_PART_VIII} },
+        flags = set{"retro"},
+        reward = { sparks = 100, xp = 300 },
+    },
+
+    [ 723] = { -- Inventory Expansion 75
+        trigger = triggers.questComplete,
+        reqs = { questComplete = {JEUNO, tpz.quest.id.jeuno.THE_GOBBIEBAG_PART_IX} },
+        flags = set{"retro"},
+        reward = { sparks = 100, xp = 300 },
+    },
+
+    [ 724] = { -- Inventory Expansion 80
+        trigger = triggers.questComplete,
+        reqs = { questComplete = {JEUNO, tpz.quest.id.jeuno.THE_GOBBIEBAG_PART_X} },
+        flags = set{"retro"},
+        reward = { sparks = 100, xp = 300 },
+    },
+
+  ----------------------------------------
+  -- Tutorial -> Missions (Bastok)      --
+  ----------------------------------------
+
+    [1333] = { -- Bastok Rank 1-1
+        trigger = triggers.missionComplete,
+        reqs = { missionComplete = {BASTOK, tpz.mission.id.bastok.THE_ZERUHN_REPORT} },
+        flags = set{"retro"},
+        reward = { sparks = 300, xp = 500 },
+    },
+
+    [1334] = { -- Bastok Rank 1-2
+        trigger = triggers.missionComplete,
+        reqs = { missionComplete = {BASTOK, tpz.mission.id.bastok.A_GEOLOGICAL_SURVEY} },
+        flags = set{"retro"},
+        reward = { sparks = 300, xp = 500 },
+    },
+
+    [1335] = { -- Bastok Rank 1-3
+        trigger = triggers.missionComplete,
+        reqs = { missionComplete = {BASTOK, tpz.mission.id.bastok.FETICHISM} },
+        flags = set{"retro"},
+        reward = { sparks = 300, xp = 500 },
+    },
+
+    [1336] = { -- Bastok Rank 2-1
+        trigger = triggers.missionComplete,
+        reqs = { missionComplete = {BASTOK, tpz.mission.id.bastok.THE_CRYSTAL_LINE} },
+        flags = set{"retro"},
+        reward = { sparks = 300, xp = 500 },
+    },
 
   --------------------------------------------
   -- Combat (Wide Area) -> Combat (General) --
@@ -261,6 +456,51 @@ tpz.roe.records =
                 return false
             end
     },
+    
+    [  31] = { -- Total Healing I
+        trigger = triggers.healAlly,
+        goal = 10000,
+        increment = 0,
+        notify = 500,
+        reward = { sparks = 1000, xp = 2500, item = { 6182 } },
+        check = function(self, player, params)
+                if params.heal and params.heal > 0 then
+                    params.progress = params.progress + params.heal
+                    return true
+                end
+                return false
+            end
+    },
+    
+    [  32] = { -- Total Healing II
+        trigger = triggers.healAlly,
+        goal = 20000,
+        increment = 0,
+        notify = 1000,
+        reward = { sparks = 3000, xp = 7000, item = { 6185 } },
+        check = function(self, player, params)
+                if params.heal and params.heal > 0 then
+                    params.progress = params.progress + params.heal
+                    return true
+                end
+                return false
+            end
+    },
+
+    [ 699] = { -- Total Healing III
+        trigger = triggers.healAlly,
+        goal = 30000,
+        increment = 0,
+        notify = 1000,
+        reward = { sparks = 3000, xp = 7000, item = { 6185 } },
+        check = function(self, player, params)
+                if params.heal and params.heal > 0 then
+                    params.progress = params.progress + params.heal
+                    return true
+                end
+                return false
+            end
+    },
 
     [  33] = { -- Total Damage Taken I
         trigger = triggers.dmgTaken,
@@ -311,6 +551,20 @@ tpz.roe.records =
         trigger = triggers.wSkillUse,
         goal = 100,
         reward = { sparks = 500, xp = 2500 },
+    },
+
+    [ 488] = { -- Heal for 500+ HP
+        trigger = triggers.healAlly,
+        goal = 100,
+        reqs = { healMin = 500 },
+        reward = { sparks = 2000, xp = 6000 },
+    },
+
+    [ 700] = { -- Heal for 750+ HP
+        trigger = triggers.healAlly,
+        goal = 100,
+        reqs = { healMin = 750 },
+        reward = { sparks = 3000, xp = 7000, item = { 6183 } },
     },
 
   --------------------------------------------
@@ -2135,6 +2389,178 @@ tpz.roe.records =
   ----------------------------------------
   -- Combat (Region) - Escha 2          --
   ----------------------------------------
+  
+  ----------------------------------------
+  -- Achievements - Job Levels I        --
+  ----------------------------------------
+
+    [1200] = { -- Level 30 Warrior
+        trigger = triggers.levelUp,
+        reqs = { jobLvl = { tpz.job.WAR, 30 } },
+        flags = set{"retro"},
+        reward = { sparks = 100, xp = 500, item = { {6152, 12} } },
+    },
+
+    [1201] = { -- Level 50 Warrior
+        trigger = triggers.levelUp,
+        reqs = { jobLvl = { tpz.job.WAR, 50 } },
+        flags = set{"retro"},
+        reward = { sparks = 200, xp = 500, item = { {6151, 12} } },
+    },
+
+    [1202] = { -- Level 75 Warrior
+        trigger = triggers.levelUp,
+        reqs = { jobLvl = { tpz.job.WAR, 75 } },
+        flags = set{"retro"},
+        reward = { sparks = 300, xp = 500, item = { {3190, 4} } },
+    },
+
+    [1203] = { -- Level 99 Warrior
+        trigger = triggers.levelUp,
+        reqs = { jobLvl = { tpz.job.WAR, 99 } },
+        flags = set{"retro"},
+        reward = { sparks = 400, xp = 500, item = { {4064, 2} } },
+    },
+
+    [1204] = { -- Level 30 Monk
+        trigger = triggers.levelUp,
+        reqs = { jobLvl = { tpz.job.MNK, 30 } },
+        flags = set{"retro"},
+        reward = { sparks = 100, xp = 500, item = { {6147, 12} } },
+    },
+
+    [1205] = { -- Level 50 Monk
+        trigger = triggers.levelUp,
+        reqs = { jobLvl = { tpz.job.MNK, 50 } },
+        flags = set{"retro"},
+        reward = { sparks = 200, xp = 500, item = { {6158, 12} } },
+    },
+
+    [1206] = { -- Level 75 Monk
+        trigger = triggers.levelUp,
+        reqs = { jobLvl = { tpz.job.MNK, 75 } },
+        flags = set{"retro"},
+        reward = { sparks = 300, xp = 500, item = { {3191, 4} } },
+    },
+
+    [1207] = { -- Level 99 Monk
+        trigger = triggers.levelUp,
+        reqs = { jobLvl = { tpz.job.MNK, 99 } },
+        flags = set{"retro"},
+        reward = { sparks = 400, xp = 500, item = { {4065, 2} } },
+    },
+
+    [1208] = { -- Level 30 White Mage
+        trigger = triggers.levelUp,
+        reqs = { jobLvl = { tpz.job.WHM, 30 } },
+        flags = set{"retro"},
+        reward = { sparks = 100, xp = 500, item = { {6167, 12} } },
+    },
+
+    [1209] = { -- Level 50 White Mage
+        trigger = triggers.levelUp,
+        reqs = { jobLvl = { tpz.job.WHM, 50 } },
+        flags = set{"retro"},
+        reward = { sparks = 200, xp = 500, item = { {6166, 12} } },
+    },
+
+    [1210] = { -- Level 75 White Mage
+        trigger = triggers.levelUp,
+        reqs = { jobLvl = { tpz.job.WHM, 75 } },
+        flags = set{"retro"},
+        reward = { sparks = 300, xp = 500, item = { {3192, 4} } },
+    },
+
+    [1211] = { -- Level 99 White Mage
+        trigger = triggers.levelUp,
+        reqs = { jobLvl = { tpz.job.WHM, 99 } },
+        flags = set{"retro"},
+        reward = { sparks = 400, xp = 500, item = { {4066, 2} } },
+    },
+
+    [1212] = { -- Level 30 Black Mage
+        trigger = triggers.levelUp,
+        reqs = { jobLvl = { tpz.job.BLM, 30 } },
+        flags = set{"retro"},
+        reward = { sparks = 100, xp = 500, item = { {6170, 12} } },
+    },
+
+    [1213] = { -- Level 50 Black Mage
+        trigger = triggers.levelUp,
+        reqs = { jobLvl = { tpz.job.BLM, 50 } },
+        flags = set{"retro"},
+        reward = { sparks = 200, xp = 500, item = { {6171, 12} } },
+    },
+
+    [1214] = { -- Level 75 Black Mage
+        trigger = triggers.levelUp,
+        reqs = { jobLvl = { tpz.job.BLM, 75 } },
+        flags = set{"retro"},
+        reward = { sparks = 300, xp = 500, item = { {3193, 4} } },
+    },
+
+    [1215] = { -- Level 99 Black Mage
+        trigger = triggers.levelUp,
+        reqs = { jobLvl = { tpz.job.BLM, 99 } },
+        flags = set{"retro"},
+        reward = { sparks = 400, xp = 500, item = { {4067, 2} } },
+    },
+
+    [1216] = { -- Level 30 Red Mage
+        trigger = triggers.levelUp,
+        reqs = { jobLvl = { tpz.job.RDM, 30 } },
+        flags = set{"retro"},
+        reward = { sparks = 100, xp = 500, item = { {6169, 12} } },
+    },
+
+    [1217] = { -- Level 50 Red Mage
+        trigger = triggers.levelUp,
+        reqs = { jobLvl = { tpz.job.RDM, 50 } },
+        flags = set{"retro"},
+        reward = { sparks = 200, xp = 500, item = { {6168, 12} } },
+    },
+
+    [1218] = { -- Level 75 Red Mage
+        trigger = triggers.levelUp,
+        reqs = { jobLvl = { tpz.job.RDM, 75 } },
+        flags = set{"retro"},
+        reward = { sparks = 300, xp = 500, item = { {3194, 4} } },
+    },
+
+    [1219] = { -- Level 99 Red Mage
+        trigger = triggers.levelUp,
+        reqs = { jobLvl = { tpz.job.RDM, 99 } },
+        flags = set{"retro"},
+        reward = { sparks = 400, xp = 500, item = { {4068, 2} } },
+    },
+
+    [1220] = { -- Level 30 Thief
+        trigger = triggers.levelUp,
+        reqs = { jobLvl = { tpz.job.THF, 30 } },
+        flags = set{"retro"},
+        reward = { sparks = 100, xp = 500, item = { {6148, 12} } },
+    },
+
+    [1221] = { -- Level 50 Thief
+        trigger = triggers.levelUp,
+        reqs = { jobLvl = { tpz.job.THF, 50 } },
+        flags = set{"retro"},
+        reward = { sparks = 200, xp = 500, item = { {6149, 12} } },
+    },
+
+    [1222] = { -- Level 75 Thief
+        trigger = triggers.levelUp,
+        reqs = { jobLvl = { tpz.job.THF, 75 } },
+        flags = set{"retro"},
+        reward = { sparks = 300, xp = 500, item = { {3195, 4} } },
+    },
+
+    [1223] = { -- Level 99 Thief
+        trigger = triggers.levelUp,
+        reqs = { jobLvl = { tpz.job.THF, 99 } },
+        flags = set{"retro"},
+        reward = { sparks = 400, xp = 500, item = { {4069, 2} } },
+    },
 
   ----------------------------------------
   -- Other - Daily Objectives           --
@@ -2146,6 +2572,21 @@ tpz.roe.records =
         reqs = { mobXP = true },
         flags = set{"daily"},
         reward = { sparks = 100, xp = 500, unity = 300, item = { 8711 } },
+    },
+
+    [4083] = { -- Buff Allies (D)
+        trigger = triggers.buffAlly,
+        goal = 20,
+        flags = set{"daily"},
+        reward = { sparks = 300, xp = 1500, unity = 300, item = { 8711 } },
+    },
+
+    [4084] = { -- Heal for 500+ HP (D)
+        trigger = triggers.healAlly,
+        goal = 100,
+        reqs = { healMin = 500 },
+        flags = set{"daily"},
+        reward = { sparks = 300, xp = 1500, unity = 300, item = { 8711 } },
     },
 
 
@@ -2254,8 +2695,21 @@ tpz.roe.records =
         reward = { sparks = 300, xp = 1500, unity = 300, item = { 8711 } },
     },
 
-    -- [4020] = {  -- Physical Damage Kills
-    -- [4021] = {  -- Magic Damage Kills
+    [4020] = {  -- Physical Damage Kills
+        trigger = triggers.mobKill,
+        goal = 20,
+        reqs = { mobXP = true, atkType = tpz.attackType.PHYSICAL },
+        flags = set{"timed", "repeat"},
+        reward = { sparks = 300, xp = 1500, unity = 300, item = { 8711 } },
+    },
+
+    [4021] = {  -- Magic Damage Kills
+        trigger = triggers.mobKill,
+        goal = 20,
+        reqs = { mobXP = true, atkType = tpz.attackType.MAGICAL },
+        flags = set{"timed", "repeat"},
+        reward = { sparks = 300, xp = 1500, unity = 300, item = { 8711 } },
+    },
 }
 
 

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -533,6 +533,7 @@ int32 CBattleEntity::addMP(int32 mp)
 int32 CBattleEntity::takeDamage(int32 amount, CBattleEntity* attacker /* = nullptr*/, ATTACKTYPE attackType /* = ATTACK_NONE*/, DAMAGETYPE damageType /* = DAMAGE_NONE*/)
 {
     PLastAttacker = attacker;
+    this->BattleHistory.lastHitTaken_atkType = attackType;
     PAI->EventHandler.triggerListener("TAKE_DAMAGE", this, amount, attacker, (uint16)attackType, (uint16)damageType);
 
     //RoE Damage Taken Trigger
@@ -1441,6 +1442,21 @@ void CBattleEntity::OnCastFinished(CMagicState& state, action_t& action)
         if (PTarget->objtype == TYPE_MOB && msg != MSGBASIC_SHADOW_ABSORB) // If message isn't the shadow loss message, because I had to move this outside of the above check for it.
         {
             luautils::OnMagicHit(this, PTarget, PSpell);
+        }
+
+        if (this == PTarget || // Casting on self or ally
+            (this->PParty && PTarget->PParty &&
+            ((this->PParty == PTarget->PParty) || (this->PParty->m_PAlliance && this->PParty->m_PAlliance == PTarget->PParty->m_PAlliance))))
+        {
+            if (PSpell->isHeal())
+            {
+                roeutils::event(ROE_HEALALLY, static_cast<CCharEntity*>(this), RoeDatagram("heal", actionTarget.param));
+            }
+            else if (this != PTarget && PSpell->isBuff() && actionTarget.param)
+            {
+                roeutils::event(ROE_BUFFALLY, static_cast<CCharEntity*>(this), RoeDatagramList{});
+            }
+
         }
     }
     if ((!(PSpell->isHeal()) || PSpell->tookEffect()) && PActionTarget->isAlive())

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -463,6 +463,11 @@ struct health_t
     int32   modhp, modmp;       // модифицированные максимальные значения
 };
 
+struct battlehistory_t
+{
+    ATTACKTYPE  lastHitTaken_atkType;
+};
+
 typedef std::vector<apAction_t> ActionList_t;
 class CModifier;
 class CParty;
@@ -669,6 +674,7 @@ public:
     CBattleEntity*	PPet;					    // питомец сущности
     CBattleEntity*	PMaster;				    // владелец/хозяин сущности (распространяется на все боевые сущности)
     CBattleEntity*	PLastAttacker;
+    battlehistory_t BattleHistory;              // Stores info related to most recent combat actions taken towards this entity.
 
     std::unique_ptr<CStatusEffectContainer> StatusEffectContainer;
     std::unique_ptr<CRecastContainer> PRecastContainer;

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -783,7 +783,10 @@ void CMobEntity::DistributeRewards()
             {
                 if (PMember->getZone() == PChar->getZone())
                 {
-                    roeutils::event(ROE_MOBKILL, (CCharEntity*)PMember, RoeDatagram("mob", (CMobEntity*)this));
+                    RoeDatagramList datagrams;
+                    datagrams.push_back(RoeDatagram("mob", (CMobEntity*)this));
+                    datagrams.push_back(RoeDatagram("atkType", this->BattleHistory.lastHitTaken_atkType));
+                    roeutils::event(ROE_MOBKILL, (CCharEntity*)PMember, datagrams);
                 }
             });
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -6470,6 +6470,7 @@ inline int32 CLuaBaseEntity::completeQuest(lua_State *L)
             PChar->pushPacket(new CQuestMissionLogPacket(PChar, questLogID, LOG_QUEST_CURRENT));
             PChar->pushPacket(new CQuestMissionLogPacket(PChar, questLogID, LOG_QUEST_COMPLETE));
             charutils::SaveQuestsList(PChar);
+            roeutils::event(ROE_QUEST_COMPLETE, PChar, RoeDatagramList{});
         }
     }
     else
@@ -6685,6 +6686,7 @@ inline int32 CLuaBaseEntity::completeMission(lua_State *L)
             PChar->pushPacket(new CQuestMissionLogPacket(PChar, missionLogID, LOG_MISSION_CURRENT));
 
             charutils::SaveMissionsList(PChar);
+            roeutils::event(ROE_MISSION_COMPLETE, PChar, RoeDatagramList{});
         }
     }
     else

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -6364,8 +6364,10 @@ void SmallPacket0x10C(map_session_data_t* session, CCharEntity* PChar, CBasicPac
     TracyZoneScoped;
     if (roeutils::RoeSystem.RoeEnabled)
     {
-        roeutils::AddEminenceRecord(PChar, data.ref<uint32>(0x04));
+        uint16 recordID = data.ref<uint32>(0x04);
+        roeutils::AddEminenceRecord(PChar, recordID);
         PChar->pushPacket(new CRoeSparkUpdatePacket(PChar));
+        roeutils::onRecordTake(PChar, recordID);
     }
     return;
 }
@@ -6385,6 +6387,22 @@ void SmallPacket0x10D(map_session_data_t* session, CCharEntity* PChar, CBasicPac
         PChar->pushPacket(new CRoeSparkUpdatePacket(PChar));
     }
     return;
+}
+
+/************************************************************************
+*                                                                        *
+*  Claim completed eminence record                                       *
+*                                                                        *
+************************************************************************/
+
+void SmallPacket0x10E(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
+{
+    TracyZoneScoped;
+    if (roeutils::RoeSystem.RoeEnabled)
+    {
+        uint16 recordID = data.ref<uint16>(0x04);
+        roeutils::onRecordClaim(PChar, recordID);
+    }
 }
 
 /************************************************************************
@@ -6667,6 +6685,7 @@ void PacketParserInitialize()
     PacketSize[0x10B] = 0x00; PacketParser[0x10B] = &SmallPacket0x10B;
     PacketSize[0x10C] = 0x04; PacketParser[0x10C] = &SmallPacket0x10C;
     PacketSize[0x10D] = 0x04; PacketParser[0x10D] = &SmallPacket0x10D;
+    PacketSize[0x10E] = 0x04; PacketParser[0x10E] = &SmallPacket0x10E;
     PacketSize[0x10F] = 0x02; PacketParser[0x10F] = &SmallPacket0x10F;
     PacketSize[0x110] = 0x0A; PacketParser[0x110] = &SmallPacket0x110;
     PacketSize[0x111] = 0x00; PacketParser[0x111] = &SmallPacket0x111; // Lock Style Request

--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -48,6 +48,68 @@ void SaveEminenceDataNice(CCharEntity* PChar)
     }
 }
 
+void call_onRecordTrigger(lua_State* L, CCharEntity* PChar, uint16 recordID, const RoeDatagramList& payload)
+{
+    uint32 stackTop = lua_gettop(L);
+
+    lua_getfield(L, -1, "onRecordTrigger");
+    if (lua_isnil(L, -1))
+    {
+        lua_settop(L, stackTop);
+        ShowError("roeutils::onRecordTrigger: unexpected lua stack state during call for record %d.", recordID);
+        return;
+    }
+
+    uint8 args { 0 };
+
+    CLuaBaseEntity LuaAllyEntity(PChar);
+    Lunar<CLuaBaseEntity>::push(L, &LuaAllyEntity);
+    args++;
+
+    // Record #
+    lua_pushinteger(L, recordID);
+    args++;
+
+    // param table
+    lua_newtable(L);
+    args++;
+
+    lua_pushinteger(L, roeutils::GetEminenceRecordProgress(PChar, recordID));
+    lua_setfield(L, -2, "progress");
+
+    for (auto& datagram : payload)  // Append datagrams to param table
+    {
+        lua_pushstring(L, datagram.luaKey.c_str());
+        if (auto value = std::get_if<uint32>(&datagram.data))
+        {
+            lua_pushinteger(L, *value);
+        }
+        else if (auto PMob = std::get_if<CMobEntity*>(&datagram.data))
+        {
+            CLuaBaseEntity LuaMobEntity(*PMob);
+            Lunar<CLuaBaseEntity>::push(L, &LuaMobEntity);
+        }
+        else if (auto text = std::get_if<std::string>(&datagram.data))
+        {
+            lua_pushstring(L, text->c_str());
+        }
+        else
+        {
+            lua_pushnil(L);
+            ShowWarning("roeutils::onRecordTrigger: Unhandled payload type for '%s' with record #%d.", datagram.luaKey, recordID);
+        }
+        lua_settable(L, -3);
+    }
+
+    if (lua_pcall(L, args, 0, 0))
+    {
+        ShowError("roeutils::onRecordTrigger: %s\n", lua_tostring(L, -1));
+        lua_pop(L, 1);
+    }
+
+    lua_settop(L, stackTop);
+}
+
 namespace roeutils
 {
 void init()
@@ -71,6 +133,7 @@ int32 ParseRecords(lua_State* L)
     RoeHandlers.fill(RoeCheckHandler());
     roeutils::RoeSystem.ImplementedRecords.reset();
     roeutils::RoeSystem.RepeatableRecords.reset();
+    roeutils::RoeSystem.RetroactiveRecords.reset();
     roeutils::RoeSystem.DailyRecords.reset();
     roeutils::RoeSystem.DailyRecordIDs.clear();
     roeutils::RoeSystem.NotifyThresholds.fill(1);
@@ -127,6 +190,10 @@ int32 ParseRecords(lua_State* L)
                 else if (flag == "repeat")
                 {
                     roeutils::RoeSystem.RepeatableRecords.set(recordID);
+                }
+                else if (flag == "retro")
+                {
+                    roeutils::RoeSystem.RetroactiveRecords.set(recordID);
                 }
                 else
                 {
@@ -197,51 +264,9 @@ bool event(ROE_EVENT eventID, CCharEntity* PChar, const RoeDatagramList& payload
     for (int i = 0; i < 31; i++)
     {
         // Check record is of this type
-        if (handler.bitmap.test(PChar->m_eminenceLog.active[i]))
+        if (uint16 recordID = PChar->m_eminenceLog.active[i]; handler.bitmap.test(recordID))
         {
-            lua_getfield(L, -1, "onRecordTrigger");
-            uint8 args { 0 };
-
-            CLuaBaseEntity LuaAllyEntity(PChar);
-            Lunar<CLuaBaseEntity>::push(L, &LuaAllyEntity);
-            args++;
-
-            // Record #
-            lua_pushinteger(L, PChar->m_eminenceLog.active[i]);
-            args++;
-
-            // param table
-            lua_newtable(L);
-            args++;
-
-            lua_pushinteger(L, PChar->m_eminenceLog.progress[i]);
-            lua_setfield(L, -2, "progress");
-
-            for (auto& datagram : payload)  // Append datagrams to param table
-            {
-                lua_pushstring(L, datagram.luaKey.c_str());
-                switch (datagram.type)
-                {
-                case RoeDatagramPayload::mob:
-                {
-                    CLuaBaseEntity LuaMobEntity(datagram.data.mobEntity);
-                    Lunar<CLuaBaseEntity>::push(L, &LuaMobEntity);
-                    break;
-                }
-                case RoeDatagramPayload::uinteger:
-                {
-                    lua_pushinteger(L, datagram.data.uinteger);
-                    break;
-                }
-                }
-                lua_settable(L, -3);
-            }
-
-            if (lua_pcall(L, args, 0, 0))
-            {
-                ShowError("roeutils::onRecordTrigger: %s\n", lua_tostring(L, -1));
-                lua_pop(L, 1);
-            }
+            call_onRecordTrigger(L, PChar, recordID, payload);
         }
     }
     lua_settop(L, stackTop);
@@ -425,6 +450,35 @@ void onCharLoad(CCharEntity* PChar)
             }
         }
     }
+}
+
+void onRecordTake(CCharEntity* PChar, uint16 recordID)
+{
+    if (RoeSystem.RetroactiveRecords.test(recordID))
+    {
+        lua_State* L = luautils::LuaHandle;
+        uint32 stackTop = lua_gettop(L);
+        lua_getglobal(L, "tpz");
+        lua_getfield(L, -1, "roe");
+        call_onRecordTrigger(L, PChar, recordID, RoeDatagramList{});
+        lua_settop(L, stackTop);
+    }
+    return;
+}
+
+bool onRecordClaim(CCharEntity* PChar, uint16 recordID)
+{
+    if (roeutils::HasEminenceRecord(PChar, recordID))
+    {
+        lua_State* L = luautils::LuaHandle;
+        uint32 stackTop = lua_gettop(L);
+        lua_getglobal(L, "tpz");
+        lua_getfield(L, -1, "roe");
+        call_onRecordTrigger(L, PChar, recordID, RoeDatagramList{RoeDatagram("claim", 1)});
+        lua_settop(L, stackTop);
+        return true;
+    }
+    return false;
 }
 
 uint16 GetActiveTimedRecord()

--- a/src/map/roe.h
+++ b/src/map/roe.h
@@ -28,6 +28,7 @@
 #include <array>
 #include <bitset>
 #include <vector>
+#include <variant>
 
 #include "../common/cbasetypes.h"
 #include "ai/helpers/event_handler.h"
@@ -48,6 +49,11 @@ enum ROE_EVENT
     ROE_DMGTAKEN = 5,
     ROE_DMGDEALT = 6,
     ROE_EXPGAIN = 7,
+    ROE_HEALALLY = 8,
+    ROE_BUFFALLY = 9,
+    ROE_LEVELUP = 10,
+    ROE_QUEST_COMPLETE = 11,
+    ROE_MISSION_COMPLETE = 12,
     ROE_NONE // End of enum marker and OOB checkpost. Do not move or remove, place any new types above.
 };
 
@@ -59,6 +65,7 @@ struct RoeSystemData
     RecordTimetable_W TimedRecordTable;
     std::bitset<4096> ImplementedRecords;
     std::bitset<4096> RepeatableRecords;
+    std::bitset<4096> RetroactiveRecords;
     std::bitset<4096> DailyRecords;
     std::vector<uint16> DailyRecordIDs;
     std::bitset<4096> TimedRecords;
@@ -77,32 +84,16 @@ struct RoeCheckHandler
 
 extern std::array<RoeCheckHandler, ROE_NONE> RoeHandlers;
 
-enum class RoeDatagramPayload
-{
-    mob,
-    uinteger,
-};
+typedef std::variant<uint32, CMobEntity*, std::string> RoeDatagramPayload;
 
 struct RoeDatagram
 {
-    RoeDatagramPayload type;
     std::string luaKey;
-    union data {
-        uint32 uinteger;
-        CMobEntity* mobEntity;
-        CItem* item;
-    } data;
+    RoeDatagramPayload data;
 
-    RoeDatagram(std::string param, uint32 id) : luaKey{param}
-    {
-        this->type = RoeDatagramPayload::uinteger;
-        this->data.uinteger = id;
-    }
-    RoeDatagram(std::string param, CMobEntity* PMob) : luaKey{param}
-    {
-        this->type = RoeDatagramPayload::mob;
-        this->data.mobEntity = PMob;
-    }
+    RoeDatagram(std::string param, uint32 payload) : luaKey{param}, data{payload} {}
+    RoeDatagram(std::string param, CMobEntity* payload) : luaKey{param}, data{payload} {}
+    RoeDatagram(std::string param, std::string payload) : luaKey{param}, data{payload} {}
 };
 
 typedef std::vector<RoeDatagram> RoeDatagramList;
@@ -127,6 +118,8 @@ bool   SetEminenceRecordProgress(CCharEntity* PChar, uint16 recordID, uint32 pro
 uint32 GetEminenceRecordProgress(CCharEntity* PChar, uint16 recordID);
 
 void   onCharLoad(CCharEntity* PChar);
+bool   onRecordClaim(CCharEntity* PChar, uint16 recordID);
+void   onRecordTake(CCharEntity* PChar, uint16 recordID);
 
 void   ClearDailyRecords(CCharEntity* PChar);
 void   CycleDailyRecords();

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3843,6 +3843,7 @@ namespace charutils
                 PChar->pushPacket(new CCharStatsPacket(PChar));
 
                 luautils::OnPlayerLevelUp(PChar);
+                roeutils::event(ROE_EVENT::ROE_LEVELUP, PChar, RoeDatagramList{});
                 PChar->updatemask |= UPDATE_HP;
                 return;
             }


### PR DESCRIPTION
<p>Adds another 60 or so records, but more importantly this new logic should cover a **huge** number of the remaining records. Those contributors who have expressed an interest in adding to the list of available records, now would be a great time as there are easily hundreds which can be implemented. If interested, please message me on the Discord (Kreidos) and let me know what sections you'd like so we can all work together to avoid duplication of effort. :smiley: </p>
<p>To whoever reviews & merges might not be a bad plan to give this a feature branch and canary time, as there is new logic as well as a potential future landrush for new records that could probably benefit from some testing.</p>

New:
- Heal + Buff Ally Records (Combat + Daily Categories now 100%)
- Physical/Magical kill timed records (Timed schedule now 100%)
- Achievements -> Job Levels I Records
- Tutorial -> Level Cap Increase Records
- Tutorial -> Storage Expansion Records
- Early Tutorial -> Bastok Rank records (Mostly as examples)

Core work + Fixes:
- Proper handling for Inventory Full on RoE Completion
- 5 new core RoE Triggers + logic (Levelup, QuestComplete, MissionComplete, BuffAlly + HealAlly)
- Core work for retroactively claimable RoE Records
- Migrate datagrams to use std::variant

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits