### PR TITLE
Adds missing stat_wsc MODs and Logic

### DIFF
--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1535,6 +1535,8 @@ tpz.mod =
     ALL_WSDMG_FIRST_HIT             = 841, -- Generic (all Weaponskills) damage, first hit only.
     WS_NO_DEPLETE                   = 949, -- % chance a Weaponskill depletes no TP.
     WS_DEX_BONUS                    = 957, -- % bonus to dex_wsc.
+    WS_AGI_BONUS                    = 980, -- % bonus to agi_wsc.
+    WS_INT_BONUS                    = 981, -- % bonus to int_wsc.
 
     -- Circle Abilities Extended Duration from AF/AF+1
     HOLY_CIRCLE_DURATION            = 857,
@@ -1573,9 +1575,9 @@ tpz.mod =
 
     -- The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     -- 570 - 825 used by WS DMG mods these are not spares.
-    -- SPARE = 977, -- stuff
-    -- SPARE = 978, -- stuff
-    -- SPARE = 979, -- stuff
+    -- SPARE = 982, -- stuff
+    -- SPARE = 983, -- stuff
+    -- SPARE = 984, -- stuff
 }
 
 tpz.latent =

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1534,9 +1534,13 @@ tpz.mod =
     -- Per https://www.bg-wiki.com/bg/Weapon_Skill_Damage we need all 3..
     ALL_WSDMG_FIRST_HIT             = 841, -- Generic (all Weaponskills) damage, first hit only.
     WS_NO_DEPLETE                   = 949, -- % chance a Weaponskill depletes no TP.
+    WS_STR_BONUS                    = 980, -- % bonus to str_wsc.
     WS_DEX_BONUS                    = 957, -- % bonus to dex_wsc.
-    WS_AGI_BONUS                    = 980, -- % bonus to agi_wsc.
-    WS_INT_BONUS                    = 981, -- % bonus to int_wsc.
+    WS_VIT_BONUS                    = 981, -- % bonus to vit_wsc.
+    WS_AGI_BONUS                    = 982, -- % bonus to agi_wsc.
+    WS_INT_BONUS                    = 983, -- % bonus to int_wsc.
+    WS_MND_BONUS                    = 984, -- % bonus to mnd_wsc.
+    WS_CHR_BONUS                    = 985, -- % bonus to chr_wsc.
 
     -- Circle Abilities Extended Duration from AF/AF+1
     HOLY_CIRCLE_DURATION            = 857,
@@ -1575,9 +1579,9 @@ tpz.mod =
 
     -- The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     -- 570 - 825 used by WS DMG mods these are not spares.
-    -- SPARE = 982, -- stuff
-    -- SPARE = 983, -- stuff
-    -- SPARE = 984, -- stuff
+    -- SPARE = 986, -- stuff
+    -- SPARE = 987, -- stuff
+    -- SPARE = 988, -- stuff
 }
 
 tpz.latent =

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -84,8 +84,18 @@ function calculateRawWSDmg(attacker, target, wsID, tp, action, wsParams, calcPar
     end
 
     -- Check for and apply WS_DEX_BONUS
-    if (attacker:getMod(tpz.mod.WS_DEX_BONUS) > 0) then
-        wsParams.dex_wsc = wsParams.dex_wsc + (attacker:getMod(tpz.mod.WS_DEX_BONUS)*.01)
+    if attacker:getMod(tpz.mod.WS_DEX_BONUS) > 0 then
+        wsParams.dex_wsc = wsParams.dex_wsc + (attacker:getMod(tpz.mod.WS_DEX_BONUS) / 100)
+    end
+
+    -- Check for and apply WS_AGI_BONUS
+    if attacker:getMod(tpz.mod.WS_AGI_BONUS) > 0 then
+        wsParams.agi_wsc = wsParams.agi_wsc + (attacker:getMod(tpz.mod.WS_AGI_BONUS) / 100)
+    end
+
+    -- Check for and apply WS_INT_BONUS
+    if attacker:getMod(tpz.mod.WS_INT_BONUS) > 0 then
+        wsParams.int_wsc = wsParams.int_wsc + (attacker:getMod(tpz.mod.WS_INT_BONUS) / 100)
     end
 
     local wsMods = calcParams.fSTR +
@@ -377,8 +387,18 @@ function doMagicWeaponskill(attacker, target, wsID, wsParams, tp, action, primar
     if not shadowAbsorb(target) then
 
         -- Check for and apply WS_DEX_BONUS
-        if (attacker:getMod(tpz.mod.WS_DEX_BONUS) > 0) then
-             wsParams.dex_wsc = wsParams.dex_wsc + (attacker:getMod(tpz.mod.WS_DEX_BONUS) * 0.01)
+        if attacker:getMod(tpz.mod.WS_DEX_BONUS) > 0 then
+            wsParams.dex_wsc = wsParams.dex_wsc + (attacker:getMod(tpz.mod.WS_DEX_BONUS) / 100)
+        end
+
+        -- Check for and apply WS_AGI_BONUS
+        if attacker:getMod(tpz.mod.WS_AGI_BONUS) > 0 then
+            wsParams.agi_wsc = wsParams.agi_wsc + (attacker:getMod(tpz.mod.WS_AGI_BONUS) / 100)
+        end
+
+        -- Check for and apply WS_INT_BONUS
+        if attacker:getMod(tpz.mod.WS_INT_BONUS) > 0 then
+            wsParams.int_wsc = wsParams.int_wsc + (attacker:getMod(tpz.mod.WS_INT_BONUS) / 100)
         end
 
         dmg = attacker:getMainLvl() + 2 + (attacker:getStat(tpz.mod.STR) * wsParams.str_wsc + attacker:getStat(tpz.mod.DEX) * wsParams.dex_wsc +

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -83,19 +83,36 @@ function calculateRawWSDmg(attacker, target, wsID, tp, action, wsParams, calcPar
         end
     end
 
-    -- Check for and apply WS_DEX_BONUS
+    -- Begin Checks for bonus wsc bonuses. See the following for details:
+    -- https://www.bg-wiki.com/bg/Utu_Grip
+    -- https://www.bluegartr.com/threads/108199-Random-Facts-Thread-Other?p=6826618&viewfull=1#post6826618
+
+    if attacker:getMod(tpz.mod.WS_STR_BONUS) > 0 then
+        wsParams.str_wsc = wsParams.str_wsc + (attacker:getMod(tpz.mod.WS_STR_BONUS) / 100)
+    end
+
     if attacker:getMod(tpz.mod.WS_DEX_BONUS) > 0 then
         wsParams.dex_wsc = wsParams.dex_wsc + (attacker:getMod(tpz.mod.WS_DEX_BONUS) / 100)
     end
 
-    -- Check for and apply WS_AGI_BONUS
+    if attacker:getMod(tpz.mod.WS_VIT_BONUS) > 0 then
+        wsParams.vit_wsc = wsParams.vit_wsc + (attacker:getMod(tpz.mod.WS_VIT_BONUS) / 100)
+    end
+
     if attacker:getMod(tpz.mod.WS_AGI_BONUS) > 0 then
         wsParams.agi_wsc = wsParams.agi_wsc + (attacker:getMod(tpz.mod.WS_AGI_BONUS) / 100)
     end
 
-    -- Check for and apply WS_INT_BONUS
     if attacker:getMod(tpz.mod.WS_INT_BONUS) > 0 then
         wsParams.int_wsc = wsParams.int_wsc + (attacker:getMod(tpz.mod.WS_INT_BONUS) / 100)
+    end
+
+    if attacker:getMod(tpz.mod.WS_MND_BONUS) > 0 then
+        wsParams.mnd_wsc = wsParams.mnd_wsc + (attacker:getMod(tpz.mod.WS_MND_BONUS) / 100)
+    end
+
+    if attacker:getMod(tpz.mod.WS_CHR_BONUS) > 0 then
+        wsParams.chr_wsc = wsParams.chr_wsc + (attacker:getMod(tpz.mod.WS_CHR_BONUS) / 100)
     end
 
     local wsMods = calcParams.fSTR +
@@ -386,19 +403,36 @@ function doMagicWeaponskill(attacker, target, wsID, wsParams, tp, action, primar
     -- Magic-based WSes never miss, so we don't need to worry about calculating a miss, only if a shadow absorbed it.
     if not shadowAbsorb(target) then
 
-        -- Check for and apply WS_DEX_BONUS
+        -- Begin Checks for bonus wsc bonuses. See the following for details:
+        -- https://www.bg-wiki.com/bg/Utu_Grip
+        -- https://www.bluegartr.com/threads/108199-Random-Facts-Thread-Other?p=6826618&viewfull=1#post6826618
+
+        if attacker:getMod(tpz.mod.WS_STR_BONUS) > 0 then
+            wsParams.str_wsc = wsParams.str_wsc + (attacker:getMod(tpz.mod.WS_STR_BONUS) / 100)
+        end
+
         if attacker:getMod(tpz.mod.WS_DEX_BONUS) > 0 then
             wsParams.dex_wsc = wsParams.dex_wsc + (attacker:getMod(tpz.mod.WS_DEX_BONUS) / 100)
         end
 
-        -- Check for and apply WS_AGI_BONUS
+        if attacker:getMod(tpz.mod.WS_VIT_BONUS) > 0 then
+            wsParams.vit_wsc = wsParams.vit_wsc + (attacker:getMod(tpz.mod.WS_VIT_BONUS) / 100)
+        end
+
         if attacker:getMod(tpz.mod.WS_AGI_BONUS) > 0 then
             wsParams.agi_wsc = wsParams.agi_wsc + (attacker:getMod(tpz.mod.WS_AGI_BONUS) / 100)
         end
 
-        -- Check for and apply WS_INT_BONUS
         if attacker:getMod(tpz.mod.WS_INT_BONUS) > 0 then
             wsParams.int_wsc = wsParams.int_wsc + (attacker:getMod(tpz.mod.WS_INT_BONUS) / 100)
+        end
+
+        if attacker:getMod(tpz.mod.WS_MND_BONUS) > 0 then
+            wsParams.mnd_wsc = wsParams.mnd_wsc + (attacker:getMod(tpz.mod.WS_MND_BONUS) / 100)
+        end
+
+        if attacker:getMod(tpz.mod.WS_CHR_BONUS) > 0 then
+            wsParams.chr_wsc = wsParams.chr_wsc + (attacker:getMod(tpz.mod.WS_CHR_BONUS) / 100)
         end
 
         dmg = attacker:getMainLvl() + 2 + (attacker:getStat(tpz.mod.STR) * wsParams.str_wsc + attacker:getStat(tpz.mod.DEX) * wsParams.dex_wsc +

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -25103,7 +25103,7 @@ INSERT INTO `item_mods` VALUES (20653,355,225); -- Chant du Cygne
 INSERT INTO `item_mods` VALUES (20654,9,20);    -- Almace 119 AG - DEX+20
 INSERT INTO `item_mods` VALUES (20654,256,44);  -- Aftermath
 INSERT INTO `item_mods` VALUES (20654,355,225); -- Chant du Cygne
-INSERT INTO `item_mods` VALUES (20672,981,10);  -- Ice Brand: WS INT +10%
+INSERT INTO `item_mods` VALUES (20672,983,10);  -- Ice Brand: WS INT +10%
 INSERT INTO `item_mods` VALUES (20678,954,15);  -- Firangi Berserk Duration + 15
 INSERT INTO `item_mods` VALUES (20685,23,60); -- Excalibur iLvL 119 AG - ATT +60
 INSERT INTO `item_mods` VALUES (20685,256,17); -- Aftermath
@@ -26400,7 +26400,7 @@ INSERT INTO `item_mods` VALUES (21565,311,217);   -- Tauret: Magic Damage+217
 INSERT INTO `item_mods` VALUES (21565,595,50);    -- Tauret: "Evisceration" damage +50%
 -- INSERT INTO `item_mods` VALUES (21565,,);      -- Tauret: Increases critical hit rate based with lower TP
 -- INSERT INTO `item_mods` VALUES (21565,,25);    -- Tauret: Main hand: "Evisceration"
-INSERT INTO `item_mods` VALUES (21570,980,10);    -- Air Knife: WS AGI +10%
+INSERT INTO `item_mods` VALUES (21570,982,10);    -- Air Knife: WS AGI +10%
 INSERT INTO `item_mods` VALUES (21573,25,30);     -- Assassin's Knife: Accuracy+30
 INSERT INTO `item_mods` VALUES (21573,26,30);     -- Assassin's Knife: Ranged Accuracy+30
 INSERT INTO `item_mods` VALUES (21573,30,30);     -- Assassin's Knife: Magic Accuracy+30

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -25103,6 +25103,7 @@ INSERT INTO `item_mods` VALUES (20653,355,225); -- Chant du Cygne
 INSERT INTO `item_mods` VALUES (20654,9,20);    -- Almace 119 AG - DEX+20
 INSERT INTO `item_mods` VALUES (20654,256,44);  -- Aftermath
 INSERT INTO `item_mods` VALUES (20654,355,225); -- Chant du Cygne
+INSERT INTO `item_mods` VALUES (20672,981,10);  -- Ice Brand: WS INT +10%
 INSERT INTO `item_mods` VALUES (20678,954,15);  -- Firangi Berserk Duration + 15
 INSERT INTO `item_mods` VALUES (20685,23,60); -- Excalibur iLvL 119 AG - ATT +60
 INSERT INTO `item_mods` VALUES (20685,256,17); -- Aftermath
@@ -26399,6 +26400,7 @@ INSERT INTO `item_mods` VALUES (21565,311,217);   -- Tauret: Magic Damage+217
 INSERT INTO `item_mods` VALUES (21565,595,50);    -- Tauret: "Evisceration" damage +50%
 -- INSERT INTO `item_mods` VALUES (21565,,);      -- Tauret: Increases critical hit rate based with lower TP
 -- INSERT INTO `item_mods` VALUES (21565,,25);    -- Tauret: Main hand: "Evisceration"
+INSERT INTO `item_mods` VALUES (21570,980,10);    -- Air Knife: WS AGI +10%
 INSERT INTO `item_mods` VALUES (21573,25,30);     -- Assassin's Knife: Accuracy+30
 INSERT INTO `item_mods` VALUES (21573,26,30);     -- Assassin's Knife: Ranged Accuracy+30
 INSERT INTO `item_mods` VALUES (21573,30,30);     -- Assassin's Knife: Magic Accuracy+30

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -801,6 +801,8 @@ enum class Mod
     ALL_WSDMG_FIRST_HIT       = 841, // Generic (all Weaponskills) damage, first hit only.
     WS_NO_DEPLETE             = 949, // % chance a Weaponskill depletes no TP.
     WS_DEX_BONUS              = 957, // % bonus to dex_wsc.
+    WS_AGI_BONUS              = 980, // % bonus to agi_wsc.
+    WS_INT_BONUS              = 981, // % bonus to int_wsc.
 
     EXPERIENCE_RETAINED       = 914, // Experience points retained upon death (this is a percentage)
     CAPACITY_BONUS            = 915, // Capacity point bonus granted
@@ -813,9 +815,9 @@ enum class Mod
 
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     // 570 through 825 used by WS DMG mods these are not spares.
-    // SPARE = 977, // stuff
-    // SPARE = 978, // stuff
-    // SPARE = 979, // stuff
+    // SPARE = 982, // stuff
+    // SPARE = 983, // stuff
+    // SPARE = 984, // stuff
 };
 
 //temporary workaround for using enum class as unordered_map key until compilers support it

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -800,9 +800,13 @@ enum class Mod
     // Per https://www.bg-wiki.com/bg/Weapon_Skill_Damage we need all 3..
     ALL_WSDMG_FIRST_HIT       = 841, // Generic (all Weaponskills) damage, first hit only.
     WS_NO_DEPLETE             = 949, // % chance a Weaponskill depletes no TP.
+    WS_STR_BONUS              = 980, // % bonus to str_wsc.
     WS_DEX_BONUS              = 957, // % bonus to dex_wsc.
-    WS_AGI_BONUS              = 980, // % bonus to agi_wsc.
-    WS_INT_BONUS              = 981, // % bonus to int_wsc.
+    WS_VIT_BONUS              = 981, // % bonus to vit_wsc.
+    WS_AGI_BONUS              = 982, // % bonus to agi_wsc.
+    WS_INT_BONUS              = 983, // % bonus to int_wsc.
+    WS_MND_BONUS              = 984, // % bonus to mnd_wsc.
+    WS_CHR_BONUS              = 985, // % bonus to chr_wsc.
 
     EXPERIENCE_RETAINED       = 914, // Experience points retained upon death (this is a percentage)
     CAPACITY_BONUS            = 915, // Capacity point bonus granted
@@ -815,9 +819,9 @@ enum class Mod
 
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     // 570 through 825 used by WS DMG mods these are not spares.
-    // SPARE = 982, // stuff
-    // SPARE = 983, // stuff
-    // SPARE = 984, // stuff
+    // SPARE = 986, // stuff
+    // SPARE = 987, // stuff
+    // SPARE = 988, // stuff
 };
 
 //temporary workaround for using enum class as unordered_map key until compilers support it


### PR DESCRIPTION
November 2020 Version Update added two items which have WS AGI+ and WS INT+
Using the same logic from Utu Grip (WS DEX +), added MODs and checks to apply them.

Creates MODs and checks for future use cases outside of AGI, INT, and/or DEX.
Updates comments to site sources for calculation details.

Note: MOD Ids have been based on two pending PRs at the time of submission:

1478 - Uses MOD 977
1490 - Uses MOD 978 and 979

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

